### PR TITLE
update AMQP Client to V5

### DIFF
--- a/airavata-api/src/main/java/org/apache/airavata/messaging/core/impl/ExperimentConsumer.java
+++ b/airavata-api/src/main/java/org/apache/airavata/messaging/core/impl/ExperimentConsumer.java
@@ -22,8 +22,8 @@ package org.apache.airavata.messaging.core.impl;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
-import com.rabbitmq.client.QueueingConsumer;
 import java.io.IOException;
 import org.apache.airavata.common.utils.AiravataUtils;
 import org.apache.airavata.common.utils.ServerSettings;
@@ -36,7 +36,7 @@ import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ExperimentConsumer extends QueueingConsumer {
+public class ExperimentConsumer extends DefaultConsumer {
     private static final Logger log = LoggerFactory.getLogger(ExperimentConsumer.class);
 
     private MessageHandler handler;

--- a/airavata-api/src/main/java/org/apache/airavata/messaging/core/impl/MessageConsumer.java
+++ b/airavata-api/src/main/java/org/apache/airavata/messaging/core/impl/MessageConsumer.java
@@ -31,7 +31,7 @@ import org.apache.log4j.Logger;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TException;
 
-public class MessageConsumer extends QueueingConsumer {
+public class MessageConsumer extends DefaultConsumer {
 
     private static final Logger logger = LogManager.getLogger(MessageConsumer.class);
 

--- a/airavata-api/src/main/java/org/apache/airavata/messaging/core/impl/ProcessConsumer.java
+++ b/airavata-api/src/main/java/org/apache/airavata/messaging/core/impl/ProcessConsumer.java
@@ -22,8 +22,8 @@ package org.apache.airavata.messaging.core.impl;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
-import com.rabbitmq.client.QueueingConsumer;
 import java.io.IOException;
 import org.apache.airavata.common.utils.AiravataUtils;
 import org.apache.airavata.common.utils.ServerSettings;
@@ -39,7 +39,7 @@ import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ProcessConsumer extends QueueingConsumer {
+public class ProcessConsumer extends DefaultConsumer {
     private static final Logger log = LoggerFactory.getLogger(ProcessConsumer.class);
 
     private MessageHandler handler;

--- a/pom.xml
+++ b/pom.xml
@@ -392,7 +392,7 @@ under the License.
             <dependency>
                 <groupId>com.rabbitmq</groupId>
                 <artifactId>amqp-client</artifactId>
-                <version>3.5.1</version>
+                <version>5.25.0</version>
             </dependency>
             <dependency>
                 <groupId>io.prometheus</groupId>


### PR DESCRIPTION
* Updated AMQP Client to V5 to fix security vulnerability.
* Switch `QueueingConsumer` class to `DefaultConsumer` (`QueueingConsumer` is removed in v5)