### PR TITLE
Add javax.annotation and JAXB API as external dependencies to reslove…

### DIFF
--- a/airavata-api/airavata-base-api/pom.xml
+++ b/airavata-api/airavata-base-api/pom.xml
@@ -18,5 +18,10 @@
             <artifactId>libthrift</artifactId>
             <version>${thrift.version}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax.annotation.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/airavata-api/airavata-data-models/pom.xml
+++ b/airavata-api/airavata-data-models/pom.xml
@@ -43,7 +43,11 @@
             <artifactId>libthrift</artifactId>
             <version>${thrift.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax.annotation.version}</version>
+        </dependency>
     </dependencies>
 
 

--- a/modules/commons/pom.xml
+++ b/modules/commons/pom.xml
@@ -158,6 +158,11 @@
             <artifactId>airavata-base-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb.version}</version>
+        </dependency>
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,8 @@
         <google.guava.version>20.0</google.guava.version>
         <jacoco.version>0.8.1</jacoco.version>
         <openjpa.version>2.4.3</openjpa.version>
+        <javax.annotation.version>1.3.2</javax.annotation.version>
+        <jaxb.version>2.4.0-b180830.0359</jaxb.version>
     </properties>
 
     <developers>


### PR DESCRIPTION
… compilation failures when migrating from Java 8 to 11