### PR TITLE
Handling special characters in output staging

### DIFF
--- a/modules/airavata-helix/helix-spectator/src/main/java/org/apache/airavata/helix/impl/task/staging/DataStagingTask.java
+++ b/modules/airavata-helix/helix-spectator/src/main/java/org/apache/airavata/helix/impl/task/staging/DataStagingTask.java
@@ -151,12 +151,27 @@ public abstract class DataStagingTask extends AiravataTask {
         return filePath;
     }
 
+    protected String escapeSpecialCharacters(String inputString){
+        final String[] metaCharacters = {"\\","^","$","{","}","[","]","(",")","?","&","%"};
+
+        for (String metaCharacter : metaCharacters) {
+            if (inputString.contains(metaCharacter)) {
+                inputString = inputString.replace(metaCharacter, "\\" + metaCharacter);
+            }
+        }
+        return inputString;
+    }
+
     public void naiveTransfer(AgentAdaptor srcAdaptor, String sourceFile, AgentAdaptor destAdaptor, String destFile,
                               String tempFile) throws TaskOnFailException {
+
+        sourceFile = escapeSpecialCharacters(sourceFile);
+        destFile = escapeSpecialCharacters(destFile);
+
         logger.info("Using naive transfer to transfer " + sourceFile + " to " + destFile);
         try {
             try {
-                logger.info("Downloading file " + sourceFile + " to loacl temp file " + tempFile);
+                logger.info("Downloading file " + sourceFile + " to local temp file " + tempFile);
                 srcAdaptor.downloadFile(sourceFile, tempFile);
             } catch (AgentException e) {
                 throw new TaskOnFailException("Failed downloading file " + sourceFile + " to the local path " +

--- a/modules/airavata-helix/helix-spectator/src/main/java/org/apache/airavata/helix/impl/task/staging/OutputDataStagingTask.java
+++ b/modules/airavata-helix/helix-spectator/src/main/java/org/apache/airavata/helix/impl/task/staging/OutputDataStagingTask.java
@@ -171,9 +171,11 @@ public class OutputDataStagingTask extends DataStagingTask {
                 }
                 if (!destinationURIs.isEmpty()) {
                     if (processOutput.getType() == DataType.URI) {
-                        saveExperimentOutput(processOutput.getName(), destinationURIs.get(0).toString());
+                        saveExperimentOutput(processOutput.getName(), escapeSpecialCharacters(destinationURIs.get(0).toString()));
                     } else if (processOutput.getType() == DataType.URI_COLLECTION) {
-                        saveExperimentOutputCollection(processOutput.getName(), destinationURIs.stream().map(URI::toString).collect(Collectors.toList()));
+                        saveExperimentOutputCollection(processOutput.getName(), destinationURIs.stream()
+                                .map(URI::toString)
+                                .map(this::escapeSpecialCharacters).collect(Collectors.toList()));
                     }
                 }
                 return onSuccess("Output data staging task " + getTaskId() + " successfully completed");
@@ -181,9 +183,10 @@ public class OutputDataStagingTask extends DataStagingTask {
             } else {
                 // Uploading output file to the storage resource
                 assert processOutput != null;
-                boolean transferred = transferFileToStorage(sourceURI.getPath(), destinationURI.getPath(), sourceFileName, adaptor, storageResourceAdaptor);
+                boolean transferred = transferFileToStorage(sourceURI.getPath(), destinationURI.getPath(),
+                        sourceFileName, adaptor, storageResourceAdaptor);
                 if (transferred) {
-                    saveExperimentOutput(processOutput.getName(), destinationURI.toString());
+                    saveExperimentOutput(processOutput.getName(), escapeSpecialCharacters(destinationURI.toString()));
                 } else {
                     logger.warn("File " + sourceFileName + " did not transfer");
                 }


### PR DESCRIPTION
In some cases output files might have special characters in the name which causes trouble for SCP protocol to handle. This fix will rename those files