### PR TITLE
fix: seed default sharing data idempotently without ERROR noise

### DIFF
--- a/airavata-api/orchestration-service/src/main/java/org/apache/airavata/orchestration/util/ExpCatalogDBInitConfig.java
+++ b/airavata-api/orchestration-service/src/main/java/org/apache/airavata/orchestration/util/ExpCatalogDBInitConfig.java
@@ -90,9 +90,9 @@ public class ExpCatalogDBInitConfig implements DBInitConfig {
     private void tryCreate(String label, ThrowingRunnable action) {
         try {
             action.run();
-            logger.info("Created {}", label);
+            logger.info("Ensured {}", label);
         } catch (Exception e) {
-            logger.debug("{} already exists: {}", label, e.getMessage());
+            logger.error("Failed to ensure {}: {}", label, e.getMessage(), e);
         }
     }
 

--- a/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/service/SharingService.java
+++ b/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/service/SharingService.java
@@ -84,6 +84,9 @@ public class SharingService implements SharingFacade, SharingProvider {
             (new PermissionTypeRepository()).create(permissionType);
 
             return domain.getDomainId();
+        } catch (DuplicateEntryException e) {
+            logger.warn("Domain {} already exists, skipping creation", domain.getDomainId());
+            return domain.getDomainId();
         } catch (Throwable ex) {
             logger.error(ex.getMessage(), ex);
             throw new SharingRegistryException(ex.getMessage() + " Stack trace:" + ExceptionUtils.getStackTrace(ex));
@@ -635,6 +638,9 @@ public class SharingService implements SharingFacade, SharingProvider {
             entityType.setUpdatedTime(System.currentTimeMillis());
             (new EntityTypeRepository()).create(entityType);
             return entityType.getEntityTypeId();
+        } catch (DuplicateEntryException e) {
+            logger.warn("EntityType {} already exists, skipping creation", entityType.getEntityTypeId());
+            return entityType.getEntityTypeId();
         } catch (Throwable ex) {
             logger.error(ex.getMessage(), ex);
             throw new SharingRegistryException(ex.getMessage() + " Stack trace:" + ExceptionUtils.getStackTrace(ex));
@@ -726,6 +732,9 @@ public class SharingService implements SharingFacade, SharingProvider {
             permissionType.setCreatedTime(System.currentTimeMillis());
             permissionType.setUpdatedTime(System.currentTimeMillis());
             (new PermissionTypeRepository()).create(permissionType);
+            return permissionType.getPermissionTypeId();
+        } catch (DuplicateEntryException e) {
+            logger.warn("PermissionType {} already exists, skipping creation", permissionType.getPermissionTypeId());
             return permissionType.getPermissionTypeId();
         } catch (Throwable ex) {
             logger.error(ex.getMessage(), ex);


### PR DESCRIPTION
On every server restart against an existing DB, default-data seeding re-ran and `SharingService.create{Domain,EntityType,PermissionType}` logged the expected duplicate at ERROR with a full stack trace. Make those creates idempotent: on an existing entry, log one clean WARN and return the existing id instead of throwing. The seeder logs `Ensured` and surfaces genuine failures at ERROR.