### PR TITLE
Ansible Changes for helix-distribution

### DIFF
--- a/dev-tools/ansible/helix.yml
+++ b/dev-tools/ansible/helix.yml
@@ -1,0 +1,50 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+---
+
+- hosts: zookeeper
+  tags: zookeeper, airavata
+  roles:
+    - env_setup
+    - java
+    - zookeeper
+
+- hosts: kafka
+  tags: kafka, airavata
+  roles:
+    - env_setup
+    - zookeeper
+    - kafka
+
+- hosts: helix
+  tags: helix, airavata
+  roles:
+    - role: common
+      become: yes
+      become_user: "{{user}}"
+    - role: helix_setup
+      become: yes
+      become_user: "{{user}}"
+    - role: job_monitor
+      become: yes
+      become_user: "{{user}}"
+
+...

--- a/dev-tools/ansible/inventories/standalone/group_vars/helix/vars.yml
+++ b/dev-tools/ansible/inventories/standalone/group_vars/helix/vars.yml
@@ -1,0 +1,43 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+---
+helix_version: 0.7.1
+helix_url: http://www-eu.apache.org/dist//helix/{{helix_version}}/binaries/helix-core-{{helix_version}}-pkg.tar
+helix_dir: "{{ deployment_dir }}/airavata-helix"
+helix_cluster_name: "AiravataDemoCluster"
+
+snapshot_version: "0.17-SNAPSHOT"
+
+# Job Monitoring related variables
+job_monitor_broker_url: "192.168.99.103:9092"
+realtime_monitor_broker_url: "localhost:9092"
+
+# Kafka related variables
+kafka_port: "9092"
+kafka_broker_url: "192.168.99.103:{{ kafka_port }}"
+kafka_broker_topic: "parsed-data"
+kafka_broker_consumer_group: "MonitoringConsumer"
+
+running_on_aws: "false"
+kafka_broker_list_url: "{{ kafka_broker_url }}"
+kafka_topic_prefix: "local"
+enable_kafka_logging: "false"
+...

--- a/dev-tools/ansible/inventories/standalone/hosts
+++ b/dev-tools/ansible/inventories/standalone/hosts
@@ -25,3 +25,6 @@
 
 [kafka]
 192.168.99.102 ansible_connection=ssh ansible_user=root
+
+[helix]
+192.168.99.102 ansible_connection=ssh ansible_user=root

--- a/dev-tools/ansible/inventories/standalone/hosts
+++ b/dev-tools/ansible/inventories/standalone/hosts
@@ -22,3 +22,6 @@
 
 [keycloak]
 192.168.99.102 ansible_connection=ssh ansible_user=root
+
+[kafka]
+192.168.99.102 ansible_connection=ssh ansible_user=root

--- a/dev-tools/ansible/roles/helix_setup/defaults/main.yml
+++ b/dev-tools/ansible/roles/helix_setup/defaults/main.yml
@@ -1,0 +1,46 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+---
+helix_controller_name: "helixcontroller"
+helix_participant_name: "helixparticipant"
+helix_pre_wm_name: "prewm"
+helix_post_wm_name: "postwm"
+
+helix_controller_version: "helix-controller-{{ snapshot_version }}"
+helix_participant_version: "helix-participant-{{ snapshot_version }}"
+helix_pre_wm_version: "helix-pre-wm-{{ snapshot_version }}"
+helix_post_wm_version: "helix-post-wm-{{ snapshot_version }}"
+
+helix_controller_dist_name: "{{ helix_controller_version }}-bin.tar.gz"
+helix_participant_dist_name: "{{ helix_participant_version }}-bin.tar.gz"
+helix_pre_wm_dist_name: "{{ helix_pre_wm_version }}-bin.tar.gz"
+helix_post_wm_dist_name: "{{ helix_post_wm_version }}-bin.tar.gz"
+
+helix_controller_log_dir: "{{ helix_dir }}/{{ helix_controller_version }}/logs"
+helix_participant_log_dir: "{{ helix_dir }}/{{ helix_participant_version }}/logs"
+helix_pre_wm_dist_log_dir: "{{ helix_dir }}/{{ helix_pre_wm_version }}/logs"
+helix_post_wm_dist_log_dir: "{{ helix_dir }}/{{ helix_post_wm_version }}/logs"
+
+job_status_publish_endpoint: "http://149.165.156.211:8082/topics/helix-airavata-mq"
+
+helix_log_max_history: 30
+helix_log_total_size_cap: "1GB"
+...

