### PR TITLE
swtich to paramiko sftp for windows path

### DIFF
--- a/airavata-api/airavata-client-sdks/airavata-python-sdk/airavata_python_sdk.egg-info/SOURCES.txt
+++ b/airavata-api/airavata-client-sdks/airavata-python-sdk/airavata_python_sdk.egg-info/SOURCES.txt
@@ -177,6 +177,7 @@ clients/file_handling_client.py
 clients/group_manager_client.py
 clients/iam_admin_client.py
 clients/keycloak_token_fetcher.py
+clients/sftp_file_handling_client.py
 clients/sharing_registry_client.py
 clients/tenant_profile_client.py
 clients/user_profile_client.py

--- a/airavata-api/airavata-client-sdks/airavata-python-sdk/clients/sftp_file_handling_client.py
+++ b/airavata-api/airavata-client-sdks/airavata-python-sdk/clients/sftp_file_handling_client.py
@@ -48,7 +48,7 @@ class SFTPConnector(object):
                 base = os.path.join('', project_name)
                 sftp.mkdir(base)
                 sftp.mkdir(remote_path)
-            except OSError:
+            except (OSError, IOError) as e:
                 pass
             sftp.put_r(localpath=local_path, remotepath=remote_path, confirm=True, preserve_mtime=False)
         sftp.close()

--- a/airavata-api/airavata-client-sdks/airavata-python-sdk/clients/sftp_file_handling_client.py
+++ b/airavata-api/airavata-client-sdks/airavata-python-sdk/clients/sftp_file_handling_client.py
@@ -15,8 +15,10 @@
 #
 
 import logging
-import pysftp
 import os
+import paramiko
+from scp import SCPClient
+
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -38,26 +40,28 @@ class SFTPConnector(object):
         self.username = username
         self.password = password
 
+        ssh = paramiko.SSHClient()
+        self.ssh = ssh
+        # Trust all key policy on remote host
+
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+
     def upload_files(self, local_path, project_name, exprement_id):
-        remote_path = os.path.join('', project_name, exprement_id, '')
-        cnopts = pysftp.CnOpts()
-        cnopts.hostkeys = None
-        with  pysftp.Connection(host=self.host, port=self.port, username=self.username,
-                                password=self.password, cnopts=cnopts) as sftp:
-            try:
-                sftp.makedirs(remote_path)
-            except (OSError, IOError) as e:
-                pass
-            sftp.put_r(localpath=local_path, remotepath=remote_path, confirm=True, preserve_mtime=False)
-        sftp.close()
-        pathsuffix = os.path.join('', self.username + remote_path)
+        remote_path = "/" + project_name + "/" + exprement_id + "/"
+
+        self.ssh.connect(self.host, self.port, self.username, password = self.password)
+        with SCPClient(self.ssh.get_transport()) as conn:
+            conn.put(local_path, remote_path, recursive=True)
+        self.ssh.close()
+
+        pathsuffix = "/" + self.username + remote_path
         return pathsuffix
 
     def download_files(self, local_path, project_name, exprement_id):
-        remote_path = os.path.join('', project_name, exprement_id, '')
-        cnopts = pysftp.CnOpts()
-        cnopts.hostkeys = None
-        with  pysftp.Connection(host=self.host, port=self.port, username=self.username,
-                                password=self.password, cnopts=cnopts) as sftp:
-            sftp.get_r(remotedir=remote_path, localdir=local_path, preserve_mtime=False)
-        sftp.close()
+        remote_path = "/" + project_name + "/" + exprement_id + "/"
+
+        self.ssh.connect(self.host, self.port, self.username, password = self.password)
+        with SCPClient(self.ssh.get_transport()) as conn:
+            conn.get(remote_path=remote_path, local_path= local_path, recursive= True)
+        self.ssh.close()

--- a/airavata-api/airavata-client-sdks/airavata-python-sdk/clients/sftp_file_handling_client.py
+++ b/airavata-api/airavata-client-sdks/airavata-python-sdk/clients/sftp_file_handling_client.py
@@ -45,9 +45,7 @@ class SFTPConnector(object):
         with  pysftp.Connection(host=self.host, port=self.port, username=self.username,
                                 password=self.password, cnopts=cnopts) as sftp:
             try:
-                base = os.path.join('', project_name)
-                sftp.mkdir(base)
-                sftp.mkdir(remote_path)
+                sftp.makedirs(remote_path)
             except (OSError, IOError) as e:
                 pass
             sftp.put_r(localpath=local_path, remotepath=remote_path, confirm=True, preserve_mtime=False)

--- a/airavata-api/airavata-client-sdks/airavata-python-sdk/clients/utils/data_model_creation_util.py
+++ b/airavata-api/airavata-client-sdks/airavata-python-sdk/clients/utils/data_model_creation_util.py
@@ -70,7 +70,8 @@ class DataModelCreationUtil(object):
                                                   experiment_dir_path):
         resource_host_id = self.airavata_util.get_resource_host_id(computation_resource_name)
         groupResourceProfileId = self.airavata_util.get_group_resource_profile_id(group_resource_profile_name)
-        storageId = self.airavata_util.get_storage_resource_id(storage_name)
+        # storageId = self.airavata_util.get_storage_resource_id(storage_name)
+        storageId = 'pgadev.scigap.org_7ddf28fd-d503-4ff8-bbc5-3279a7c3b99e'
         computRes = ComputationalResourceSchedulingModel()
         computRes.resourceHostId = resource_host_id
         computRes.nodeCount = node_count
@@ -91,7 +92,8 @@ class DataModelCreationUtil(object):
         return experiment_model
 
     def register_input_file(self, file_identifier, storage_name, input_file_name, uploaded_storage_path):
-        storageId = self.airavata_util.get_storage_resource_id(storage_name)
+        #storageId = self.airavata_util.get_storage_resource_id(storage_name)
+        storageId = 'pgadev.scigap.org_7ddf28fd-d503-4ff8-bbc5-3279a7c3b99e'
         dataProductModel = DataProductModel()
         dataProductModel.gatewayId = self.gateway_id
         dataProductModel.ownerName = self.username


### PR DESCRIPTION
- difficult to make pysftp work with windows path (https://stackoverflow.com/questions/50118919/python-pysftp-get-r-from-linux-works-fine-on-linux-but-not-on-windows), so switch to paramiko. 
- also use hard-coded storage-id, because non-privildge gateway users fail in airavata_util.get_storage_resource_id