### PR TITLE
AIRAVATA-3590 remove xmlbeans

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -305,17 +305,6 @@
         <!-- dependency> <groupId>org.ogce</groupId> <artifactId>bcgss</artifactId>
             <version>146</version> </dependency> -->
         <dependency>
-            <groupId>org.apache.xmlbeans</groupId>
-            <artifactId>xmlbeans</artifactId>
-            <version>${xmlbeans.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>stax</groupId>
-                    <artifactId>stax-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
             <version>${thrift.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,6 @@
         <surefire.version>3.0.0-M4</surefire.version>
         <junit.version>4.12</junit.version>
         <curator.version>2.8.0</curator.version>
-        <!--remove xmlbeans version -->
-        <xmlbeans.version>2.5.0</xmlbeans.version>
         <groovy.version>2.4.7</groovy.version>
         <xpp3.version>1.1.6</xpp3.version>
         <xpp5.version>1.2.8</xpp5.version>


### PR DESCRIPTION
XMLBeans 2.5.0 has a serious XXE issue and does not really seem to be used anyway

https://issues.apache.org/jira/browse/AIRAVATA-3590