--- a/dev-tools/ansible/roles/helix_setup/tasks/main.yml
+++ b/dev-tools/ansible/roles/helix_setup/tasks/main.yml
@@ -1,0 +1,103 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+---
+
+# Create the directory for Helix deployment
+- name: Create helix deployment directory
+  file: path="{{ helix_dir }}" state=directory owner={{ user }} group={{ group }}
+
+# Setup Helix
+- name: Download and unarchive Helix
+  unarchive: src="{{ helix_url }}"
+      dest="{{ helix_dir }}"
+      copy=no
+      owner="{{ user }}"
+      group="{{ group }}"
+  become: yes
+
+# Create the cluster
+- name: Create Helix Cluster
+  command: "{{ item }} chdir={{ helix_dir }}/helix-core-{{ helix_version }}/"
+  with_items:
+  - ./bin/helix-admin.sh --zkSvr localhost:{{ zookeeper_client_port }} --dropCluster {{ helix_cluster_name }}
+  - ./bin/helix-admin.sh --zkSvr localhost:{{ zookeeper_client_port }} --addCluster {{ helix_cluster_name }}
+
+# Copy required distributions to the deployment directory
+- name: Copy distributions to airavata-helix deployment directory
+  unarchive: "src={{ airavata_source_dir }}/modules/airavata-helix/helix-distribution/target/{{ item }}
+              dest={{ helix_dir }}/ copy=no"
+  with_items:
+  - "{{ helix_controller_dist_name }}"
+  - "{{ helix_participant_dist_name }}"
+  - "{{ helix_pre_wm_dist_name }}"
+  - "{{ helix_post_wm_dist_name }}"
+
+# Copy properties files & logback.xml files
+
+- name: Copy Airavata server properties files
+  template: "src={{ item.name }}/airavata-server.properties.j2
+            dest={{ helix_dir }}/{{ item.dir }}/conf/airavata-server.properties
+            owner={{ user }}
+            group={{ group }}
+            mode=\"u=rw,g=r,o=r\""
+  with_items:
+  - { name: controller, dir: "{{ helix_controller_version }}" }
+  - { name: participant, dir: "{{ helix_participant_version }}" }
+  - { name: pre-wm, dir: "{{ helix_pre_wm_version }}" }
+  - { name: post-wm, dir: "{{ helix_post_wm_version }}" }
+
+- name: Copy logback configuration file
+  template: "src={{ item.name }}/logback.xml.j2
+            dest={{ helix_dir }}/{{ item.dir }}/conf/logback.xml
+            owner={{ user }}
+            group={{ group }}
+            mode=\"u=rw,g=r,o=r\""
+  with_items:
+  - { name: controller, dir: "{{ helix_controller_version }}" }
+  - { name: participant, dir: "{{ helix_participant_version }}" }
+  - { name: pre-wm, dir: "{{ helix_pre_wm_version }}" }
+  - { name: post-wm, dir: "{{ helix_post_wm_version }}" }
+
+- name: Create logs directory
+  file: "path={{ item }} state=directory owner={{ user }} group={{ group }}"
+  with_items:
+  - "{{ helix_controller_log_dir }}"
+  - "{{ helix_participant_log_dir }}"
+  - "{{ helix_pre_wm_dist_log_dir }}"
+  - "{{ helix_post_wm_dist_log_dir }}"
+
+- name: Stop daemons
+  command: "{{ item.command }} chdir={{ helix_dir }}/{{ item.dir }}/"
+  with_items:
+  - { command: ./bin/controller-daemon.sh stop, dir: "{{ helix_controller_version }}" }
+  - { command: ./bin/participant-daemon.sh stop, dir: "{{ helix_participant_version }}" }
+  - { command: ./bin/pre-wm-daemon.sh stop, dir: "{{ helix_pre_wm_version }}" }
+  - { command: ./bin/post-wm-daemon.sh stop, dir: "{{ helix_post_wm_version }}" }
+
+# Run bash-scripts
+- name: Start daemons
+  command: "{{ item.command }} chdir={{ helix_dir }}/{{ item.dir }}/"
+  with_items:
+  - { command: ./bin/controller-daemon.sh start, dir: "{{ helix_controller_version }}" }
+  - { command: ./bin/participant-daemon.sh start, dir: "{{ helix_participant_version }}" }
+  - { command: ./bin/pre-wm-daemon.sh start, dir: "{{ helix_pre_wm_version }}" }
+  - { command: ./bin/post-wm-daemon.sh start, dir: "{{ helix_post_wm_version }}" }
+...

--- a/dev-tools/ansible/roles/helix_setup/templates/controller/airavata-server.properties.j2
+++ b/dev-tools/ansible/roles/helix_setup/templates/controller/airavata-server.properties.j2
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+###########################################################################
+# Helix Controller configurations
+###########################################################################
+
+helix.cluster.name={{ helix_cluster_name }}
+helix.controller.name={{ helix_controller_name }}
+
+###########################################################################
+# Zookeeper Server Configuration
+###########################################################################
+embedded.zk=false
+zookeeper.server.connection={{ zookeeper_url }}
+zookeeper.timeout=30000

--- a/dev-tools/ansible/roles/helix_setup/templates/controller/logback.xml.j2
+++ b/dev-tools/ansible/roles/helix_setup/templates/controller/logback.xml.j2
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%t] %-5p %c{30} %X - %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <File>{{ helix_controller_log_dir }}/airavata.log</File>
+        <Append>true</Append>
+        <encoder>
+            <pattern>%d [%t] %-5p %c{30} %X - %m%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>{{ helix_controller_log_dir }}/airavata.log.%d{yyyy-MM-dd}</fileNamePattern>
+            <maxHistory>{{ helix_log_max_history }}</maxHistory>
+            <totalSizeCap>{{ helix_log_total_size_cap }}</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <logger name="ch.qos.logback" level="WARN"/>
+    <logger name="org.apache.helix" level="WARN"/>
+    <logger name="org.apache.zookeeper" level="ERROR"/>
+    <logger name="org.apache.airavata" level="INFO"/>
+    <logger name="org.hibernate" level="ERROR"/>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="LOGFILE"/>
+    </root>
+</configuration>

--- a/dev-tools/ansible/roles/helix_setup/templates/participant/airavata-server.properties.j2
+++ b/dev-tools/ansible/roles/helix_setup/templates/participant/airavata-server.properties.j2
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+###########################################################################
+#  Registry Server Configurations
+###########################################################################
+regserver.server.host={{ registry_host }}
+regserver.server.port={{ registry_port }}
+
+###########################################################################
+# Credential Store module Configuration
+###########################################################################
+credential.store.server.host={{ cred_store_server_host }}
+credential.store.server.port={{ cred_store_port }}
+
+###########################################################################
+# Monitoring module Configuration
+###########################################################################
+email.based.monitor.address={{ monitor_email_address }}
+job.notification.emailids=
+job.notification.enable=true
+
+###########################################################################
+# Helix workflow manager configurations
+###########################################################################
+helix.cluster.name={{ helix_cluster_name }}
+helix.participant.name={{ helix_participant_name }}
+job.status.publish.endpoint={{ job_status_publish_endpoint }}
+
+###########################################################################
+# AMQP Notification Configuration
+###########################################################################
+#for simple scenarios we can use the guest user
+#rabbitmq.broker.url=amqp://localhost:5672
+#for production scenarios, give url as amqp://userName:password@hostName:portNumber/virtualHost, create user, virtualhost
+# and give permissions, refer: http://blog.dtzq.com/2012/06/rabbitmq-users-and-virtual-hosts.html
+rabbitmq.broker.url={{ rabbitmq_broker_url }}
+rabbitmq.status.exchange.name=status_exchange
+rabbitmq.process.exchange.name=process_exchange
+rabbitmq.experiment.exchange.name=experiment_exchange
+durable.queue=false
+prefetch.count=200
+process.launch.queue.name=process.launch.queue
+experiment.launch..queue.name=experiment.launch.queue
+
+###########################################################################
+# Zookeeper Server Configuration
+###########################################################################
+zookeeper.server.connection={{ zookeeper_url }}
+zookeeper.timeout=30000

