### PR TITLE
Upgrade to log4j-slf4j2-impl for SLF4J 2.x compatibility

### DIFF
--- a/modules/distribution/src/main/assembly/controller-bin-assembly.xml
+++ b/modules/distribution/src/main/assembly/controller-bin-assembly.xml
@@ -144,7 +144,7 @@
                 <include>org.slf4j:slf4j-api:jar</include>
                 <include>org.apache.logging.log4j:log4j-api</include>
                 <include>org.apache.logging.log4j:log4j-core</include>
-                <include>org.apache.logging.log4j:log4j-slf4j-impl</include>
+                <include>org.apache.logging.log4j:log4j-slf4j2-impl</include>
                 <include>org.apache.logging.log4j:log4j-1.2-api</include>
                 <include>org.yaml:snakeyaml:jar</include>
                 <include>org.xerial.snappy:snappy-java:jar</include>

--- a/modules/distribution/src/main/assembly/email-monitor-bin-assembly.xml
+++ b/modules/distribution/src/main/assembly/email-monitor-bin-assembly.xml
@@ -117,7 +117,7 @@
                 <include>org.slf4j:log4j-over-slf4j:jar</include>
                 <include>org.apache.logging.log4j:log4j-api</include>
                 <include>org.apache.logging.log4j:log4j-core</include>
-                <include>org.apache.logging.log4j:log4j-slf4j-impl</include>
+                <include>org.apache.logging.log4j:log4j-slf4j2-impl</include>
                 <include>org.apache.logging.log4j:log4j-1.2-api</include>
                 <include>com.github.danielwegener:logback-kafka-appender:jar</include>
                 <include>net.logstash.logback:logstash-logback-encoder:jar</include>

--- a/modules/distribution/src/main/assembly/parser-wm-bin-assembly.xml
+++ b/modules/distribution/src/main/assembly/parser-wm-bin-assembly.xml
@@ -132,7 +132,7 @@
                 <include>org.slf4j:log4j-over-slf4j:jar</include>
                 <include>org.apache.logging.log4j:log4j-api</include>
                 <include>org.apache.logging.log4j:log4j-core</include>
-                <include>org.apache.logging.log4j:log4j-slf4j-impl</include>
+                <include>org.apache.logging.log4j:log4j-slf4j2-impl</include>
                 <include>org.apache.logging.log4j:log4j-1.2-api</include>
                 <include>com.github.danielwegener:logback-kafka-appender:jar</include>
                 <include>net.logstash.logback:logstash-logback-encoder:jar</include>

--- a/modules/distribution/src/main/assembly/participant-bin-assembly.xml
+++ b/modules/distribution/src/main/assembly/participant-bin-assembly.xml
@@ -134,7 +134,7 @@
                 <include>org.slf4j:log4j-over-slf4j:jar</include>
                 <include>org.apache.logging.log4j:log4j-api</include>
                 <include>org.apache.logging.log4j:log4j-core</include>
-                <include>org.apache.logging.log4j:log4j-slf4j-impl</include>
+                <include>org.apache.logging.log4j:log4j-slf4j2-impl</include>
                 <include>org.apache.logging.log4j:log4j-1.2-api</include>
                 <include>com.github.danielwegener:logback-kafka-appender:jar</include>
                 <include>net.logstash.logback:logstash-logback-encoder:jar</include>

--- a/modules/distribution/src/main/assembly/post-wm-bin-assembly.xml
+++ b/modules/distribution/src/main/assembly/post-wm-bin-assembly.xml
@@ -133,7 +133,7 @@
                 <include>org.slf4j:log4j-over-slf4j:jar</include>
                 <include>org.apache.logging.log4j:log4j-api</include>
                 <include>org.apache.logging.log4j:log4j-core</include>
-                <include>org.apache.logging.log4j:log4j-slf4j-impl</include>
+                <include>org.apache.logging.log4j:log4j-slf4j2-impl</include>
                 <include>org.apache.logging.log4j:log4j-1.2-api</include>
                 <include>com.github.danielwegener:logback-kafka-appender:jar</include>
                 <include>net.logstash.logback:logstash-logback-encoder:jar</include>

--- a/modules/distribution/src/main/assembly/pre-wm-bin-assembly.xml
+++ b/modules/distribution/src/main/assembly/pre-wm-bin-assembly.xml
@@ -133,7 +133,7 @@
                 <include>org.slf4j:log4j-over-slf4j:jar</include>
                 <include>org.apache.logging.log4j:log4j-api</include>
                 <include>org.apache.logging.log4j:log4j-core</include>
-                <include>org.apache.logging.log4j:log4j-slf4j-impl</include>
+                <include>org.apache.logging.log4j:log4j-slf4j2-impl</include>
                 <include>org.apache.logging.log4j:log4j-1.2-api</include>
                 <include>com.github.danielwegener:logback-kafka-appender:jar</include>
                 <include>net.logstash.logback:logstash-logback-encoder:jar</include>

--- a/modules/distribution/src/main/assembly/realtime-monitor-bin-assembly.xml
+++ b/modules/distribution/src/main/assembly/realtime-monitor-bin-assembly.xml
@@ -111,7 +111,7 @@
                 <include>org.slf4j:log4j-over-slf4j:jar</include>
                 <include>org.apache.logging.log4j:log4j-api</include>
                 <include>org.apache.logging.log4j:log4j-core</include>
-                <include>org.apache.logging.log4j:log4j-slf4j-impl</include>
+                <include>org.apache.logging.log4j:log4j-slf4j2-impl</include>
                 <include>org.apache.logging.log4j:log4j-1.2-api</include>
 
                 <include>org.apache.commons:commons-pool2:jar</include>

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -201,7 +201,7 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j-impl</artifactId>
+                <artifactId>log4j-slf4j2-impl</artifactId>
                 <version>${log4j2.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Replaced `log4j-slf4j-impl` with `log4j-slf4j2-impl` to ensure compatibility with SLF4J 2.x

```
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J(W): Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J(W): Ignoring binding found at [jar:file:/home/airavata/master-deployment/api-orchestrator/apache-airavata-api-server-0.21-SNAPSHOT/lib/log4j-slf4j-impl-2.23.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J(W): See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
```
