### PR TITLE
Add serialVersionUID for previous version of class

### DIFF
--- a/modules/credential-store/credential-store-service/src/main/java/org/apache/airavata/credential/store/credential/Credential.java
+++ b/modules/credential-store/credential-store-service/src/main/java/org/apache/airavata/credential/store/credential/Credential.java
@@ -30,6 +30,8 @@ import java.util.Date;
  */
 public abstract class Credential implements Serializable {
 
+    private static final long serialVersionUID = -3653870227035604734L;
+
     private String portalUserName;
     private Date persistedTime;
     private String token;


### PR DESCRIPTION
To keep Credential.java compatible with the previous version, I'm adding
the serialVersionUID from the previous version. This will allow
serialized instances of the old version to be deserialized with the new
version.