--- a/dev-tools/ansible/roles/helix_setup/templates/participant/logback.xml.j2
+++ b/dev-tools/ansible/roles/helix_setup/templates/participant/logback.xml.j2
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%t] %-5p %c{30} %X - %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <File>.{{ helix_participant_log_dir }}/airavata.log</File>
+        <Append>true</Append>
+        <encoder>
+            <pattern>%d [%t] %-5p %c{30} %X - %m%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>{{ helix_participant_log_dir }}/airavata.log.%d{yyyy-MM-dd}</fileNamePattern>
+            <maxHistory>{{ helix_log_max_history }}</maxHistory>
+            <totalSizeCap>{{ helix_log_total_size_cap }}</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <logger name="ch.qos.logback" level="WARN"/>
+    <logger name="org.apache.helix" level="WARN"/>
+    <logger name="org.apache.zookeeper" level="ERROR"/>
+    <logger name="org.apache.airavata" level="INFO"/>
+    <logger name="org.hibernate" level="ERROR"/>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="LOGFILE"/>
+    </root>
+</configuration>

--- a/dev-tools/ansible/roles/helix_setup/templates/post-wm/airavata-server.properties.j2
+++ b/dev-tools/ansible/roles/helix_setup/templates/post-wm/airavata-server.properties.j2
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+###########################################################################
+#  Registry Server Configurations
+###########################################################################
+regserver.server.host={{ registry_host }}
+regserver.server.port={{ registry_port }}
+
+###########################################################################
+# Helix workflow manager configurations
+###########################################################################
+kafka.broker.url={{ kafka_broker_url }}
+kafka.broker.topic={{ kafka_broker_topic }}
+kafka.broker.consumer.group={{ kafka_broker_consumer_group }}
+helix.cluster.name={{ helix_cluster_name }}
+post.workflow.manager.name={{ helix_post_wm_name }}
+
+###########################################################################
+# AMQP Notification Configuration
+###########################################################################
+#for simple scenarios we can use the guest user
+#rabbitmq.broker.url=amqp://localhost:5672
+#for production scenarios, give url as amqp://userName:password@hostName:portNumber/virtualHost, create user, virtualhost
+# and give permissions, refer: http://blog.dtzq.com/2012/06/rabbitmq-users-and-virtual-hosts.html
+rabbitmq.broker.url={{ rabbitmq_broker_url }}
+rabbitmq.status.exchange.name=status_exchange
+rabbitmq.process.exchange.name=process_exchange
+rabbitmq.experiment.exchange.name=experiment_exchange
+durable.queue=false
+prefetch.count=200
+process.launch.queue.name=process.launch.queue
+experiment.launch..queue.name=experiment.launch.queue
+
+###########################################################################
+# Zookeeper Server Configuration
+###########################################################################
+zookeeper.server.connection={{ zookeeper_url }}
+zookeeper.timeout=30000

--- a/dev-tools/ansible/roles/helix_setup/templates/post-wm/logback.xml.j2
+++ b/dev-tools/ansible/roles/helix_setup/templates/post-wm/logback.xml.j2
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%t] %-5p %c{30} %X - %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <File>{{ helix_post_wm_dist_log_dir }}/airavata.log</File>
+        <Append>true</Append>
+        <encoder>
+            <pattern>%d [%t] %-5p %c{30} %X - %m%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>{{ helix_post_wm_dist_log_dir }}/airavata.log.%d{yyyy-MM-dd}</fileNamePattern>
+            <maxHistory>{{ helix_log_max_history }}</maxHistory>
+            <totalSizeCap>{{ helix_log_total_size_cap }}</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <logger name="ch.qos.logback" level="WARN"/>
+    <logger name="org.apache.helix" level="WARN"/>
+    <logger name="org.apache.zookeeper" level="ERROR"/>
+    <logger name="org.apache.airavata" level="INFO"/>
+    <logger name="org.hibernate" level="ERROR"/>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="LOGFILE"/>
+    </root>
+</configuration>

--- a/dev-tools/ansible/roles/helix_setup/templates/pre-wm/airavata-server.properties.j2
+++ b/dev-tools/ansible/roles/helix_setup/templates/pre-wm/airavata-server.properties.j2
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+###########################################################################
+#  Registry Server Configurations
+###########################################################################
+regserver.server.host={{ registry_host }}
+regserver.server.port={{ registry_port }}
+
+###########################################################################
+# Helix workflow manager configurations
+###########################################################################
+helix.cluster.name={{ helix_cluster_name }}
+pre.workflow.manager.name={{ helix_pre_wm_name }}
+
+###########################################################################
+# AMQP Notification Configuration
+###########################################################################
+#for simple scenarios we can use the guest user
+#rabbitmq.broker.url=amqp://localhost:5672
+#for production scenarios, give url as amqp://userName:password@hostName:portNumber/virtualHost, create user, virtualhost
+# and give permissions, refer: http://blog.dtzq.com/2012/06/rabbitmq-users-and-virtual-hosts.html
+rabbitmq.broker.url={{ rabbitmq_broker_url }}
+rabbitmq.status.exchange.name=status_exchange
+rabbitmq.process.exchange.name=process_exchange
+rabbitmq.experiment.exchange.name=experiment_exchange
+durable.queue=false
+prefetch.count=200
+process.launch.queue.name=process.launch.queue
+experiment.launch..queue.name=experiment.launch.queue
+
+###########################################################################
+# Zookeeper Server Configuration
+###########################################################################
+zookeeper.server.connection={{ zookeeper_url }}
+zookeeper.timeout=30000

--- a/dev-tools/ansible/roles/helix_setup/templates/pre-wm/logback.xml.j2
+++ b/dev-tools/ansible/roles/helix_setup/templates/pre-wm/logback.xml.j2
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%t] %-5p %c{30} %X - %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <File>{{ helix_pre_wm_dist_log_dir }}/airavata.log</File>
+        <Append>true</Append>
+        <encoder>
+            <pattern>%d [%t] %-5p %c{30} %X - %m%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>{{ helix_pre_wm_dist_log_dir }}/airavata.log.%d{yyyy-MM-dd}</fileNamePattern>
+            <maxHistory>{{ helix_log_max_history }}</maxHistory>
+            <totalSizeCap>{{ helix_log_total_size_cap }}</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <logger name="ch.qos.logback" level="WARN"/>
+    <logger name="org.apache.helix" level="WARN"/>
+    <logger name="org.apache.zookeeper" level="ERROR"/>
+    <logger name="org.apache.airavata" level="INFO"/>
+    <logger name="org.hibernate" level="ERROR"/>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="LOGFILE"/>
+    </root>
+</configuration>

