### PR TITLE
Updated keycloak image in docker-compose.yml

### DIFF
--- a/modules/ide-integration/src/main/containers/docker-compose.yml
+++ b/modules/ide-integration/src/main/containers/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   keycloak:
-    image: jboss/keycloak:2.5.4.Final
+    image: quay.io/keycloak/keycloak:latest
     environment:
       - KEYCLOAK_USER=admin
       - KEYCLOAK_PASSWORD=admin


### PR DESCRIPTION
Updated Keycloak container image from `jboss/keycloak:2.5.4.Final` to `quay.io/keycloak/keycloak:latest`. I believe the official Keycloak container image was moved away from jboss/keycloak, and it was causing errors when running `docker-compose up` in the ide-integration guide.