### PR TITLE
AIRAVATA-2282 notification sort: Prevent int overflow

### DIFF
--- a/modules/registry/registry-core/src/main/java/org/apache/airavata/registry/core/experiment/catalog/impl/NotificationRegistry.java
+++ b/modules/registry/registry-core/src/main/java/org/apache/airavata/registry/core/experiment/catalog/impl/NotificationRegistry.java
@@ -80,7 +80,7 @@ public class NotificationRegistry {
                 notifications.add(ThriftDataModelConversion.getNotification((NotificationResource) e));
             }
         }
-        Collections.sort(notifications, (o1, o2) -> (int) (o2.getCreationTime() - o1.getCreationTime()));
+        Collections.sort(notifications, (o1, o2) -> (o2.getCreationTime() - o1.getCreationTime()) > 0 ? 1 : -1);
         return notifications;
     }
 


### PR DESCRIPTION
Instead of returning the difference as a long and casting to an int,
which risks integer overflow, just return 1 or -1 corresponding to the
sign of the difference.