### PR TITLE
Registry Refactoring : ComputeResourceEntity fix

### DIFF
--- a/modules/registry-refactoring/src/main/java/org/apache/airavata/registry/core/entities/appcatalog/ComputeResourceEntity.java
+++ b/modules/registry-refactoring/src/main/java/org/apache/airavata/registry/core/entities/appcatalog/ComputeResourceEntity.java
@@ -51,7 +51,7 @@ public class ComputeResourceEntity implements Serializable {
     private String gatewayUsageModuleLoadCommand;
 
     @Column(name = "GATEWAY_USAGE_REPORTING")
-    private short gatewayUsageReporting;
+    private boolean gatewayUsageReporting;
 
     @Column(name = "HOST_NAME")
     private String hostName;
@@ -126,11 +126,11 @@ public class ComputeResourceEntity implements Serializable {
         this.gatewayUsageExecutable = gatewayUsageExecutable;
     }
 
-    public short getGatewayUsageReporting() {
+    public boolean isGatewayUsageReporting() {
         return gatewayUsageReporting;
     }
 
-    public void setGatewayUsageReporting(short gatewayUsageReporting) {
+    public void setGatewayUsageReporting(boolean gatewayUsageReporting) {
         this.gatewayUsageReporting = gatewayUsageReporting;
     }
 

--- a/modules/registry-refactoring/src/test/java/org/apache/airavata/registry/core/repositories/appcatalog/ComputeResourceRepositoryTest.java
+++ b/modules/registry-refactoring/src/test/java/org/apache/airavata/registry/core/repositories/appcatalog/ComputeResourceRepositoryTest.java
@@ -47,6 +47,7 @@ public class ComputeResourceRepositoryTest {
 
         description.setHostName("localhost");
         description.setResourceDescription("test compute resource");
+        description.setGatewayUsageReporting(true);
         List<String> ipdaresses = new ArrayList<String>();
         ipdaresses.add("222.33.43.444");
         ipdaresses.add("23.344.44.454");
@@ -152,6 +153,7 @@ public class ComputeResourceRepositoryTest {
             }
             System.out.println("**********Resource name ************* : " +  host.getHostName());
             assertTrue(host.getHostName().equals("localhost"));
+            assertTrue(host.isGatewayUsageReporting());
         }
 
         // Verify updating compute resource


### PR DESCRIPTION
Changes:

- `ComputeResourceEntity.gatewayUsageReporting` to boolean instead of boolean