### PR TITLE
support auto open start project modal on login

### DIFF
--- a/modules/research-framework/portal/src/App.tsx
+++ b/modules/research-framework/portal/src/App.tsx
@@ -79,7 +79,7 @@ function App() {
       <AuthProvider
         {...oidcConfig}
         onSigninCallback={() => {
-          navigate(location.pathname, { replace: true });
+          navigate(location.search, { replace: true });
         }}
       >
         <Toaster />

--- a/modules/research-framework/portal/src/components/home/StartSessionFromProjectButton.tsx
+++ b/modules/research-framework/portal/src/components/home/StartSessionFromProjectButton.tsx
@@ -10,7 +10,7 @@ import {
   Input,
   CloseButton,
 } from "@chakra-ui/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toaster } from "../ui/toaster";
 import { useAuth } from "react-oidc-context";
 import { AxiosError } from "axios";
@@ -31,7 +31,7 @@ export const StartSessionFromProjectButton = ({
   const handleClickStart = () => {
     if (shouldRedirect) {
       auth.signinRedirect({
-        redirect_uri: `${window.location.origin}/${window.location.pathname}`,
+        redirect_uri: `${window.location.origin}/${window.location.pathname}?showStartProjectSessionModal=true`,
         extraQueryParams: {
           prompt: "login",
           kc_idp_hint: "oidc",
@@ -88,6 +88,13 @@ export const StartSessionFromProjectButton = ({
     }
     setLoadingOpenProject(false);
   };
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("showStartProjectSessionModal") === "true") {
+      dialog.setOpen(true);
+    }
+  }, []);
 
   return (
     <>

--- a/modules/research-framework/portal/src/components/home/StartSessionFromProjectButton.tsx
+++ b/modules/research-framework/portal/src/components/home/StartSessionFromProjectButton.tsx
@@ -93,8 +93,10 @@ export const StartSessionFromProjectButton = ({
     const params = new URLSearchParams(window.location.search);
     if (params.get("showStartProjectSessionModal") === "true") {
       dialog.setOpen(true);
+      // remove ALL query params
+      window.history.replaceState({}, "", window.location.pathname);
     }
-  }, []);
+  }, [dialog]);
 
   return (
     <>

--- a/modules/research-framework/portal/src/components/resources/ResourceDetails.tsx
+++ b/modules/research-framework/portal/src/components/resources/ResourceDetails.tsx
@@ -64,7 +64,15 @@ const ResourceDetails = () => {
     <>
       <Container maxW="breakpoint-lg" mx="auto" p={4} mt={16}>
         <Box>
-          <Button variant="plain" p={0} onClick={() => navigate(-1)}>
+          <Button
+            variant="plain"
+            p={0}
+            onClick={() =>
+              navigate(
+                "/resources?resourceTypes=REPOSITORY%2CNOTEBOOK%2CDATASET%2CMODEL"
+              )
+            }
+          >
             <HStack
               alignItems="center"
               mb={4}

--- a/modules/research-framework/portal/src/components/resources/index.tsx
+++ b/modules/research-framework/portal/src/components/resources/index.tsx
@@ -21,6 +21,7 @@ import { FaCheck } from "react-icons/fa";
 import { Tag as TagEntity } from "@/interfaces/TagType";
 import { useLocation, useNavigate } from "react-router";
 import { toaster } from "../ui/toaster";
+import { resourceTypeToColor } from "@/lib/util";
 
 const getResources = async (
   types: ResourceTypeEnum[],
@@ -237,15 +238,16 @@ export const Resources = () => {
             <HStack wrap="wrap">
               {labels.map((type) => {
                 const isSelected = resourceTypes.includes(type);
+                const color = resourceTypeToColor(type);
                 return (
                   <Button
                     key={type}
                     variant="outline"
-                    color={isSelected ? "blue.600" : "black"}
-                    bg={isSelected ? "blue.100" : "white"}
+                    color={isSelected ? color + ".600" : "black"}
+                    bg={isSelected ? color + ".100" : "white"}
                     _hover={{
-                      bg: isSelected ? "blue.200" : "gray.100",
-                      color: isSelected ? "blue.700" : "black",
+                      bg: isSelected ? color + ".200" : "gray.100",
+                      color: isSelected ? color + ".700" : "black",
                     }}
                     size="sm"
                     onClick={() => {
@@ -261,7 +263,7 @@ export const Resources = () => {
                     }}
                   >
                     {type}
-                    {isSelected && <FaCheck color="blue" />}
+                    {isSelected && <FaCheck color={color} />}
                   </Button>
                 );
               })}

--- a/modules/research-framework/portal/src/lib/constants.ts
+++ b/modules/research-framework/portal/src/lib/constants.ts
@@ -3,7 +3,7 @@ let APP_URL: string;
 
 if (process.env.NODE_ENV === 'production') {
   BACKEND_URL = "https://api.cybershuttle.org:18889";
-  APP_URL = "https://catalog.dev.cybershuttle.org";
+  APP_URL = "https://cybershuttle.org";
 } else {
   BACKEND_URL = "http://localhost:18999";
   APP_URL = 'http://localhost:5173';
@@ -12,6 +12,6 @@ if (process.env.NODE_ENV === 'production') {
 export const API_VERSION = "v1";
 export const CLIENT_ID = 'data-catalog-portal';
 export const APP_REDIRECT_URI = `${APP_URL}/oauth_callback`;
-export const OPENID_CONFIG_URL = `https://auth.dev.cybershuttle.org/realms/default/.well-known/openid-configuration`;
+export const OPENID_CONFIG_URL = `https://auth.cybershuttle.org/realms/default/.well-known/openid-configuration`;
 
 export { BACKEND_URL, APP_URL };


### PR DESCRIPTION
**Updates:**
- Updated coloring for resource types (filters now show as colored): dataset = green, notebook = blue, model = purple, repo = red
- When user is not logged in, and they click "start project session", the redirect back will automatically open the start modal

**Demo**:

https://github.com/user-attachments/assets/edc5fc81-5782-48c7-9141-fa0a99d40b23