--- a/dev-tools/ansible/roles/job_monitor/defaults/main.yml
+++ b/dev-tools/ansible/roles/job_monitor/defaults/main.yml
@@ -1,0 +1,50 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+---
+# Variables related to helix integration
+helix_controller_name: "helixcontroller"
+helix_participant_name: "helixparticipant"
+helix_pre_wm_name: "prewm"
+helix_post_wm_name: "postwm"
+
+# Variables related to email monitor
+email_monitor_version: "email-monitor-{{ snapshot_version }}"
+email_monitor_dist_name: "{{ email_monitor_version }}-bin.tar.gz"
+email_monitor_log_dir: "{{ helix_dir }}/{{ email_monitor_version }}/logs"
+email_job_monitor_broker_publisher: "EmailBasedProducer"
+
+# Variables related to realtime monitor
+realtime_monitor_version: "realtime-monitor-{{ snapshot_version }}"
+realtime_monitor_dist_name: "{{ realtime_monitor_version }}-bin.tar.gz"
+realtime_monitor_log_dir: "{{ helix_dir }}/{{ realtime_monitor_version }}/logs"
+realtime_job_monitor_broker_publisher: "RealtimeProducer"
+realtime_monitor_broker_consumer_group: "monitor"
+realtime_monitor_broker_topic: "helix-airavata-mq"
+
+job_monitor_broker_topic: "parsed-data"
+
+# kafka related variables
+kafka_broker_topic: "parsed-data"
+kafka_broker_consumer_group: "MonitoringConsumer"
+
+helix_log_max_history: 30
+helix_log_total_size_cap: "1GB"
+...

--- a/dev-tools/ansible/roles/job_monitor/tasks/main.yml
+++ b/dev-tools/ansible/roles/job_monitor/tasks/main.yml
@@ -1,0 +1,82 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+---
+
+# Create the directory for Helix deployment
+- name: Create helix deployment directory
+  file: path="{{ helix_dir }}" state=directory owner={{ user }} group={{ group }}
+
+# Copy job monitoring distributions to the deployment directory
+- name: Copy Job monitoring distributions to airavata-helix deployment directory
+  unarchive: "src={{ airavata_source_dir }}/modules/job-monitor/job-monitor-distribution/target/{{ item }}
+              dest={{ helix_dir }}/ copy=no"
+  with_items:
+  - "{{ email_monitor_dist_name }}"
+  - "{{ realtime_monitor_dist_name }}"
+
+# Copy properties files, logback.xml files & config files
+
+- name: Copy Airavata server properties files
+  template: "src={{ item.name }}/airavata-server.properties.j2
+            dest={{ helix_dir }}/{{ item.dir }}/conf/airavata-server.properties
+            owner={{ user }}
+            group={{ group }}
+            mode=\"u=rw,g=r,o=r\""
+  with_items:
+  - { name: email-monitor, dir: "{{ email_monitor_version }}" }
+  - { name: realtime-monitor, dir: "{{ realtime_monitor_version }}" }
+
+- name: Copy logback configuration file
+  template: "src={{ item.name }}/logback.xml.j2
+            dest={{ helix_dir }}/{{ item.dir }}/conf/logback.xml
+            owner={{ user }}
+            group={{ group }}
+            mode=\"u=rw,g=r,o=r\""
+  with_items:
+  - { name: email-monitor, dir: "{{ email_monitor_version }}" }
+  - { name: realtime-monitor, dir: "{{ realtime_monitor_version }}" }
+
+- name: Copy email-monitor configuration file
+  template: src=email-monitor/email-config.yaml.j2
+            dest="{{ helix_dir }}/{{ email_monitor_version }}/conf/email-config.yaml"
+            owner={{ user }}
+            group={{ group }}
+            mode="u=rw,g=r,o=r"
+
+- name: Create logs directory
+  file: "path={{ item }} state=directory owner={{ user }} group={{ group }}"
+  with_items:
+  - "{{ email_monitor_log_dir }}"
+  - "{{ realtime_monitor_log_dir }}"
+
+- name: Stop daemons
+  command: "{{ item.command }} chdir={{ helix_dir }}/{{ item.dir }}/"
+  with_items:
+  - { command: ./bin/email-monitor-daemon.sh stop, dir: "{{ email_monitor_version }}" }
+  - { command: ./bin/realtime-monitor-daemon.sh stop, dir: "{{ realtime_monitor_version }}" }
+
+# Run bash-scripts
+- name: Start daemons
+  command: "{{ item.command }} chdir={{ helix_dir }}/{{ item.dir }}/"
+  with_items:
+  - { command: ./bin/email-monitor-daemon.sh start, dir: "{{ email_monitor_version }}" }
+  - { command: ./bin/realtime-monitor-daemon.sh start, dir: "{{ realtime_monitor_version }}" }
+...

