### PR TITLE
update from mysql-connector-java:5 (vulnerable) to mysql-connector-j:9

### DIFF
--- a/dev-tools/ansible/inventories/scigap/develop/group_vars/all/vars.yml
+++ b/dev-tools/ansible/inventories/scigap/develop/group_vars/all/vars.yml
@@ -53,7 +53,7 @@ profile_service: "profile_service"
 django_db_username: "django"
 django_db_password: "{{ vault_db_password }}"
 
-mysql_connector_jar: "mysql-connector-java-5.1.37-bin.jar"
+mysql_connector_jar: "mysql-connector-j-9.3.0-bin.jar"
 
 # Rabbitmq related vareables
 rabbitmq_server: "{{ groups['rabbitmq'][0] }}"

--- a/dev-tools/ansible/inventories/standalone/group_vars/all/vars.yml
+++ b/dev-tools/ansible/inventories/standalone/group_vars/all/vars.yml
@@ -54,7 +54,7 @@ workflow_catalog: "workflow_catalog"
 credential_store: "credential_store"
 profile_service: "profile_service"
 
-mysql_connector_jar: "mysql-connector-java-5.1.37-bin.jar"
+mysql_connector_jar: "mysql-connector-j-9.3.0-bin.jar"
 
 # Rabbitmq related vareables
 rabbitmq_server: "{{ groups['rabbitmq'][0] }}"

--- a/dev-tools/ansible/inventories/template/group_vars/all/vars.yml
+++ b/dev-tools/ansible/inventories/template/group_vars/all/vars.yml
@@ -54,7 +54,7 @@ workflow_catalog: "workflow_catalog"
 credential_store: "credential_store"
 profile_service: "profile_service"
 
-mysql_connector_jar: "mysql-connector-java-5.1.37-bin.jar"
+mysql_connector_jar: "mysql-connector-j-9.3.0-bin.jar"
 
 # Rabbitmq related vareables
 rabbitmq_server: "{{ groups['rabbitmq'][0] }}"

--- a/dev-tools/ansible/roles/keycloak/defaults/main.yml
+++ b/dev-tools/ansible/roles/keycloak/defaults/main.yml
@@ -22,7 +22,7 @@
 keycloak_version: "2.5.4.Final"
 keycloak_downlaod_url: "https://downloads.jboss.org/keycloak/{{keycloak_version}}/keycloak-{{keycloak_version}}.tar.gz"
 keycloak_install_dir: "keycloak-{{keycloak_version}}"
-keycloak_db_connector_name: "mysql-connector-java-5.1.41"
+keycloak_db_connector_name: "mysql-connector-j-9.3.0-bin.jar"
 # keycloak_ssl_keystore_file: "airavata.jks"
 # keycloak_ssl_keystore_file_name: "airavata.jks"
 # keycloak_ssl_keystore_password: "Airavata"

--- a/pom.xml
+++ b/pom.xml
@@ -322,8 +322,8 @@ under the License.
             <!-- Database -->
             <dependency>
                 <groupId>mysql</groupId>
-                <artifactId>mysql-connector-java</artifactId>
-                <version>8.0.31</version>
+                <artifactId>mysql-connector-j</artifactId>
+                <version>9.3.0</version>
             </dependency>
             <dependency>
                 <groupId>org.mariadb.jdbc</groupId>


### PR DESCRIPTION
Fixes [CVE-2023-22102](https://nvd.nist.gov/vuln/detail/CVE-2023-22102)