### PR TITLE
fix: eliminate server cold-start startup warnings

### DIFF
--- a/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/model/SharingEntity.java
+++ b/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/model/SharingEntity.java
@@ -38,7 +38,7 @@ public class SharingEntity {
     private Long updatedTime;
 
     @Id
-    @Column(name = "PERMISSION_TYPE_ID")
+    @Column(name = "PERMISSION_TYPE_ID", length = 152)
     public String getPermissionTypeId() {
         return permissionTypeId;
     }
@@ -48,7 +48,7 @@ public class SharingEntity {
     }
 
     @Id
-    @Column(name = "ENTITY_ID")
+    @Column(name = "ENTITY_ID", length = 152)
     public String getEntityId() {
         return entityId;
     }
@@ -58,7 +58,7 @@ public class SharingEntity {
     }
 
     @Id
-    @Column(name = "GROUP_ID")
+    @Column(name = "GROUP_ID", length = 152)
     public String getGroupId() {
         return groupId;
     }
@@ -68,7 +68,7 @@ public class SharingEntity {
     }
 
     @Id
-    @Column(name = "INHERITED_PARENT_ID")
+    @Column(name = "INHERITED_PARENT_ID", length = 152)
     public String getInheritedParentId() {
         return inheritedParentId;
     }
@@ -78,7 +78,7 @@ public class SharingEntity {
     }
 
     @Id
-    @Column(name = "DOMAIN_ID")
+    @Column(name = "DOMAIN_ID", length = 152)
     public String getDomainId() {
         return domainId;
     }

--- a/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/model/SharingPK.java
+++ b/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/model/SharingPK.java
@@ -33,7 +33,7 @@ public class SharingPK implements Serializable {
     private String inheritedParentId;
     private String domainId;
 
-    @Column(name = "PERMISSION_TYPE_ID")
+    @Column(name = "PERMISSION_TYPE_ID", length = 152)
     @Id
     public String getPermissionTypeId() {
         return permissionTypeId;
@@ -43,7 +43,7 @@ public class SharingPK implements Serializable {
         this.permissionTypeId = permissionTypeId;
     }
 
-    @Column(name = "ENTITY_ID")
+    @Column(name = "ENTITY_ID", length = 152)
     @Id
     public String getEntityId() {
         return entityId;
@@ -53,7 +53,7 @@ public class SharingPK implements Serializable {
         this.entityId = entityId;
     }
 
-    @Column(name = "GROUP_ID")
+    @Column(name = "GROUP_ID", length = 152)
     @Id
     public String getGroupId() {
         return groupId;
@@ -63,7 +63,7 @@ public class SharingPK implements Serializable {
         this.groupId = groupId;
     }
 
-    @Column(name = "INHERITED_PARENT_ID")
+    @Column(name = "INHERITED_PARENT_ID", length = 152)
     @Id
     public String getInheritedParentId() {
         return inheritedParentId;
@@ -73,7 +73,7 @@ public class SharingPK implements Serializable {
         this.inheritedParentId = inheritedParentId;
     }
 
-    @Column(name = "DOMAIN_ID")
+    @Column(name = "DOMAIN_ID", length = 152)
     @Id
     public String getDomainId() {
         return domainId;

--- a/airavata-server/src/main/java/org/apache/airavata/server/grpc/AiravataArmeriaConfig.java
+++ b/airavata-server/src/main/java/org/apache/airavata/server/grpc/AiravataArmeriaConfig.java
@@ -24,6 +24,7 @@ import com.linecorp.armeria.server.cors.CorsService;
 import com.linecorp.armeria.server.cors.CorsServiceBuilder;
 import com.linecorp.armeria.server.docs.DocService;
 import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.spring.ArmeriaBeanPostProcessor;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 import io.grpc.BindableService;
 import java.util.List;
@@ -34,6 +35,7 @@ import org.apache.airavata.server.file.FileController;
 import org.apache.airavata.server.grpc.config.GrpcAuthInterceptor;
 import org.apache.airavata.server.grpc.config.HttpAuthDecorator;
 import org.apache.airavata.server.kafka.KafkaProxyService;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -57,6 +59,13 @@ import org.springframework.context.annotation.Import;
             "org.apache.airavata.iam.service"
         })
 public class AiravataArmeriaConfig {
+
+    // Static replacement for Armeria's non-static ArmeriaBeanPostProcessorConfiguration
+    // (excluded via spring.autoconfigure.exclude) — avoids the BPP-eligibility warning.
+    @Bean
+    public static ArmeriaBeanPostProcessor armeriaBeanPostProcessor(BeanFactory beanFactory) {
+        return new ArmeriaBeanPostProcessor(beanFactory);
+    }
 
     @Bean
     public ArmeriaServerConfigurator grpcServerConfigurator(

--- a/airavata-server/src/main/resources/application.properties
+++ b/airavata-server/src/main/resources/application.properties
@@ -35,6 +35,7 @@ spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
 
 # --- Spring ---
 spring.main.web-application-type=none
+spring.autoconfigure.exclude=com.linecorp.armeria.spring.ArmeriaBeanPostProcessorConfiguration
 
 # --- Actuator ---
 management.endpoints.web.exposure.include=health,info


### PR DESCRIPTION
The server cold-started with two recurring warnings. Aligns the `SHARING` composite-key column lengths in `SharingEntity`/`SharingPK` with the V1 baseline (`varchar(152)`) so Hibernate `ddl-auto` no longer tries to widen them past InnoDB's 3072-byte key limit, and registers Armeria's `BeanPostProcessor` as a static `@Bean` (excluding the library's non-static `ArmeriaBeanPostProcessorConfiguration`). The server now cold-starts with zero WARN/ERROR.