### PR TITLE
Improvement for Jira 1870 - provide ability to search experiments by jobId in the experiment statistics tab under admin dashboard

### DIFF
--- a/airavata-api/airavata-client-sdks/airavata-php-sdk/src/main/resources/lib/Airavata/Model/Experiment/Types.php
+++ b/airavata-api/airavata-client-sdks/airavata-php-sdk/src/main/resources/lib/Airavata/Model/Experiment/Types.php
@@ -34,6 +34,8 @@ final class ExperimentSearchFields {
   const TO_DATE = 4;
   const STATUS = 5;
   const PROJECT_ID = 6;
+  const USER_NAME = 7;
+  const JOB_ID = 8;
   static public $__names = array(
     0 => 'EXPERIMENT_NAME',
     1 => 'EXPERIMENT_DESC',
@@ -42,6 +44,8 @@ final class ExperimentSearchFields {
     4 => 'TO_DATE',
     5 => 'STATUS',
     6 => 'PROJECT_ID',
+    7 => 'USER_NAME',
+    8 => 'JOB_ID',
   );
 }
 

--- a/airavata-api/airavata-client-sdks/airavata-python-sdk/src/main/resources/lib/airavata/model/experiment/ttypes.py
+++ b/airavata-api/airavata-client-sdks/airavata-python-sdk/src/main/resources/lib/airavata/model/experiment/ttypes.py
@@ -43,6 +43,7 @@ class ExperimentSearchFields(object):
     STATUS = 5
     PROJECT_ID = 6
     USER_NAME = 7
+    JOB_ID = 8
 
     _VALUES_TO_NAMES = {
         0: "EXPERIMENT_NAME",
@@ -53,6 +54,7 @@ class ExperimentSearchFields(object):
         5: "STATUS",
         6: "PROJECT_ID",
         7: "USER_NAME",
+        8: "JOB_ID",
     }
 
     _NAMES_TO_VALUES = {
@@ -64,6 +66,7 @@ class ExperimentSearchFields(object):
         "STATUS": 5,
         "PROJECT_ID": 6,
         "USER_NAME": 7,
+        "JOB_ID": 8,
     }
 
 

--- a/airavata-api/airavata-data-models/src/main/java/org/apache/airavata/model/experiment/ExperimentSearchFields.java
+++ b/airavata-api/airavata-data-models/src/main/java/org/apache/airavata/model/experiment/ExperimentSearchFields.java
@@ -36,7 +36,8 @@ public enum ExperimentSearchFields implements org.apache.thrift.TEnum {
   TO_DATE(4),
   STATUS(5),
   PROJECT_ID(6),
-  USER_NAME(7);
+  USER_NAME(7),
+  JOB_ID(8);
 
   private final int value;
 
@@ -73,6 +74,8 @@ public enum ExperimentSearchFields implements org.apache.thrift.TEnum {
         return PROJECT_ID;
       case 7:
         return USER_NAME;
+      case 8:
+        return JOB_ID;
       default:
         return null;
     }

--- a/modules/ide-integration/src/main/resources/pga/airavata-php-gateway/app/controllers/ExperimentController.php
+++ b/modules/ide-integration/src/main/resources/pga/airavata-php-gateway/app/controllers/ExperimentController.php
@@ -142,7 +142,7 @@ class ExperimentController extends BaseController
                     $pageNo);
             } catch (AuthorizationException $ae) {
 
-                Log::error("Experiment wasn't found", array("message" => $enf->getMessage(), "username" => Session::get("username"), "gateway_id" => Session::get("gateway_id")));
+                Log::error("User isn't authorized to see experiment", array("message" => $ae->getMessage(), "username" => Session::get("username"), "gateway_id" => Session::get("gateway_id")));
                 return $this->makeInvalidExperimentView();
             } catch (ExperimentNotFoundException $enf) {
 

--- a/modules/ide-integration/src/main/resources/pga/airavata-php-gateway/app/libraries/Airavata/Model/Experiment/Types.php
+++ b/modules/ide-integration/src/main/resources/pga/airavata-php-gateway/app/libraries/Airavata/Model/Experiment/Types.php
@@ -34,6 +34,8 @@ final class ExperimentSearchFields {
   const TO_DATE = 4;
   const STATUS = 5;
   const PROJECT_ID = 6;
+  const USER_NAME = 7;
+  const JOB_ID = 8;
   static public $__names = array(
     0 => 'EXPERIMENT_NAME',
     1 => 'EXPERIMENT_DESC',
@@ -42,6 +44,8 @@ final class ExperimentSearchFields {
     4 => 'TO_DATE',
     5 => 'STATUS',
     6 => 'PROJECT_ID',
+    7 => 'USER_NAME',
+    8 => 'JOB_ID',
   );
 }
 
@@ -464,6 +468,10 @@ class ExperimentModel {
    * @var \Airavata\Model\Process\ProcessModel[]
    */
   public $processes = null;
+  /**
+   * @var \Airavata\Model\Workflow\AiravataWorkflow
+   */
+  public $workflow = null;
 
   public function __construct($vals=null) {
     if (!isset(self::$_TSPEC)) {
@@ -574,6 +582,11 @@ class ExperimentModel {
             'class' => '\Airavata\Model\Process\ProcessModel',
             ),
           ),
+        20 => array(
+          'var' => 'workflow',
+          'type' => TType::STRUCT,
+          'class' => '\Airavata\Model\Workflow\AiravataWorkflow',
+          ),
         );
     }
     if (is_array($vals)) {
@@ -633,6 +646,9 @@ class ExperimentModel {
       }
       if (isset($vals['processes'])) {
         $this->processes = $vals['processes'];
+      }
+      if (isset($vals['workflow'])) {
+        $this->workflow = $vals['workflow'];
       }
     }
   }
@@ -855,6 +871,14 @@ class ExperimentModel {
             $xfer += $input->skip($ftype);
           }
           break;
+        case 20:
+          if ($ftype == TType::STRUCT) {
+            $this->workflow = new \Airavata\Model\Workflow\AiravataWorkflow();
+            $xfer += $this->workflow->read($input);
+          } else {
+            $xfer += $input->skip($ftype);
+          }
+          break;
         default:
           $xfer += $input->skip($ftype);
           break;
@@ -1036,6 +1060,14 @@ class ExperimentModel {
         }
         $output->writeListEnd();
       }