--- a/dev-tools/ansible/roles/job_monitor/templates/email-monitor/airavata-server.properties.j2
+++ b/dev-tools/ansible/roles/job_monitor/templates/email-monitor/airavata-server.properties.j2
@@ -1,0 +1,278 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+###########################################################################
+#
+#  This properties file provides configuration for all Airavata Services:
+#  API Server, Registry, Workflow Interpreter, GFac, Orchestrator
+#
+###########################################################################
+
+###########################################################################
+#  API Server Registry Configuration
+###########################################################################
+
+#for derby [AiravataJPARegistry]
+#registry.jdbc.driver=org.apache.derby.jdbc.ClientDriver
+#registry.jdbc.url=jdbc:derby://localhost:1527/experiment_catalog;create=true;user=airavata;password=airavata
+# MariaDB database configuration
+registry.jdbc.driver=org.mariadb.jdbc.Driver
+registry.jdbc.url=jdbc:mariadb://{{ db_server }}:{{ db_server_port }}/{{ exp_catalog }}
+registry.jdbc.user={{ db_user }}
+registry.jdbc.password={{ db_password }}
+#FIXME: Probably the following property should be removed.
+start.derby.server.mode=false
+validationQuery=SELECT 1 from CONFIGURATION
+cache.enable=false
+jpa.cache.size=-1
+#jpa.connection.properties=MaxActive=10,MaxIdle=5,MinIdle=2,MaxWait=60000,testWhileIdle=true,testOnBorrow=true
+enable.sharing={{enable_sharing}}
+
+# Properties for default user mode
+default.registry.user={{ default_registry_user }}
+default.registry.password={{ default_registry_password }}
+default.registry.password.hash.method=SHA
+default.registry.gateway={{ default_gateway }}
+super.tenant.gatewayId={{ default_gateway }}
+
+###########################################################################
+#  Application Catalog DB Configuration
+###########################################################################
+#for derby [AiravataJPARegistry]
+#appcatalog.jdbc.driver=org.apache.derby.jdbc.ClientDriver
+#appcatalog.jdbc.url=jdbc:derby://localhost:1527/app_catalog;create=true;user=airavata;password=airavata
+# MariaDB database configuration
+appcatalog.jdbc.driver=org.mariadb.jdbc.Driver
+appcatalog.jdbc.url=jdbc:mariadb://{{ db_server }}:{{ db_server_port }}/{{ app_catalog }}
+appcatalog.jdbc.user={{ db_user }}
+appcatalog.jdbc.password={{ db_password }}
+appcatalog.validationQuery=SELECT 1 from CONFIGURATION
+
+##########################################################################
+#  Replica Catalog DB Configuration
+###########################################################################
+#for derby [AiravataJPARegistry]
+#replicacatalog.jdbc.driver=org.apache.derby.jdbc.ClientDriver
+#replicacatalog.jdbc.url=jdbc:derby://localhost:1527/replica_catalog;create=true;user=airavata;password=airavata
+# MariaDB database configuration
+replicacatalog.jdbc.driver=org.mariadb.jdbc.Driver
+replicacatalog.jdbc.url=jdbc:mariadb://{{ db_server }}:{{ db_server_port }}/{{ replica_catalog }}
+replicacatalog.jdbc.user={{ db_user }}
+replicacatalog.jdbc.password={{ db_password }}
+replicacatalog.validationQuery=SELECT 1 from CONFIGURATION
+
+###########################################################################
+#  Sharing Catalog DB Configuration
+###########################################################################
+#for derby [AiravataJPARegistry]
+#sharingcatalog.jdbc.driver=org.apache.derby.jdbc.ClientDriver
+#sharingcatalog.jdbc.url=jdbc:derby://localhost:1527/sharing_catalog;create=true;user=airavata;password=airavata
+# MariaDB database configuration
+sharingcatalog.jdbc.driver=org.mariadb.jdbc.Driver
+sharingcatalog.jdbc.url=jdbc:mariadb://{{ db_server }}:{{ db_server_port }}/{{ sharing_catalog }}
+sharingcatalog.jdbc.user={{ db_user }}
+sharingcatalog.jdbc.password={{ db_password }}
+sharingcatalog.validationQuery=SELECT 1 from CONFIGURATION
+
+###########################################################################
+#  Sharing Registry Server Configuration
+###########################################################################
+sharing_server=org.apache.airavata.sharing.registry.server.SharingRegistryServer
+sharing.registry.server.host={{ sharing_registry_host }}
+sharing.registry.server.port={{ sharing_registry_port }}
+
+###########################################################################
+#  API Server Configurations
+###########################################################################
+apiserver=org.apache.airavata.api.server.AiravataAPIServer
+apiserver.name={{ api_server_name }}
+apiserver.host={{ api_server_host }}
+apiserver.port={{ api_server_port }}
+apiserver.min.threads=50
+
+###########################################################################
+#  Registry Server Configurations
+###########################################################################
+regserver=org.apache.airavata.registry.api.service.RegistryAPIServer
+regserver.server.name={{registry_name}}
+regserver.server.host={{registry_host}}
+regserver.server.port={{registry_port}}
+regserver.server.min.threads=50
+
+
+###########################################################################
+#  Job Scheduler can send informative email messages to you about the status of your job.
+# Specify a string which consists of either the single character "n" (no mail), or one or more
+#  of the characters "a" (send mail when job is aborted), "b" (send mail when job begins),
+# and "e" (send mail when job terminates).  The default is "a" if not specified.
+###########################################################################
+
+job.notification.enable=true
+#Provide comma separated email ids as a string if more than one
+job.notification.emailids=
+job.notification.flags=abe
+
+###########################################################################
+# Credential Store module Configuration
+###########################################################################
+credential.store.keystore.url={{ keystores_location }}/{{ cred_keystore_src_path | basename }}
+credential.store.keystore.alias={{ cred_keystore_alias }}
+credential.store.keystore.password={{ cred_keystore_passwd }}
+credential.store.jdbc.url=jdbc:mariadb://{{ db_server }}:{{ db_server_port }}/{{ credential_store }}
+credential.store.jdbc.user={{ db_user }}
+credential.store.jdbc.password={{ db_password }}
+credential.store.jdbc.driver=org.mariadb.jdbc.Driver
+credential.store.server.host={{ cred_store_server_host }}
+credential.store.server.port={{ cred_store_port }}
+credentialstore=org.apache.airavata.credential.store.server.CredentialStoreServer
+credential.stroe.jdbc.validationQuery=SELECT 1 from CONFIGURATION
+
+# these properties used by credential store email notifications
+email.server=smtp.googlemail.com
+email.server.port=465
+email.user=airavata
+email.password=xxx
+email.ssl=true
+email.from=airavata@apache.org
+
+# SSH PKI key pair or ssh password can be used SSH based sshKeyAuthentication is used.
+# if user specify both password sshKeyAuthentication gets the higher preference
+
+################# ---------- For ssh key pair sshKeyAuthentication ------------------- ################
+#ssh.public.key=/path to public key for ssh
+#ssh.private.key=/path to private key file for ssh
+#ssh.keypass=passphrase for the private key
+#ssh.username=username for ssh connection
+## If you set "yes" for ssh.strict.hostKey.checking, then you must provide known hosts file path
+#ssh.strict.hostKey.checking=yes/no
+#ssh.known.hosts.file=/path to known hosts file
+### Incase of password sshKeyAuthentication.
+#ssh.password=Password for ssh connection
+
+################ ---------- BES Properties ------------------- ###############
+#bes.ca.cert.path=<location>/certificates/cacert.pem
+#bes.ca.key.path=<location>/certificates/cakey.pem
+#bes.ca.key.pass=passphrase
+
+###########################################################################
+# Monitoring module Configuration
+###########################################################################
+
+#This will be the primary monitoring tool which runs in airavata, in future there will be multiple monitoring
+#mechanisms and one would be able to start a monitor
+monitors=org.apache.airavata.gfac.monitor.impl.pull.qstat.QstatMonitor,org.apache.airavata.gfac.monitor.impl.LocalJobMonitor
+
+#These properties will used to enable email base monitoring
+email.based.monitor.host=imap.gmail.com
+email.based.monitor.address={{ monitor_email_address }}
+email.based.monitor.password={{ monitor_email_password }}
+email.based.monitor.folder.name=INBOX
+# either imaps or pop3
+email.based.monitor.store.protocol=imaps
+#These property will be used to query the email server periodically. value in milliseconds(ms).
+email.based.monitoring.period=10000
+job.monitor.broker.url={{ job_monitor_broker_url }}
+job.monitor.broker.topic={{ job_monitor_broker_topic }}
+job.monitor.broker.publisher.id={{ email_job_monitor_broker_publisher }}
+
+###########################################################################
+#Helix workflow manager configurations
+###########################################################################
+
+kafka.broker.url={{ kafka_broker_url }}
+kafka.broker.topic={{ kafka_broker_topic }}
+kafka.broker.consumer.group={{ kafka_broker_consumer_group }}
+helix.cluster.name={{ helix_cluster_name }}
+pre.workflow.manager.name={{ helix_pre_wm_name }}
+post.workflow.manager.name={{ helix_post_wm_name }}
+helix.controller.name={{ helix_controller_name }}
+helix.participant.name={{ helix_participant_name }}
+
+###########################################################################
+# AMQP Notification Configuration
+###########################################################################
+#for simple scenarios we can use the guest user
+#rabbitmq.broker.url=amqp://localhost:5672
+#for production scenarios, give url as amqp://userName:password@hostName:portNumber/virtualHost, create user, virtualhost
+# and give permissions, refer: http://blog.dtzq.com/2012/06/rabbitmq-users-and-virtual-hosts.html
+rabbitmq.broker.url={{ rabbitmq_broker_url }}
+rabbitmq.status.exchange.name=status_exchange
+rabbitmq.process.exchange.name=process_exchange
+rabbitmq.experiment.exchange.name=experiment_exchange
+durable.queue=false
+prefetch.count=200
+process.launch.queue.name=process.launch.queue
+experiment.launch..queue.name=experiment.launch.queue
+
+###########################################################################
+# Zookeeper Server Configuration
+###########################################################################
+embedded.zk=false
+zookeeper.server.connection={{ zookeeper_url }}
+zookeeper.timeout=30000
+
+########################################################################
+## API Security Configuration
+########################################################################
+api.secured={{ api_secured }}
+security.manager.class=org.apache.airavata.service.security.KeyCloakSecurityManager
+### TLS related configuration ####
+TLS.enabled={{ tls_enable }}
+TLS.api.server.port={{ api_server_tls_port }}
+TLS.client.timeout=10000
+#### keystore configuration ####
+keystore.path={{ keystores_location }}/{{ keystore_src_path | basename }}
+keystore.password={{ keystore_passwd }}
+#### trust store configuration ####
+trust.store={{ keystores_location }}/{{ client_truststore_src_path | basename }}
+trust.store.password={{ client_truststore_passwd }}
+#### authorization cache related configuration ####
+authz.cache.enabled=true
+authz.cache.manager.class=org.apache.airavata.service.security.authzcache.DefaultAuthzCacheManager
+in.memory.cache.size=1000
+
+# Kafka Logging related configuration
+isRunningOnAws={{ running_on_aws }}
+kafka.broker.list={{ kafka_broker_list_url }}
+kafka.topic.prefix={{ kafka_topic_prefix }}
+enable.kafka.logging={{ enable_kafka_logging }}
+
+###########################################################################
+# Profile Service Configuration
+###########################################################################
+profile.service.server.host={{ profile_service_host }}
+profile.service.server.port={{ profile_service_port }}
+profile_service=org.apache.airavata.service.profile.server.ProfileServiceServer
+# MariaDB properties
+profile.service.jdbc.url=jdbc:mariadb://{{ db_server }}:{{ db_server_port }}/{{ profile_service }}
+profile.service.jdbc.user={{ db_user }}
+profile.service.jdbc.password={{ db_password }}
+profile.service.jdbc.driver=org.mariadb.jdbc.Driver
+profile.service.validationQuery=SELECT 1
+
+###########################################################################
+# Iam Admin services Configuration
+###########################################################################
+iam.server.url={{ iam_server_url }}
+iam.server.super.admin.username={{ iam_server_super_admin_username }}
+iam.server.super.admin.password={{ iam_server_super_admin_password }}
+
+###########################################################################
+# DB Event Manager Runner
+###########################################################################
+db_event_manager=org.apache.airavata.db.event.manager.DBEventManagerRunner

