### PR TITLE
Temporary fix for mysql-selinux issue

### DIFF
--- a/dev-tools/ansible/roles/database/files/mysql-tmp.te
+++ b/dev-tools/ansible/roles/database/files/mysql-tmp.te
@@ -1,0 +1,9 @@
+module mysql-tmp 1.0;
+
+require {
+	type mysqld_safe_t;
+	class capability { setgid setuid };
+}
+
+#============= mysqld_safe_t ==============
+allow mysqld_safe_t self:capability { setgid setuid };

--- a/dev-tools/ansible/roles/database/tasks/main.yml
+++ b/dev-tools/ansible/roles/database/tasks/main.yml
@@ -34,9 +34,55 @@
   yum: name="{{ item }}" state=latest update_cache=yes
   with_items: "{{ mysql_packages }}"
   become_user: root
+#" for vim
+
+- name: check if mysql has been updated
+  stat: path=/usr/share/mysql/SELinux/mariadb.pp
+  register: mysql_selinux_update
+
+- debug:
+    var: mysql_selinux_update
+
+- name: double check policycoreutils installed
+  yum: name=policycoreutils-python state=installed
+  when: mysql_selinux_update.stat.exists == False
+
+- name: Copy SELinux type enforcement file
+  copy: src=mysql-tmp.te dest=/tmp/
+  when: mysql_selinux_update.stat.exists == False
+
+- name: Compile SELinux module file
+  command: checkmodule -M -m -o /tmp/mysql-tmp.mod /tmp/mysql-tmp.te
+  when: mysql_selinux_update.stat.exists == False
+
+- name: Build SELinux policy package
+  command: semodule_package -o /tmp/mysql-tmp.pp -m /tmp/mysql-tmp.mod
+  when: mysql_selinux_update.stat.exists == False
+
+#- name: check if mysql has been updated
+#  stat: path=/tmp/mysql-tmp.pp
+#  register: mysql_pp
+#
+#- debug:
+#    var: mysql_pp
+
+- name: unLoad SELinux policy package
+  command: semodule -r mysql-tmp
+  when: mysql_selinux_update.stat.exists == False
+  become_user: root
+  ignore_errors: True
+
+- name: Load SELinux policy package
+  command: semodule -i /tmp/mysql-tmp.pp
+  when: mysql_selinux_update.stat.exists == False
+  become_user: root
+
+- name: Remove temporary files
+  file: path=/tmp/mysql-tmp.* state=absent
+  when: mysql_selinux_update.stat.exists == False
 
 # TODO: SELinux issue for 10.0.29 MariaDB, need to allow setgid/setuid.
-# See https://www.rootusers.com/how-to-fix-mariadb-10-0-29-selinux-update-failure/
+## See https://www.rootusers.com/how-to-fix-mariadb-10-0-29-selinux-update-failure/
 # and https://jira.mariadb.org/browse/MDEV-11789
 # For now I'm not adding to Ansible script since this bug should be fixed in next MariaDB release
 - name: start mariadb


### PR DESCRIPTION
Tmp fix for this issue: https://jira.mariadb.org/browse/MDEV-12231

Adds selinux policy module to allow mysql to set uid/gid. Also
checks for .pp file which should be incuded in future releases
of MariaDB.