+      $xfer += $output->writeFieldEnd();
+    }
+    if ($this->workflow !== null) {
+      if (!is_object($this->workflow)) {
+        throw new TProtocolException('Bad type in structure.', TProtocolException::INVALID_DATA);
+      }
+      $xfer += $output->writeFieldBegin('workflow', TType::STRUCT, 20);
+      $xfer += $this->workflow->write($output);
       $xfer += $output->writeFieldEnd();
     }
     $xfer += $output->writeFieldStop();

--- a/modules/ide-integration/src/main/resources/pga/airavata-php-gateway/app/libraries/ExperimentUtilities.php
+++ b/modules/ide-integration/src/main/resources/pga/airavata-php-gateway/app/libraries/ExperimentUtilities.php
@@ -243,6 +243,30 @@ class ExperimentUtilities
 
     }
 
+        public static function get_experimentId_by_jobId($jobId)
+    {
+        try {
+                return Airavata::getExperimentByJobID(Session::get('authz-token'), $jobId);
+                        
+        } catch (InvalidRequestException $ire) {
+            CommonUtilities::print_error_message('<p>InvalidRequestException: ' . $ire->getMessage() . '</p>');
+        } catch (ExperimentNotFoundException $enf) {
+            throw $enf; // rethrow
+        } catch (AuthorizationException $ae) {
+            throw $ae; // rethrow
+        } catch (AiravataClientException $ace) {
+            CommonUtilities::print_error_message('AiravataClientException: ' . $ace->getMessage() . '</p>');
+        } catch (AiravataSystemException $ase) {
+            CommonUtilities::print_error_message('AiravataSystemException: ' . $ase->getMessage() . '</p>');
+        } catch (TTransportException $tte) {
+            CommonUtilities::print_error_message('TTransportException: ' . $tte->getMessage() . '</p>');
+        } catch (Exception $e) {
+            CommonUtilities::print_error_message('Exception: ' . $e->getMessage() . '</p>');
+        }
+
+    }
+
+
     /**
      * Get the detailed tree of an experiment with the given ID
      * @param $expId
@@ -1206,7 +1230,7 @@ class ExperimentUtilities
      * @return array|null
      */
     public static function get_expsearch_results_with_pagination($inputs, $limit, $offset)