--- a/dev-tools/ansible/roles/job_monitor/templates/email-monitor/email-config.yaml.j2
+++ b/dev-tools/ansible/roles/job_monitor/templates/email-monitor/email-config.yaml.j2
@@ -1,0 +1,21 @@
+config:
+ resources:
+   - jobManagerType: PBS
+     emailParser: org.apache.airavata.monitor.email.parser.PBSEmailParser
+     resourceEmailAddresses:
+       - pbsconsult@sdsc.edu  # gordon
+       - adm@trident.bigred2.uits.iu.edu # Bigred2
+       - root <adm@trident.bigred2.uits.iu.edu> # Bigred2
+       - root <adm@scyld.localdomain> # alamo
+
+   - jobManagerType: SLURM
+     emailParser: org.apache.airavata.monitor.email.parser.SLURMEmailParser
+     resourceEmailAddresses:
+       - SDSC Admin <slurm@comet-fe3.sdsc.edu> # comet
+       - slurm@batch1.stampede.tacc.utexas.edu # stampede
+       - slurm@helix-slurm-headnode.novalocal
+
+   - jobManagerType: UGE
+     emailParser: org.apache.airavata.monitor.email.parser.UGEEmailParser
+     resourceEmailAddresses:
+       - ls4.tacc.utexas.edu # contain Lonestar

