### PR TITLE
AIRAVATA-2282 notification sort: Prevent int overflow

### DIFF
--- a/airavata-api/airavata-api-server/src/main/java/org/apache/airavata/api/server/handler/AiravataServerHandler.java
+++ b/airavata-api/airavata-api-server/src/main/java/org/apache/airavata/api/server/handler/AiravataServerHandler.java
@@ -375,8 +375,8 @@ public class AiravataServerHandler implements Airavata.Iface {
         }
     }
 
+    // No security check
     @Override
-    @SecurityCheck
     public List<Notification> getAllNotifications(AuthzToken authzToken, String gatewayId) throws InvalidRequestException,
             AiravataClientException, AiravataSystemException, AuthorizationException, TException {
         try {

--- a/modules/registry/registry-core/src/main/java/org/apache/airavata/registry/core/experiment/catalog/impl/NotificationRegistry.java
+++ b/modules/registry/registry-core/src/main/java/org/apache/airavata/registry/core/experiment/catalog/impl/NotificationRegistry.java
@@ -80,7 +80,7 @@ public class NotificationRegistry {
                 notifications.add(ThriftDataModelConversion.getNotification((NotificationResource) e));
             }
         }
-        Collections.sort(notifications, (o1, o2) -> (int) (o2.getCreationTime() - o1.getCreationTime()));
+        Collections.sort(notifications, (o1, o2) -> (o2.getCreationTime() - o1.getCreationTime()) > 0 ? 1 : -1);
         return notifications;
     }
 


### PR DESCRIPTION
Instead of returning the difference as a long and casting to an int,
which risks integer overflow, just return 1 or -1 corresponding to the
sign of the difference.

Note: this branch was branched from master which is ahead of develop by a few spurious commits.  My change for this bug fix is really just NotificationRegistry.java change.