-    {
+    {   print_r("Search experiments called");
         $experiments = array();
 
         try {
@@ -1235,9 +1259,14 @@ class ExperimentUtilities
                         $filters[\Airavata\Model\Experiment\ExperimentSearchFields::FROM_DATE] = strtotime( $addOrSubtract . " " . Session::get("user_timezone") . " hours", strtotime($inputs["from-date"]) ) * 1000;
                         $filters[\Airavata\Model\Experiment\ExperimentSearchFields::TO_DATE] = strtotime( $addOrSubtract . " " . Session::get("user_timezone") . " hours", strtotime($inputs["to-date"]) ) * 1000;
                         break;
+                    case 'jobId':
+                        Log::info(print_r($inputs, True));
+                        $filters[\Airavata\Model\Experiment\ExperimentSearchFields::JOB_ID] = $inputs["search-value"];
+                        break;
                     case '':
                 }
             }
+            Log::info(print_r($filters, True));
             $experiments = Airavata::searchExperiments(Session::get('authz-token'),
                 Session::get('gateway_id'), Session::get('username'), $filters, $limit, $offset);
         } catch (InvalidRequestException $ire) {

--- a/modules/ide-integration/src/main/resources/pga/airavata-php-gateway/app/libraries/ExperimentUtilities.php
+++ b/modules/ide-integration/src/main/resources/pga/airavata-php-gateway/app/libraries/ExperimentUtilities.php
@@ -243,30 +243,6 @@ class ExperimentUtilities
 
     }
 
-        public static function get_experimentId_by_jobId($jobId)
-    {
-        try {
-                return Airavata::getExperimentByJobID(Session::get('authz-token'), $jobId);
-                        
-        } catch (InvalidRequestException $ire) {
-            CommonUtilities::print_error_message('<p>InvalidRequestException: ' . $ire->getMessage() . '</p>');
-        } catch (ExperimentNotFoundException $enf) {
-            throw $enf; // rethrow
-        } catch (AuthorizationException $ae) {
-            throw $ae; // rethrow
-        } catch (AiravataClientException $ace) {
-            CommonUtilities::print_error_message('AiravataClientException: ' . $ace->getMessage() . '</p>');
-        } catch (AiravataSystemException $ase) {
-            CommonUtilities::print_error_message('AiravataSystemException: ' . $ase->getMessage() . '</p>');
-        } catch (TTransportException $tte) {
-            CommonUtilities::print_error_message('TTransportException: ' . $tte->getMessage() . '</p>');
-        } catch (Exception $e) {
-            CommonUtilities::print_error_message('Exception: ' . $e->getMessage() . '</p>');
-        }
-
-    }
-
-
     /**
      * Get the detailed tree of an experiment with the given ID
      * @param $expId
@@ -1230,7 +1206,7 @@ class ExperimentUtilities
      * @return array|null
      */
     public static function get_expsearch_results_with_pagination($inputs, $limit, $offset)
