### PR TITLE
install dependencies of airavata-python-sdk

### DIFF
--- a/airavata-api/airavata-client-sdks/airavata-python-sdk/pyproject.toml
+++ b/airavata-api/airavata-client-sdks/airavata-python-sdk/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "airavata-python-sdk"
+version = "1.1.6"
+description = "Apache Airavata Python SDK"
+readme = "README.md"
+license = { text = "Apache License 2.0" }
+authors = [{ name = "Airavata Developers", email = "dev@airavata.apache.org" }]
+requires-python = ">=3.6"
+dependencies = [
+  "oauthlib",
+  "requests",
+  "requests-oauthlib",
+  "thrift~=0.16.0",
+  "thrift_connector",
+  "paramiko",
+  "scp",
+  "pysftp",
+  "configparser",
+  "urllib3",
+  "pyjwt"
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["airavata*"]
+
+[tool.setuptools.package-data]
+"airavata_sdk.transport" = ["*.ini"]
+"airavata_sdk.samples.resources" = ["*.pem"]

--- a/airavata-api/airavata-client-sdks/airavata-python-sdk/requirements.txt
+++ b/airavata-api/airavata-client-sdks/airavata-python-sdk/requirements.txt
@@ -1,8 +1,8 @@
 oauthlib
-requests==2.13.0
-requests-oauthlib==0.7.0
-thrift==0.10.0
-thrift_connector==0.24
+requests
+requests-oauthlib
+thrift==0.16.0
+thrift_connector
 paramiko
 scp
 pysftp

--- a/airavata-api/airavata-client-sdks/airavata-python-sdk/setup.py
+++ b/airavata-api/airavata-client-sdks/airavata-python-sdk/setup.py
@@ -18,5 +18,5 @@ setup(
     author='Airavata Developers',
     author_email='dev@airavata.apache.org',
     description='Apache Airavata Python  SDK',
-    requires=read("requirements.txt").splitlines()
+    install_requires=read("requirements.txt").splitlines()
 )

--- a/airavata-api/airavata-client-sdks/airavata-python-sdk/setup.py
+++ b/airavata-api/airavata-client-sdks/airavata-python-sdk/setup.py
@@ -17,5 +17,6 @@ setup(
     license='Apache License 2.0',
     author='Airavata Developers',
     author_email='dev@airavata.apache.org',
-    description='Apache Airavata Python  SDK'
+    description='Apache Airavata Python  SDK',
+    requires=read("requirements.txt").splitlines()
 )


### PR DESCRIPTION
Currently when installing airavata-python-sdk through pip, its dependencies are not installed. I updated setup.py to install the dependencies specified in requirements.txt in the install step.