--- a/dev-tools/ansible/roles/job_monitor/templates/email-monitor/logback.xml.j2
+++ b/dev-tools/ansible/roles/job_monitor/templates/email-monitor/logback.xml.j2
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%t] %-5p %c{30} %X - %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <File>{{ email_monitor_log_dir }}/airavata.log</File>
+        <Append>true</Append>
+        <encoder>
+            <pattern>%d [%t] %-5p %c{30} %X - %m%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>{{ email_monitor_log_dir }}/airavata.log.%d{yyyy-MM-dd}</fileNamePattern>
+            <maxHistory>{{ helix_log_max_history }}</maxHistory>
+            <totalSizeCap>{{ helix_log_total_size_cap }}</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <logger name="ch.qos.logback" level="WARN"/>
+    <logger name="org.apache.helix" level="WARN"/>
+    <logger name="org.apache.zookeeper" level="ERROR"/>
+    <logger name="org.apache.airavata" level="INFO"/>
+    <logger name="org.hibernate" level="ERROR"/>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="LOGFILE"/>
+    </root>
+</configuration>

--- a/dev-tools/ansible/roles/job_monitor/templates/realtime-monitor/airavata-server.properties.j2
+++ b/dev-tools/ansible/roles/job_monitor/templates/realtime-monitor/airavata-server.properties.j2
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+zookeeper.server.connection={{ zookeeper_url }}
+zookeeper.timeout=30000
+
+realtime.monitor.broker.url={{ realtime_monitor_broker_url }}
+realtime.monitor.broker.consumer.group={{ realtime_monitor_broker_consumer_group }}
+realtime.monitor.broker.topic={{ realtime_monitor_broker_topic }}
+
+job.monitor.broker.url={{ job_monitor_broker_url }}
+job.monitor.broker.topic={{ job_monitor_broker_topic }}
+job.monitor.broker.publisher.id={{ realtime_job_monitor_broker_publisher }}

--- a/dev-tools/ansible/roles/job_monitor/templates/realtime-monitor/logback.xml.j2
+++ b/dev-tools/ansible/roles/job_monitor/templates/realtime-monitor/logback.xml.j2
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%t] %-5p %c{30} %X - %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <File>{{ realtime_monitor_log_dir }}/airavata.log</File>
+        <Append>true</Append>
+        <encoder>
+            <pattern>%d [%t] %-5p %c{30} %X - %m%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>{{ realtime_monitor_log_dir }}/airavata.log.%d{yyyy-MM-dd}</fileNamePattern>
+            <maxHistory>{{ helix_log_max_history }}</maxHistory>
+            <totalSizeCap>{{ helix_log_total_size_cap }}</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <logger name="ch.qos.logback" level="WARN"/>
+    <logger name="org.apache.helix" level="WARN"/>
+    <logger name="org.apache.zookeeper" level="ERROR"/>
+    <logger name="org.apache.airavata" level="INFO"/>
+    <logger name="org.hibernate" level="ERROR"/>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="LOGFILE"/>
+    </root>
+</configuration>

--- a/dev-tools/ansible/roles/kafka/defaults/main.yml
+++ b/dev-tools/ansible/roles/kafka/defaults/main.yml
@@ -1,0 +1,48 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+---
+
+#Variables associated with this role
+
+scala_version: "2.11" #recommended scala version
+kafka_version: "1.1.0"
+kafka_package_name: "kafka_{{ scala_version }}-{{ kafka_version }}"
+kafka_tgz_url: "http://www-eu.apache.org/dist/kafka/{{ kafka_version }}/{{ kafka_package_name }}.tgz"
+kafka_dir: "{{ user_home }}/{{ kafka_package_name }}"
+
+# Kafka related variables
+broker_id: "0"
+network_threads_count: "3"
+io_threads_count: "8"
+socket_send_buf_bytes: "102400"
+socket_receive_buf_bytes: "102400"
+socket_request_max_bytes: "104857600"
+num_partitions: "1"
+num_recovery_threads: "1"
+offsets_topic_replication_fac: "1"
+trans_state_log_replication_fac: "1"
+trans_state_log: "1"
+log_retention_hrs: "168"
+log_segment_bytes: "1073741824"
+log_retention_check_interval: "300000"
+grp_initial_rebalance_delay: "0"
+
+...

--- a/dev-tools/ansible/roles/kafka/handlers/main.yml
+++ b/dev-tools/ansible/roles/kafka/handlers/main.yml
@@ -1,0 +1,30 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+---
+# Kafka related handlers
+- name: start kafka
+  service: name=kafka state=started enabled=yes
+
+- name: stop kafka
+  service: name=kafka state=stopped enabled=yes
+
+- name: restart kafka
+  service: name=kafka state=restarted enabled=yes

--- a/dev-tools/ansible/roles/kafka/tasks/main.yml
+++ b/dev-tools/ansible/roles/kafka/tasks/main.yml
@@ -1,0 +1,70 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+---
+
+# Create the directory
+- name: Create directory
+  file: path="{{ user_home }}" state=directory owner={{ user }} group={{ group }}
+
+# Check for the availability of the Kafka package
+- name: Check kafka package availability
+  stat: path={{ kafka_dir }}
+  register: kafka_package
+
+# Download Kafka
+- name: Download and unarchive Kafka
+  unarchive: src="{{ kafka_tgz_url }}"
+      dest="{{ user_home }}"
+      copy=no
+      owner="{{ user }}"
+      group="{{ group }}"
+  when: not kafka_package.stat.exists
+  become: yes
+
+# Create kafka logs directory
+- name: Create kafka logs directory
+  file: path="{{ kafka_dir }}/logs" state=directory owner={{ user }} group={{ group }}
+
+# Config and start Kafka
+- name: Copy kafka server properties file
+  template: src=server.properties.j2
+            dest="{{ kafka_dir }}/config/server.properties"
+            owner={{ user }}
+            group={{ group }}
+            mode="u=rw,g=r,o=r"
+  notify: restart kafka
+  become: yes
+
+- name: systemd start script
+  template: src=kafka.service.j2
+            dest=/usr/lib/systemd/system/kafka.service
+            owner={{ user }}
+            group={{ group }}
+            mode="u=rw,g=r,o=r"
+  notify: start kafka
+  become: yes
+
+- name: Reload systemd daemons
+  command: systemctl daemon-reload
+  notify: restart kafka
+  become: yes
+
+...

