### PR TITLE
Fix for the script: generate-thrift-file.sh 

### DIFF
--- a/airavata-api/airavata-api-server/pom.xml
+++ b/airavata-api/airavata-api-server/pom.xml
@@ -23,20 +23,7 @@
     <artifactId>airavata-api-server</artifactId>
     <packaging>jar</packaging>
     <url>http://airavata.apache.org/</url>
-
-    <repositories>
-        <repository>
-            <id>wso2-nexus</id>
-            <name>WSO2 internal Repository</name>
-            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-                <checksumPolicy>ignore</checksumPolicy>
-            </releases>
-        </repository>
-    </repositories>
-
+    
     <dependencies>
 
         <dependency>

--- a/component-interface-descriptions/airavata-api/generate-thrift-files.sh
+++ b/component-interface-descriptions/airavata-api/generate-thrift-files.sh
@@ -56,13 +56,13 @@ if [ "$VERSION" -ne 1 ] ; then
 fi
 
 # Global Constants used across the script
-THRIFT_IDL_DIR='thrift-interface-descriptions'
+THRIFT_IDL_DIR='../airavata-api'
 BASE_TARGET_DIR='target'
-DATAMODEL_SRC_DIR='../airavata-api/airavata-data-models/src/main/java'
-JAVA_API_SDK_DIR='../airavata-api/airavata-api-stubs/src/main/java'
-PHP_SDK_DIR='../airavata-api/airavata-client-sdks/airavata-php-sdk/src/main/resources/lib'
-CPP_SDK_DIR='../airavata-api/airavata-client-sdks/airavata-cpp-sdk/src/main/resources/lib/airavata/'
-PYTHON_SDK_DIR='../airavata-api/airavata-client-sdks/airavata-python-sdk/src/main/resources/lib/'
+DATAMODEL_SRC_DIR='../../airavata-api/airavata-data-models/src/main/java'
+JAVA_API_SDK_DIR='../../airavata-api/airavata-api-stubs/src/main/java'
+PHP_SDK_DIR='../../airavata-api/airavata-client-sdks/airavata-php-sdk/src/main/resources/lib'
+CPP_SDK_DIR='../../airavata-api/airavata-client-sdks/airavata-cpp-sdk/src/main/resources/lib/airavata/'
+PYTHON_SDK_DIR='../../airavata-api/airavata-client-sdks/airavata-python-sdk/src/main/resources/lib/'
 
 # Initialize the thrift arguments.
 #  Since most of the Airavata API and Data Models have includes, use recursive option by default.

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -286,11 +286,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.airavata</groupId>
-            <artifactId>airavata-experiment-catalog</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.airavata</groupId>
             <artifactId>airavata-data-models</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
I got an error when running the generate-thrift-file.sh due to the file paths that do not match the new source structure. It is fixed herewith and it worked for me after this fix.