-    {   print_r("Search experiments called");
+    {
         $experiments = array();
 
         try {
@@ -1260,13 +1236,11 @@ class ExperimentUtilities
                         $filters[\Airavata\Model\Experiment\ExperimentSearchFields::TO_DATE] = strtotime( $addOrSubtract . " " . Session::get("user_timezone") . " hours", strtotime($inputs["to-date"]) ) * 1000;
                         break;
                     case 'jobId':
-                        Log::info(print_r($inputs, True));
                         $filters[\Airavata\Model\Experiment\ExperimentSearchFields::JOB_ID] = $inputs["search-value"];
                         break;
                     case '':
                 }
             }
-            Log::info(print_r($filters, True));
             $experiments = Airavata::searchExperiments(Session::get('authz-token'),
                 Session::get('gateway_id'), Session::get('username'), $filters, $limit, $offset);
         } catch (InvalidRequestException $ire) {

--- a/modules/ide-integration/src/main/resources/pga/airavata-php-gateway/app/routes.php
+++ b/modules/ide-integration/src/main/resources/pga/airavata-php-gateway/app/routes.php
@@ -322,7 +322,12 @@ Route::get("admin/dashboard/experimentStatistics", "AdminController@experimentSt
 Route::get("admin/dashboard/resources", "AdminController@resourcesView");
 
 Route::get("admin/dashboard/experiment/summary", function () {
-    return Redirect::to("experiment/summary?expId=" . urlencode($_GET["expId"]) . "&dashboard=true");
+    if(isset($_GET['jobId'])) {
+        return Redirect::to("experiment/summary?jobId=" . urlencode($_GET["jobId"]) . "&dashboard=true");
+    }
+    else {
+        return Redirect::to("experiment/summary?expId=" . urlencode($_GET["expId"]) . "&dashboard=true");
+    }
 });
 
 Route::get("admin/dashboard/credential-store", "AdminController@credentialStoreView");

--- a/modules/ide-integration/src/main/resources/pga/airavata-php-gateway/app/views/admin/manage-experiments.blade.php
+++ b/modules/ide-integration/src/main/resources/pga/airavata-php-gateway/app/views/admin/manage-experiments.blade.php
@@ -449,12 +449,12 @@ to be uncommented when actually in use.
     });
 
     $(".get-experiment").click(function () {
+        // check whether user wants to search by expId or jobId
         var getExpByJobID = $(".get-experiment-by-jobid").prop("checked");
-        alert(getExpByJobID);
         if(getExpByJobID == false){
             var jobId = $(".experimentId").val();
             var expHTMLId = util.sanitizeHTMLId(jobId);
-            alert("Searching by JobId: " + jobId);
+
             if( $("#" + expHTMLId).length <= 0){
                 $(".loading-img").removeClass("hide");
                 $.ajax({
@@ -482,8 +482,6 @@ to be uncommented when actually in use.
             }
         }
         else{
-            alert("Searching by ExpID");
-
             var expId = $(".experimentId").val();
             var expHTMLId = util.sanitizeHTMLId(expId);
             if( $("#" + expHTMLId).length <= 0){

--- a/modules/ide-integration/src/main/resources/pga/airavata-php-gateway/app/views/admin/manage-experiments.blade.php
+++ b/modules/ide-integration/src/main/resources/pga/airavata-php-gateway/app/views/admin/manage-experiments.blade.php
@@ -2,6 +2,7 @@
 
 @section('page-header')
 @parent
+{{ HTML::style('css/bootstrap-toggle.css')}}
 {{ HTML::style('css/admin.css')}}
 {{ HTML::style('css/datetimepicker.css')}}
 @stop
@@ -18,14 +19,18 @@
 <div class="container-fluid">
 
     <div class="well form-group form-horizontal col-md-12">
-        <label class="col-md-3">Enter Experiment Id to View Summary :</label>
-
-        <div class="col-md-6">
-            <input type="text" class="form-control experimentId"/>
+        <div class="col-md-9">
+            <label class="col-md-3">Enter Id to View Summary :</label>
+            <input unchecked class="col-md-3 get-experiment-by-jobid" type="checkbox" data-toggle="toggle" data-on="Experiment ID" data-off="Job ID" data-onstyle="success" data-offstyle="danger">
+            <div class="col-md-6">
+                <input type="text" class="form-control experimentId"/>
+            </div>
         </div>
-        <button class="col-md-3 btn btn-primary get-experiment" disabled="disabled">Get</button>
-        <div class="loading-img hide text-center"><img src="{{URL::to('/')}}/assets/ajax-loader.gif"/></div>
-
+        <div class="col-md-3">
+            <button class="col-md-12 btn btn-primary get-experiment" disabled="disabled">Get</button>
+            <div class="loading-img hide text-center">
+                <img src="{{URL::to('/')}}/assets/ajax-loader.gif"/>
+            </div>
         </div>
     </div>
 
@@ -384,6 +389,7 @@
 
 @section('scripts')
 @parent
+{{ HTML::script('js/bootstrap-toggle.js')}}
 {{ HTML::script('js/gateway.js') }}
 {{ HTML::script('js/moment.js')}}
 {{ HTML::script('js/datetimepicker-3.1.3.js')}}
@@ -409,6 +415,9 @@ to be uncommented when actually in use.
 {{ HTML::script('js/util.js')}}
 <script>
 
+    // instantiate bootstrap jobId toggle button to search by Experiment
+    $(".get-experiment-by-jobid").bootstrapToggle('on');
+
     //make first tab of accordion open by default.
     //temporary fix
     $("#accordion2").children(".panel").children(".collapse").addClass("in");
@@ -431,6 +440,7 @@ to be uncommented when actually in use.
         e.stopPropagation();
     });
 
+    //when key is pressed in experimentId enable get button
     $(".experimentId").keyup( function(){
         if( $.trim( $(this).val()) == "")
             $(".get-experiment").attr("disabled", "disabled");
@@ -439,33 +449,68 @@ to be uncommented when actually in use.
     });
 
     $(".get-experiment").click(function () {
+        var getExpByJobID = $(".get-experiment-by-jobid").prop("checked");
+        alert(getExpByJobID);
+        if(getExpByJobID == false){
+            var jobId = $(".experimentId").val();
+            var expHTMLId = util.sanitizeHTMLId(jobId);
+            alert("Searching by JobId: " + jobId);
+            if( $("#" + expHTMLId).length <= 0){
+                $(".loading-img").removeClass("hide");
+                $.ajax({
+                    url: 'experiment/summary?jobId=' + encodeURIComponent(jobId),
+                    type: 'get',
+                    success: function (data) {
+                        $("#myTabs").append('<li role="presentation"><a href="#' + expHTMLId + '" aria-controls="' + expHTMLId + '" role="tab" data-toggle="tab"><span class="expid-label"></span><button type="button" style="margin-left:10px;" class="close pull-right close-tab" aria-label="Close"><span aria-hidden="true">&times;</span></button></a></li>');
+                        // Set expId with .text() so it gets properly escaped
+                        $('#myTabs a[href="#' + expHTMLId + '"] .expid-label').text(jobId);
+                        $(".tab-content").append('<div role="tabpanel" class="tab-pane" id="' + expHTMLId + '"></div>');
+                        $(".tab-content #" + expHTMLId).html(data);
+                        $('#myTabs a[href="#' + expHTMLId + '"]').tab('show'); // Select tab by name
 
-        var expId = $(".experimentId").val();
-        var expHTMLId = util.sanitizeHTMLId(expId);
-        if( $("#" + expHTMLId).length <= 0){
-            $(".loading-img").removeClass("hide");
-            $.ajax({
-                url: 'experiment/summary?expId=' + encodeURIComponent(expId),
-                type: 'get',
-                success: function (data) {
-                    $("#myTabs").append('<li role="presentation"><a href="#' + expHTMLId + '" aria-controls="' + expHTMLId + '" role="tab" data-toggle="tab"><span class="expid-label"></span><button type="button" style="margin-left:10px;" class="close pull-right close-tab" aria-label="Close"><span aria-hidden="true">&times;</span></button></a></li>');
-                    // Set expId with .text() so it gets properly escaped
-                    $('#myTabs a[href="#' + expHTMLId + '"] .expid-label').text(expId);
-                    $(".tab-content").append('<div role="tabpanel" class="tab-pane" id="' + expHTMLId + '"></div>');
-                    $(".tab-content #" + expHTMLId).html(data);
-                    $('#myTabs a[href="#' + expHTMLId + '"]').tab('show'); // Select tab by name
+                        //$('#myTabs a[href="#expsummary"]').tab('show') // Select tab by name
 
-                    //$('#myTabs a[href="#expsummary"]').tab('show') // Select tab by name
+                        //from time-conversion.js
+                        updateTime();
+                    }
+                }).complete(function () {
+                    $(".loading-img").addClass("hide");
+                });
+            } else {
+                // Experiment data already loaded so just show it
+                $('#myTabs a[href="#' + expHTMLId + '"]').tab('show');
+            }
+        }
+        else{
+            alert("Searching by ExpID");
 
-                    //from time-conversion.js
-                    updateTime();
-                }
-            }).complete(function () {
-                $(".loading-img").addClass("hide");
-            });
-        } else {
-            // Experiment data already loaded so just show it
-            $('#myTabs a[href="#' + expHTMLId + '"]').tab('show');
+            var expId = $(".experimentId").val();
+            var expHTMLId = util.sanitizeHTMLId(expId);
+            if( $("#" + expHTMLId).length <= 0){
+                $(".loading-img").removeClass("hide");
+                $.ajax({
+                    url: 'experiment/summary?expId=' + encodeURIComponent(expId),
+                    type: 'get',
+                    success: function (data) {
+                        $("#myTabs").append('<li role="presentation"><a href="#' + expHTMLId + '" aria-controls="' + expHTMLId + '" role="tab" data-toggle="tab"><span class="expid-label"></span><button type="button" style="margin-left:10px;" class="close pull-right close-tab" aria-label="Close"><span aria-hidden="true">&times;</span></button></a></li>');
+                        // Set expId with .text() so it gets properly escaped
+                        $('#myTabs a[href="#' + expHTMLId + '"] .expid-label').text(expId);
+                        $(".tab-content").append('<div role="tabpanel" class="tab-pane" id="' + expHTMLId + '"></div>');
+                        $(".tab-content #" + expHTMLId).html(data);
+                        $('#myTabs a[href="#' + expHTMLId + '"]').tab('show'); // Select tab by name
+
+                        //$('#myTabs a[href="#expsummary"]').tab('show') // Select tab by name
+
+                        //from time-conversion.js
+                        updateTime();
+                    }
+                }).complete(function () {
+                    $(".loading-img").addClass("hide");
+                });
+            } else {
+                // Experiment data already loaded so just show it
+                $('#myTabs a[href="#' + expHTMLId + '"]').tab('show');
+            }
         }
     });
 

--- a/modules/registry/registry-core/src/main/java/org/apache/airavata/registry/core/repositories/expcatalog/ExperimentSummaryRepository.java
+++ b/modules/registry/registry-core/src/main/java/org/apache/airavata/registry/core/repositories/expcatalog/ExperimentSummaryRepository.java
@@ -24,9 +24,14 @@ import org.apache.airavata.model.experiment.ExperimentStatistics;
 import org.apache.airavata.model.experiment.ExperimentSummaryModel;
 import org.apache.airavata.model.status.ExperimentState;
 import org.apache.airavata.registry.core.entities.expcatalog.ExperimentSummaryEntity;
+import org.apache.airavata.registry.core.entities.expcatalog.JobEntity;
+import org.apache.airavata.registry.core.entities.expcatalog.ProcessEntity;
+import org.apache.airavata.registry.core.entities.expcatalog.TaskEntity;
 import org.apache.airavata.registry.core.utils.DBConstants;
 import org.apache.airavata.registry.cpi.RegistryException;
 import org.apache.airavata.registry.cpi.ResultOrderType;
+import org.apache.airavata.registry.cpi.utils.Constants;
+import org.apache.derby.vti.Restriction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +54,17 @@ public class ExperimentSummaryRepository extends ExpCatAbstractRepository<Experi
         if (filters == null || !filters.containsKey(DBConstants.Experiment.GATEWAY_ID)) {
             logger.error("GatewayId is required");
             throw new RegistryException("GatewayId is required");
+        }
+
+        if (filters.get(DBConstants.Job.JOB_ID) != null) {
+            logger.debug("Filter Experiments by JobId");
+            queryParameters.put(DBConstants.Job.JOB_ID, filters.get(DBConstants.Job.JOB_ID));
+            String query_jobId = "SELECT P.experimentId FROM "
+                    + JobEntity.class.getSimpleName() + " J "
+                    + " JOIN J.task T"
+                    + " JOIN T.process P"
+                    + " WHERE J.jobId = : " + DBConstants.Job.JOB_ID;
+            query += "ES.experimentId IN  ( "+ query_jobId + " ) AND ";
         }
 
         if (filters.get(DBConstants.Experiment.USER_NAME) != null) {

--- a/modules/registry/registry-core/src/main/java/org/apache/airavata/registry/core/utils/DBConstants.java
+++ b/modules/registry/registry-core/src/main/java/org/apache/airavata/registry/core/utils/DBConstants.java
@@ -136,6 +136,7 @@ public class DBConstants {
     public static class Job {
         public static final String PROCESS_ID = "processId";
         public static final String TASK_ID = "taskId";
+        public static final String JOB_ID = "jobId";
     }
 
     public static class ExperimentSummary {

--- a/modules/registry/registry-server/registry-api-service/src/main/java/org/apache/airavata/registry/api/service/handler/RegistryServerHandler.java
+++ b/modules/registry/registry-server/registry-api-service/src/main/java/org/apache/airavata/registry/api/service/handler/RegistryServerHandler.java
@@ -3788,6 +3788,8 @@ public class RegistryServerHandler implements RegistryService.Iface {
                     regFilters.put(Constants.FieldConstants.ExperimentConstants.PROJECT_ID, entry.getValue());
                 } else if (entry.getKey().equals(ExperimentSearchFields.USER_NAME)){
                     regFilters.put(Constants.FieldConstants.ExperimentConstants.USER_NAME, entry.getValue());
+                } else if (entry.getKey().equals(ExperimentSearchFields.JOB_ID)){
+                    regFilters.put(Constants.FieldConstants.JobConstants.JOB_ID, entry.getValue());
                 }
             }
 

--- a/pom.xml
+++ b/pom.xml
@@ -594,7 +594,7 @@
                     </plugin>
 		    <plugin>
 		       <groupId>org.apache.maven.plugins</groupId>
-		       <artificatId>maven-jar-plugins</artificatId>
+		       <artifactId>maven-jar-plugins</artifactId>
 		       <version>$(openjpa.version)</version>
 		    </plugin>
 		    

--- a/thrift-interface-descriptions/data-models/experiment-catalog-models/experiment_model.thrift
+++ b/thrift-interface-descriptions/data-models/experiment-catalog-models/experiment_model.thrift
@@ -44,6 +44,7 @@ enum ExperimentSearchFields {
     STATUS,
     PROJECT_ID,
     USER_NAME,
+    JOB_ID,
 }
 
 enum ProjectSearchFields {


### PR DESCRIPTION
I have added functionality in the PGA to search experiments using the jobId. It uses an existing API function searchExperiment() to first search the experiments using a new field 'JobId'. This new field is added to the experiment_model.thrift file.
After searching the corresponding experimentid using jobid, the normal flow of information follows i.e, the experiment Id is used to search a detailed view of the experiment and then presented to the user. 

The below screenshot displays the functionality. 

![image](https://user-images.githubusercontent.com/5948157/58507598-12935600-8160-11e9-8666-09a28ab0e4ad.png)
