### PR TITLE
chore: reword duplicate-seed WARNs and quiet Kafka config dumps

### DIFF
--- a/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/service/SharingService.java
+++ b/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/service/SharingService.java
@@ -85,7 +85,7 @@ public class SharingService implements SharingFacade, SharingProvider {
 
             return domain.getDomainId();
         } catch (DuplicateEntryException e) {
-            logger.warn("Domain {} already exists, skipping creation", domain.getDomainId());
+            logger.warn("A domain with id={} already exists, skipping recreation", domain.getDomainId());
             return domain.getDomainId();
         } catch (Throwable ex) {
             logger.error(ex.getMessage(), ex);
@@ -639,7 +639,7 @@ public class SharingService implements SharingFacade, SharingProvider {
             (new EntityTypeRepository()).create(entityType);
             return entityType.getEntityTypeId();
         } catch (DuplicateEntryException e) {
-            logger.warn("EntityType {} already exists, skipping creation", entityType.getEntityTypeId());
+            logger.warn("An entity type with id={} already exists, skipping recreation", entityType.getEntityTypeId());
             return entityType.getEntityTypeId();
         } catch (Throwable ex) {
             logger.error(ex.getMessage(), ex);
@@ -734,7 +734,7 @@ public class SharingService implements SharingFacade, SharingProvider {
             (new PermissionTypeRepository()).create(permissionType);
             return permissionType.getPermissionTypeId();
         } catch (DuplicateEntryException e) {
-            logger.warn("PermissionType {} already exists, skipping creation", permissionType.getPermissionTypeId());
+            logger.warn("A permission type with id={} already exists, skipping recreation", permissionType.getPermissionTypeId());
             return permissionType.getPermissionTypeId();
         } catch (Throwable ex) {
             logger.error(ex.getMessage(), ex);

--- a/airavata-server/src/main/resources/logback.xml
+++ b/airavata-server/src/main/resources/logback.xml
@@ -30,6 +30,10 @@
   <logger name="org.apache.zookeeper" level="ERROR" />
   <logger name="org.apache.airavata" level="INFO" />
   <logger name="org.hibernate" level="ERROR" />
+  <!-- Kafka client config dumps are very verbose; keep them out of normal (INFO) logs. -->
+  <logger name="org.apache.kafka.clients.producer.ProducerConfig" level="WARN" />
+  <logger name="org.apache.kafka.clients.consumer.ConsumerConfig" level="WARN" />
+  <logger name="org.apache.kafka.clients.admin.AdminClientConfig" level="WARN" />
 
   <root level="INFO">
     <appender-ref ref="Console" />


### PR DESCRIPTION
Rewords the idempotent-seed warnings to `A domain with id={} already exists, skipping recreation` (and entity/permission type variants), and raises the Kafka client `ProducerConfig`/`ConsumerConfig`/`AdminClientConfig` loggers to WARN so their verbose value dumps stay out of normal INFO logs (recoverable by lowering those loggers to INFO).