--- a/dev-tools/ansible/roles/kafka/templates/kafka.service.j2
+++ b/dev-tools/ansible/roles/kafka/templates/kafka.service.j2
@@ -1,0 +1,14 @@
+# {{ansible_managed}}
+
+[Unit]
+Description=Kafka
+Before=
+After=network.target
+
+[Service]
+LOG_DIR={{ kafka_dir }}/logs
+ExecStart={{ kafka_dir }}/bin/kafka-server-start.sh {{ kafka_dir }}/config/server.properties
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target

--- a/dev-tools/ansible/roles/kafka/templates/server.properties.j2
+++ b/dev-tools/ansible/roles/kafka/templates/server.properties.j2
@@ -1,0 +1,139 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+############################# Server Basics #############################
+
+# The id of the broker. This must be set to a unique integer for each broker.
+broker.id={{ broker_id }}
+
+############################# Socket Server Settings #############################
+
+# The address the socket server listens on. It will get the value returned from
+# java.net.InetAddress.getCanonicalHostName() if not configured.
+#   FORMAT:
+#     listeners = listener_name://host_name:port
+#   EXAMPLE:
+#     listeners = PLAINTEXT://your.host.name:9092
+#listeners=PLAINTEXT://your.host.name:9092
+
+# Hostname and port the broker will advertise to producers and consumers. If not set,
+# it uses the value for "listeners" if configured.  Otherwise, it will use the value
+# returned from java.net.InetAddress.getCanonicalHostName().
+#advertised.listeners=PLAINTEXT://your.host.name:9092
+
+# Maps listener names to security protocols, the default is for them to be the same. See the config documentation for more details
+#listener.security.protocol.map=PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
+
+# The number of threads that the server uses for receiving requests from the network and sending responses to the network
+num.network.threads={{ network_threads_count }}
+
+# The number of threads that the server uses for processing requests, which may include disk I/O
+num.io.threads={{ io_threads_count }}
+
+# The send buffer (SO_SNDBUF) used by the socket server
+socket.send.buffer.bytes={{ socket_send_buf_bytes }}
+
+# The receive buffer (SO_RCVBUF) used by the socket server
+socket.receive.buffer.bytes={{ socket_receive_buf_bytes }}
+
+# The maximum size of a request that the socket server will accept (protection against OOM)
+socket.request.max.bytes={{ socket_request_max_bytes }}
+
+
+############################# Log Basics #############################
+
+# A comma separated list of directories under which to store log files
+log.dirs={{ kafka_dir }}/logs
+
+# The default number of log partitions per topic. More partitions allow greater
+# parallelism for consumption, but this will also result in more files across
+# the brokers.
+num.partitions={{ num_partitions }}
+
+# The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
+# This value is recommended to be increased for installations with data dirs located in RAID array.
+num.recovery.threads.per.data.dir={{ num_recovery_threads }}
+
+############################# Internal Topic Settings  #############################
+# The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"
+# For anything other than development testing, a value greater than 1 is recommended for to ensure availability such as 3.
+offsets.topic.replication.factor={{ offsets_topic_replication_fac }}
+transaction.state.log.replication.factor={{ trans_state_log_replication_fac }}
+transaction.state.log.min.isr={{ trans_state_log }}
+
+############################# Log Flush Policy #############################
+
+# Messages are immediately written to the filesystem but by default we only fsync() to sync
+# the OS cache lazily. The following configurations control the flush of data to disk.
+# There are a few important trade-offs here:
+#    1. Durability: Unflushed data may be lost if you are not using replication.
+#    2. Latency: Very large flush intervals may lead to latency spikes when the flush does occur as there will be a lot of data to flush.
+#    3. Throughput: The flush is generally the most expensive operation, and a small flush interval may lead to excessive seeks.
+# The settings below allow one to configure the flush policy to flush data after a period of time or
+# every N messages (or both). This can be done globally and overridden on a per-topic basis.
+
+# The number of messages to accept before forcing a flush of data to disk
+#log.flush.interval.messages=10000
+
+# The maximum amount of time a message can sit in a log before we force a flush
+#log.flush.interval.ms=1000
+
+############################# Log Retention Policy #############################
+
+# The following configurations control the disposal of log segments. The policy can
+# be set to delete segments after a period of time, or after a given size has accumulated.
+# A segment will be deleted whenever *either* of these criteria are met. Deletion always happens
+# from the end of the log.
+
+# The minimum age of a log file to be eligible for deletion due to age
+log.retention.hours={{ log_retention_hrs }}
+
+# A size-based retention policy for logs. Segments are pruned from the log unless the remaining
+# segments drop below log.retention.bytes. Functions independently of log.retention.hours.
+#log.retention.bytes=1073741824
+
+# The maximum size of a log segment file. When this size is reached a new log segment will be created.
+log.segment.bytes={{ log_segment_bytes }}
+
+# The interval at which log segments are checked to see if they can be deleted according
+# to the retention policies
+log.retention.check.interval.ms={{ log_retention_check_interval }}
+
+############################# Zookeeper #############################
+
+# Zookeeper connection string (see zookeeper docs for details).
+# This is a comma separated host:port pairs, each corresponding to a zk
+# server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
+# You can also append an optional chroot string to the urls to specify the
+# root directory for all kafka znodes.
+zookeeper.connect={{ zookeeper_url }}
+
+# Timeout in ms for connecting to zookeeper
+zookeeper.connection.timeout.ms=6000
+
+
+############################# Group Coordinator Settings #############################
+
+# The following configuration specifies the time, in milliseconds, that the GroupCoordinator will delay the initial consumer rebalance.
+# The rebalance will be further delayed by the value of group.initial.rebalance.delay.ms as new members join the group, up to a maximum of max.poll.interval.ms.
+# The default value for this is 3 seconds.
+# We override this to 0 here as it makes for a better out-of-the-box experience for development and testing.
+# However, in production environments the default value of 3 seconds is more suitable as this will help to avoid unnecessary, and potentially expensive, rebalances during application startup.
+group.initial.rebalance.delay.ms={{ grp_initial_rebalance_delay }}


### PR DESCRIPTION
Mainly two roles,
- kafka role
- helix_setup role

helix_setup role with the following functionalities,
- create Helix deployment directory
- download & unarchive Helix
- create a cluster
- copy distributions to helix deployment directory. Distributions of
        Helix Controller, Helix Participant, Pre Work flow Manager, Post Work flow Manager, Email Monitor, & Realtime Monitor
- copy airavata server property files, logback configuration files, & configuration files
- stop the daemons
- start all the 6 daemons