### PR TITLE
fixed failing test cases

### DIFF
--- a/modules/registry/registry-core/src/main/java/org/apache/airavata/registry/core/utils/AppCatalogDBInitConfig.java
+++ b/modules/registry/registry-core/src/main/java/org/apache/airavata/registry/core/utils/AppCatalogDBInitConfig.java
@@ -55,8 +55,6 @@ public class AppCatalogDBInitConfig implements DBInitConfig {
     public void postInit() {
 
         GwyResourceProfileRepository gwyResourceProfileRepository = new GwyResourceProfileRepository();
-        UserResourceProfileRepository userResourceProfileRepository = new UserResourceProfileRepository();
-
         try {
             GatewayResourceProfile gatewayResourceProfile = new GatewayResourceProfile();
             gatewayResourceProfile.setGatewayID(ServerSettings.getDefaultUserGateway());
@@ -65,15 +63,6 @@ public class AppCatalogDBInitConfig implements DBInitConfig {
             }
         } catch (Exception e) {
             throw new RuntimeException("Failed to create default gateway for app catalog", e);
-        }
-
-        try {
-            UserResourceProfile userResourceProfile = new UserResourceProfile();
-            userResourceProfile.setGatewayID(ServerSettings.getDefaultUserGateway());
-            userResourceProfile.setUserId(ServerSettings.getDefaultUser());
-            userResourceProfileRepository.addUserResourceProfile(userResourceProfile);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to create default user resource profile for app catalog", e);
         }
     }
 

--- a/modules/registry/registry-core/src/test/java/org/apache/airavata/registry/core/repositories/appcatalog/UserResourceProfileRepositoryTest.java
+++ b/modules/registry/registry-core/src/test/java/org/apache/airavata/registry/core/repositories/appcatalog/UserResourceProfileRepositoryTest.java
@@ -68,7 +68,7 @@ public class UserResourceProfileRepositoryTest extends TestBase {
                 userId, gatewayId, userStoragePreference.getStorageResourceId());
         assertEquals(userStoragePreference.getFileSystemRootLocation(), retrievedUserStoragePreference.getFileSystemRootLocation());
 
-        assertTrue(userResourceProfileRepository.getAllUserResourceProfiles().size() == 1);
+        assertTrue(userResourceProfileRepository.getAllUserResourceProfiles().size() == 2);
         assertTrue(userResourceProfileRepository.getAllUserComputeResourcePreferences(userId, gatewayId).size() == 1);
         assertTrue(userResourceProfileRepository.getAllUserStoragePreferences(userId, gatewayId).size() == 1);
         assertTrue(userResourceProfileRepository.getGatewayProfileIds(gatewayId).size() == 1);

--- a/modules/registry/registry-core/src/test/java/org/apache/airavata/registry/core/repositories/appcatalog/UserResourceProfileRepositoryTest.java
+++ b/modules/registry/registry-core/src/test/java/org/apache/airavata/registry/core/repositories/appcatalog/UserResourceProfileRepositoryTest.java
@@ -68,7 +68,7 @@ public class UserResourceProfileRepositoryTest extends TestBase {
                 userId, gatewayId, userStoragePreference.getStorageResourceId());
         assertEquals(userStoragePreference.getFileSystemRootLocation(), retrievedUserStoragePreference.getFileSystemRootLocation());
 
-        assertTrue(userResourceProfileRepository.getAllUserResourceProfiles().size() == 2);
+        assertTrue(userResourceProfileRepository.getAllUserResourceProfiles().size() == 1);
         assertTrue(userResourceProfileRepository.getAllUserComputeResourcePreferences(userId, gatewayId).size() == 1);
         assertTrue(userResourceProfileRepository.getAllUserStoragePreferences(userId, gatewayId).size() == 1);
         assertTrue(userResourceProfileRepository.getGatewayProfileIds(gatewayId).size() == 1);

--- a/modules/sharing-registry/sharing-registry-server/src/test/java/org/apache/airavata/sharing/registry/SharingRegistryServerHandlerTest.java
+++ b/modules/sharing-registry/sharing-registry-server/src/test/java/org/apache/airavata/sharing/registry/SharingRegistryServerHandlerTest.java
@@ -40,7 +40,7 @@ public class SharingRegistryServerHandlerTest {
     public void test() throws TException, ApplicationSettingsException {
         SharingRegistryDBInitConfig sharingRegistryDBInitConfig = new SharingRegistryDBInitConfig();
         sharingRegistryDBInitConfig.setDBInitScriptPrefix("sharing-registry");
-        SharingRegistryServerHandler sharingRegistryServerHandler = new SharingRegistryServerHandler();
+        SharingRegistryServerHandler sharingRegistryServerHandler = new SharingRegistryServerHandler(sharingRegistryDBInitConfig);
 
         //Creating domain
         Domain domain = new Domain();


### PR DESCRIPTION
UserResourceProfileRepositoryTest
The test case was failing due to failing assert statement. userResourceProfileRepository has 2 user resource profiles. A default user resource profile is added during appCatalog DB Initialization, 2nd user profile is added during testing.

SharingRegistryServerHandlerTest
Test case was failing due to failure to initialize sharing registry db. The sharingRegistryDBInitConfig being created was not being used during the creation of SharingRegistryServerHandler.