### PR TITLE
Fixing the document root of PGA installation Ansible script

### DIFF
--- a/dev-tools/ansible/roles/pga/templates/default.conf.j2
+++ b/dev-tools/ansible/roles/pga/templates/default.conf.j2
@@ -2,5 +2,5 @@
 # This will show the welcome page when requesting on the ip address or server default hostname
 Listen {{ pga_default_http_port }}
 <VirtualHost _default_:{{ pga_default_http_port }}>
-    DocumentRoot "/www/default"
+    DocumentRoot {{ doc_root_dir }}/public
 </VirtualHost>


### PR DESCRIPTION
Existing DocumentRoot `/www/default` will lead to Apache Server Testing page when entering 
`http://<pga-host>:8008/` to configure PGA. Correct DocumentRoot should be `/var/www/portals/default/public` 