### PR TITLE
Change Date.getTime() to System.currentTimeMillis()

### DIFF
--- a/modules/credential-store/credential-store-service/src/main/java/org/apache/airavata/credential/store/store/impl/db/CredentialsDAO.java
+++ b/modules/credential-store/credential-store-service/src/main/java/org/apache/airavata/credential/store/store/impl/db/CredentialsDAO.java
@@ -100,8 +100,7 @@ public class CredentialsDAO extends ParentDAO {
 
             preparedStatement.setString(4, credential.getPortalUserName());
 
-            java.util.Date date = new java.util.Date();
-            Timestamp timestamp = new Timestamp(date.getTime());
+            Timestamp timestamp = new Timestamp(System.currentTimeMillis());
 
             preparedStatement.setTimestamp(5, timestamp);
 


### PR DESCRIPTION
Hello,

new Date() is a wrapper of method System.currentTimeMillis(). If it is intensively invoked in the program, the performance will be greatly damaged.  
According to my local testing, when these two methods are invoked 5,000,000 times at the same environment, System.currentTimeMillis() can achieve a speedup to 5 times (435 ms vs 2073 ms). 
Therefore, if only getTime() is used for Date object, the light method System.currentTimeMillis() is highly recommended, which can also avoid creating the temporary Date object.