### PR TITLE
dev: fix DevStorage cold-start initialization in the containerized server

### DIFF
--- a/airavata-api/orchestration-service/src/main/java/org/apache/airavata/orchestration/util/DevStorageInitializer.java
+++ b/airavata-api/orchestration-service/src/main/java/org/apache/airavata/orchestration/util/DevStorageInitializer.java
@@ -1,6 +1,5 @@
 package org.apache.airavata.orchestration.util;
 
-import jakarta.annotation.PostConstruct;
 import org.apache.airavata.config.ServerSettings;
 import org.apache.airavata.credential.service.CredentialStoreService;
 import org.apache.airavata.model.appcatalog.gatewayprofile.proto.StoragePreference;
@@ -15,7 +14,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.annotation.Order;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -30,7 +30,6 @@ import java.nio.file.Path;
  * Idempotent: checks if the storage resource already exists before creating.
  */
 @Component
-@Order(200) // Run after ExpCatalogDBInitConfig and AppCatalogDBInitConfig
 public class DevStorageInitializer {
 
     private static final Logger logger = LoggerFactory.getLogger(DevStorageInitializer.class);
@@ -53,7 +52,8 @@ public class DevStorageInitializer {
     @Autowired
     private CredentialStoreService credentialStoreService;
 
-    @PostConstruct
+    // Run after DBInitConfig.postInit() creates the default gateway (@Order can't sequence @PostConstruct).
+    @EventListener(ApplicationReadyEvent.class)
     public void initialize() {
         try {
             String gatewayId = ServerSettings.getDefaultUserGateway();

--- a/compose.yml
+++ b/compose.yml
@@ -220,6 +220,7 @@ services:
         exec java -jar airavata-server.jar
     volumes:
       - ./conf/traefik/certs/rootCA.pem:/certs/rootCA.pem:ro
+      - ./conf:/opt/airavata/conf:ro   # SSH key, credential keystore, TLS read from conf/
     ports:
       - "9090:9090"
     depends_on:


### PR DESCRIPTION
On a fresh-DB cold start the containerized server failed to initialize the dev SFTP storage. Mounts `conf/` so it finds the SSH keypair and the credential-store keystore, and moves `DevStorageInitializer` to `ApplicationReadyEvent` so the default gateway exists before its storage preference is added (`@Order` does not sequence `@PostConstruct`).