### PR TITLE
Remove leftover Apache Thrift naming

### DIFF
--- a/airavata-api/credential-service/src/main/java/org/apache/airavata/credential/service/SSHAccountManager.java
+++ b/airavata-api/credential-service/src/main/java/org/apache/airavata/credential/service/SSHAccountManager.java
@@ -277,13 +277,13 @@ public class SSHAccountManager {
         return resolvedConfig;
     }
 
-    private Map<ConfigParam, String> convertConfigParams(String provisionerName, Map<String, String> thriftConfigParams)
+    private Map<ConfigParam, String> convertConfigParams(String provisionerName, Map<String, String> inputConfigParams)
             throws InvalidSetupException {
         List<ConfigParam> configParams = provisionerFactory.getSSHAccountProvisionerConfigParams(provisionerName);
         Map<String, ConfigParam> configParamMap =
                 configParams.stream().collect(Collectors.toMap(ConfigParam::getName, Function.identity()));
 
-        Map<ConfigParam, String> result = thriftConfigParams.entrySet().stream()
+        Map<ConfigParam, String> result = inputConfigParams.entrySet().stream()
                 .collect(Collectors.toMap(entry -> configParamMap.get(entry.getKey()), entry -> entry.getValue()));
         for (ConfigParam configParam : configParams) {
             if (!configParam.isOptional() && !result.containsKey(configParam)) {

--- a/airavata-api/iam-service/src/main/java/org/apache/airavata/iam/repository/AbstractRepository.java
+++ b/airavata-api/iam-service/src/main/java/org/apache/airavata/iam/repository/AbstractRepository.java
@@ -34,14 +34,14 @@ public abstract class AbstractRepository<T, E, Id> {
 
     private Class<E> dbEntityGenericClass;
 
-    public AbstractRepository(Class<T> thriftGenericClass, Class<E> dbEntityGenericClass) {
+    public AbstractRepository(Class<T> modelClass, Class<E> dbEntityGenericClass) {
         this.dbEntityGenericClass = dbEntityGenericClass;
     }
 
-    /** Convert a JPA entity to the Thrift/model object. */
+    /** Convert a JPA entity to the model object. */
     protected abstract T toModel(E entity);
 
-    /** Convert a Thrift/model object to a JPA entity. */
+    /** Convert a model object to a JPA entity. */
     protected abstract E toEntity(T model);
 
     public T create(T t) {

--- a/airavata-api/iam-service/src/main/java/org/apache/airavata/iam/util/AuthorizationException.java
+++ b/airavata-api/iam-service/src/main/java/org/apache/airavata/iam/util/AuthorizationException.java
@@ -22,7 +22,7 @@ package org.apache.airavata.iam.util;
 /**
  * Exception thrown for invalid authorization requests such as when a user does
  * not have access to an application or resource.
- * Replaces the former Thrift-generated exception of the same name.
+ * Replaces the legacy generated exception of the same name.
  */
 public class AuthorizationException extends AiravataSecurityException {
 

--- a/airavata-api/iam-service/src/main/java/org/apache/airavata/iam/util/QueryConstants.java
+++ b/airavata-api/iam-service/src/main/java/org/apache/airavata/iam/util/QueryConstants.java
@@ -24,7 +24,7 @@ package org.apache.airavata.iam.util;
  */
 public class QueryConstants {
 
-    // Field name constants (formerly derived from Thrift _Fields enums)
+    // Field name constants
     public static final String USER_ID = "userId";
     public static final String GATEWAY_ID = "gatewayId";
     public static final String AIRAVATA_INTERNAL_GATEWAY_ID = "airavataInternalGatewayId";

--- a/airavata-api/orchestration-service/src/main/java/org/apache/airavata/orchestration/workflow/PostWorkflowManager.java
+++ b/airavata-api/orchestration-service/src/main/java/org/apache/airavata/orchestration/workflow/PostWorkflowManager.java
@@ -48,8 +48,8 @@ import org.apache.airavata.server.CountMonitor;
 import org.apache.airavata.server.IServer;
 import org.apache.airavata.task.AiravataTask;
 import org.apache.airavata.task.OutPort;
+import org.apache.airavata.task.SubTaskModelDecoder;
 import org.apache.airavata.util.AiravataUtils;
-import org.apache.airavata.util.ThriftUtils;
 import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.slf4j.Logger;
@@ -261,7 +261,7 @@ public class PostWorkflowManager implements IServer {
                 } else if (taskModel.getTaskType() == TaskTypes.DATA_STAGING) {
                     if (jobSubmissionFound) {
                         DataStagingTaskModel subTaskModel =
-                                (DataStagingTaskModel) ThriftUtils.getSubTaskModel(taskModel);
+                                (DataStagingTaskModel) SubTaskModelDecoder.getSubTaskModel(taskModel);
                         assert subTaskModel != null;
                         switch (subTaskModel.getType()) {
                             case OUPUT:

--- a/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/event/SharingServiceDBEventHandler.java
+++ b/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/event/SharingServiceDBEventHandler.java
@@ -32,7 +32,7 @@ import org.apache.airavata.model.workspace.proto.Gateway;
 import org.apache.airavata.model.workspace.proto.Project;
 import org.apache.airavata.sharing.model.*;
 import org.apache.airavata.sharing.service.SharingService;
-import org.apache.airavata.sharing.util.ThriftDataModelConversion;
+import org.apache.airavata.sharing.util.SharingModelConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +75,7 @@ public class SharingServiceDBEventHandler implements MessageHandler {
                                 .getPublisher()
                                 .getPublisherContext()
                                 .getEntityDataModel());
-                        UserEntity user = ThriftDataModelConversion.getUser(userProfile);
+                        UserEntity user = SharingModelConverter.getUser(userProfile);
 
                         switch (dBEventMessageContext
                                 .getPublisher()

--- a/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/grpc/SharingGrpcService.java
+++ b/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/grpc/SharingGrpcService.java
@@ -190,7 +190,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
     @Override
     public void createDomain(CreateDomainRequest request, StreamObserver<CreateDomainResponse> observer) {
         try {
-            var domain = toThriftDomain(request.getDomain());
+            var domain = toDomainEntity(request.getDomain());
             String id = sharingHandler.createDomain(domain);
             observer.onNext(CreateDomainResponse.newBuilder().setDomainId(id).build());
             observer.onCompleted();
@@ -202,7 +202,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
     @Override
     public void updateDomain(UpdateDomainRequest request, StreamObserver<Empty> observer) {
         try {
-            sharingHandler.updateDomain(toThriftDomain(request.getDomain()));
+            sharingHandler.updateDomain(toDomainEntity(request.getDomain()));
             observer.onNext(Empty.getDefaultInstance());
             observer.onCompleted();
         } catch (Exception e) {
@@ -266,7 +266,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
     @Override
     public void createUser(CreateUserRequest request, StreamObserver<CreateUserResponse> observer) {
         try {
-            String id = sharingHandler.createUser(toThriftUser(request.getUser()));
+            String id = sharingHandler.createUser(toUserEntity(request.getUser()));
             observer.onNext(CreateUserResponse.newBuilder().setUserId(id).build());
             observer.onCompleted();
         } catch (Exception e) {
@@ -277,7 +277,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
     @Override
     public void updateUser(UpdateUserRequest request, StreamObserver<Empty> observer) {
         try {
-            sharingHandler.updatedUser(toThriftUser(request.getUser()));
+            sharingHandler.updatedUser(toUserEntity(request.getUser()));
             observer.onNext(Empty.getDefaultInstance());
             observer.onCompleted();
         } catch (Exception e) {
@@ -339,7 +339,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
     @Override
     public void createGroup(CreateGroupRequest request, StreamObserver<CreateGroupResponse> observer) {
         try {
-            String id = sharingHandler.createGroup(toThriftUserGroup(request.getGroup()));
+            String id = sharingHandler.createGroup(toUserGroupEntity(request.getGroup()));
             observer.onNext(CreateGroupResponse.newBuilder().setGroupId(id).build());
             observer.onCompleted();
         } catch (Exception e) {
@@ -350,7 +350,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
     @Override
     public void updateGroup(UpdateGroupRequest request, StreamObserver<Empty> observer) {
         try {
-            sharingHandler.updateGroup(toThriftUserGroup(request.getGroup()));
+            sharingHandler.updateGroup(toUserGroupEntity(request.getGroup()));
             observer.onNext(Empty.getDefaultInstance());
             observer.onCompleted();
         } catch (Exception e) {
@@ -568,7 +568,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
     @Override
     public void createEntityType(CreateEntityTypeRequest request, StreamObserver<CreateEntityTypeResponse> observer) {
         try {
-            String id = sharingHandler.createEntityType(toThriftEntityType(request.getEntityType()));
+            String id = sharingHandler.createEntityType(toEntityTypeEntity(request.getEntityType()));
             observer.onNext(
                     CreateEntityTypeResponse.newBuilder().setEntityTypeId(id).build());
             observer.onCompleted();
@@ -580,7 +580,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
     @Override
     public void updateEntityType(UpdateEntityTypeRequest request, StreamObserver<Empty> observer) {
         try {
-            sharingHandler.updateEntityType(toThriftEntityType(request.getEntityType()));
+            sharingHandler.updateEntityType(toEntityTypeEntity(request.getEntityType()));
             observer.onNext(Empty.getDefaultInstance());
             observer.onCompleted();
         } catch (Exception e) {
@@ -645,7 +645,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
     @Override
     public void createEntity(CreateEntityRequest request, StreamObserver<CreateEntityResponse> observer) {
         try {
-            String id = sharingHandler.createEntity(toThriftEntity(request.getEntity()));
+            String id = sharingHandler.createEntity(toEntityEntity(request.getEntity()));
             observer.onNext(CreateEntityResponse.newBuilder().setEntityId(id).build());
             observer.onCompleted();
         } catch (Exception e) {
@@ -656,7 +656,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
     @Override
     public void updateEntity(UpdateEntityRequest request, StreamObserver<Empty> observer) {
         try {
-            sharingHandler.updateEntity(toThriftEntity(request.getEntity()));
+            sharingHandler.updateEntity(toEntityEntity(request.getEntity()));
             observer.onNext(Empty.getDefaultInstance());
             observer.onCompleted();
         } catch (Exception e) {
@@ -788,7 +788,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
     public void createPermissionType(
             CreatePermissionTypeRequest request, StreamObserver<CreatePermissionTypeResponse> observer) {
         try {
-            String id = sharingHandler.createPermissionType(toThriftPermissionType(request.getPermissionType()));
+            String id = sharingHandler.createPermissionType(toPermissionTypeEntity(request.getPermissionType()));
             observer.onNext(CreatePermissionTypeResponse.newBuilder()
                     .setPermissionTypeId(id)
                     .build());
@@ -801,7 +801,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
     @Override
     public void updatePermissionType(UpdatePermissionTypeRequest request, StreamObserver<Empty> observer) {
         try {
-            sharingHandler.updatePermissionType(toThriftPermissionType(request.getPermissionType()));
+            sharingHandler.updatePermissionType(toPermissionTypeEntity(request.getPermissionType()));
             observer.onNext(Empty.getDefaultInstance());
             observer.onCompleted();
         } catch (Exception e) {
@@ -862,7 +862,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
     }
 
     // ========================================================================
-    // Entity sharing (Thrift-compatible)
+    // Entity sharing
     // ========================================================================
 
     @Override
@@ -926,7 +926,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
     }
 
     // ========================================================================
-    // Proto <-> Thrift conversion helpers
+    // Proto -> entity conversion helpers
     // ========================================================================
 
     private static Map<String, ResourcePermissionType> toResourcePermissionMap(Map<String, String> protoMap) {
@@ -939,7 +939,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
 
     // --- Domain ---
 
-    private static org.apache.airavata.sharing.model.DomainEntity toThriftDomain(
+    private static org.apache.airavata.sharing.model.DomainEntity toDomainEntity(
             org.apache.airavata.sharing.registry.models.proto.Domain proto) {
         var t = new org.apache.airavata.sharing.model.DomainEntity();
         if (!proto.getDomainId().isEmpty()) t.setDomainId(proto.getDomainId());
@@ -965,7 +965,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
 
     // --- User ---
 
-    private static org.apache.airavata.sharing.model.UserEntity toThriftUser(
+    private static org.apache.airavata.sharing.model.UserEntity toUserEntity(
             org.apache.airavata.sharing.registry.models.proto.User proto) {
         var t = new org.apache.airavata.sharing.model.UserEntity();
         if (!proto.getUserId().isEmpty()) t.setUserId(proto.getUserId());
@@ -989,7 +989,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
 
     // --- UserGroup ---
 
-    private static org.apache.airavata.sharing.model.UserGroupEntity toThriftUserGroup(
+    private static org.apache.airavata.sharing.model.UserGroupEntity toUserGroupEntity(
             org.apache.airavata.sharing.registry.models.proto.UserGroup proto) {
         var t = new org.apache.airavata.sharing.model.UserGroupEntity();
         if (!proto.getGroupId().isEmpty()) t.setGroupId(proto.getGroupId());
@@ -1034,7 +1034,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
 
     // --- EntityType ---
 
-    private static org.apache.airavata.sharing.model.EntityTypeEntity toThriftEntityType(
+    private static org.apache.airavata.sharing.model.EntityTypeEntity toEntityTypeEntity(
             org.apache.airavata.sharing.registry.models.proto.EntityType proto) {
         var t = new org.apache.airavata.sharing.model.EntityTypeEntity();
         if (!proto.getEntityTypeId().isEmpty()) t.setEntityTypeId(proto.getEntityTypeId());
@@ -1060,7 +1060,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
 
     // --- Entity ---
 
-    private static org.apache.airavata.sharing.model.EntityEntity toThriftEntity(
+    private static org.apache.airavata.sharing.model.EntityEntity toEntityEntity(
             org.apache.airavata.sharing.registry.models.proto.Entity proto) {
         var t = new org.apache.airavata.sharing.model.EntityEntity();
         if (!proto.getEntityId().isEmpty()) t.setEntityId(proto.getEntityId());
@@ -1102,7 +1102,7 @@ public class SharingGrpcService extends SharingServiceGrpc.SharingServiceImplBas
 
     // --- PermissionType ---
 
-    private static org.apache.airavata.sharing.model.PermissionTypeEntity toThriftPermissionType(
+    private static org.apache.airavata.sharing.model.PermissionTypeEntity toPermissionTypeEntity(
             org.apache.airavata.sharing.registry.models.proto.PermissionType proto) {
         var t = new org.apache.airavata.sharing.model.PermissionTypeEntity();
         if (!proto.getPermissionTypeId().isEmpty()) t.setPermissionTypeId(proto.getPermissionTypeId());

--- a/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/model/DuplicateEntryException.java
+++ b/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/model/DuplicateEntryException.java
@@ -21,7 +21,7 @@ package org.apache.airavata.sharing.model;
 
 /**
  * Exception thrown when attempting to create a duplicate entry.
- * Replaces the Thrift-generated exception of the same name.
+ * Replaces the legacy generated exception of the same name.
  */
 public class DuplicateEntryException extends Exception {
 

--- a/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/model/SharingRegistryException.java
+++ b/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/model/SharingRegistryException.java
@@ -21,7 +21,7 @@ package org.apache.airavata.sharing.model;
 
 /**
  * Exception thrown by the sharing registry when an operation fails.
- * Replaces the Thrift-generated exception of the same name.
+ * Replaces the legacy generated exception of the same name.
  */
 public class SharingRegistryException extends Exception {
 

--- a/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/util/SharingModelConverter.java
+++ b/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/util/SharingModelConverter.java
@@ -25,7 +25,7 @@ import org.apache.airavata.sharing.model.UserEntity;
 /**
  * Converts proto data models to sharing entity types.
  */
-public class ThriftDataModelConversion {
+public class SharingModelConverter {
 
     /**
      * Build UserEntity from proto UserProfile.

--- a/airavata-api/sharing-service/src/main/proto/sharing_service.proto
+++ b/airavata-api/sharing-service/src/main/proto/sharing_service.proto
@@ -431,7 +431,7 @@ service SharingService {
     };
   }
 
-  // --- Entity sharing (Thrift-compatible aliases using domain_id) ---
+  // --- Entity sharing (aliases using domain_id) ---
 
   rpc ShareEntityWithUsers(ShareEntityWithUsersRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
@@ -938,7 +938,7 @@ message GetPermissionTypesResponse {
 }
 
 // ===========================================================================
-// Request/Response messages — Entity sharing (Thrift-compatible)
+// Request/Response messages — Entity sharing
 // ===========================================================================
 
 message ShareEntityWithUsersRequest {

--- a/airavata-api/src/main/java/org/apache/airavata/db/AbstractRepository.java
+++ b/airavata-api/src/main/java/org/apache/airavata/db/AbstractRepository.java
@@ -33,14 +33,14 @@ public abstract class AbstractRepository<T, E, Id> {
 
     private Class<E> dbEntityGenericClass;
 
-    public AbstractRepository(Class<T> thriftGenericClass, Class<E> dbEntityGenericClass) {
+    public AbstractRepository(Class<T> modelClass, Class<E> dbEntityGenericClass) {
         this.dbEntityGenericClass = dbEntityGenericClass;
     }
 
-    /** Convert a JPA entity to the Thrift/model object. */
+    /** Convert a JPA entity to the model object. */
     protected abstract T toModel(E entity);
 
-    /** Convert a Thrift/model object to a JPA entity. */
+    /** Convert a model object to a JPA entity. */
     protected abstract E toEntity(T model);
 
     public T create(T t) {

--- a/airavata-api/src/main/java/org/apache/airavata/exception/IamAdminServicesException.java
+++ b/airavata-api/src/main/java/org/apache/airavata/exception/IamAdminServicesException.java
@@ -21,7 +21,7 @@ package org.apache.airavata.exception;
 
 /**
  * Exception thrown by IAM admin service operations.
- * Replaces the former Thrift-generated exception of the same name.
+ * Replaces the legacy generated exception of the same name.
  */
 public class IamAdminServicesException extends Exception {
 

--- a/airavata-api/src/main/java/org/apache/airavata/task/SubTaskModelDecoder.java
+++ b/airavata-api/src/main/java/org/apache/airavata/task/SubTaskModelDecoder.java
@@ -17,13 +17,13 @@
 * specific language governing permissions and limitations
 * under the License.
 */
-package org.apache.airavata.util;
+package org.apache.airavata.task;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.airavata.model.task.proto.*;
 
-public class ThriftUtils {
+public class SubTaskModelDecoder {
 
     public static Object getSubTaskModel(TaskModel taskModel) throws InvalidProtocolBufferException {
         ByteString subTaskBytes = taskModel.getSubTaskModel();

--- a/airavata-api/src/main/java/org/apache/airavata/task/TaskContext.java
+++ b/airavata-api/src/main/java/org/apache/airavata/task/TaskContext.java
@@ -68,7 +68,6 @@ import org.apache.airavata.model.status.proto.TaskStatus;
 import org.apache.airavata.model.task.proto.TaskModel;
 import org.apache.airavata.model.user.proto.UserProfile;
 import org.apache.airavata.util.AiravataUtils;
-import org.apache.airavata.util.ThriftUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -989,7 +988,7 @@ public class TaskContext {
 
     public Object getSubTaskModel() throws Exception {
         if (subTaskModel == null) {
-            subTaskModel = ThriftUtils.getSubTaskModel(getCurrentTaskModel());
+            subTaskModel = SubTaskModelDecoder.getSubTaskModel(getCurrentTaskModel());
         }
         return subTaskModel;
     }

--- a/airavata-api/src/main/proto/org/apache/airavata/model/appcatalog/groupresourceprofile/group_resource_profile.proto
+++ b/airavata-api/src/main/proto/org/apache/airavata/model/appcatalog/groupresourceprofile/group_resource_profile.proto
@@ -63,7 +63,7 @@ message AwsComputeResourcePreference {
   string preferred_instance_type = 3;
 }
 
-// Thrift union — represented as a oneof message wrapper
+// Variant — represented as a oneof message wrapper
 message EnvironmentSpecificPreferences {
   oneof preferences {
     SlurmComputeResourcePreference slurm = 1;

--- a/airavata-api/src/main/proto/org/apache/airavata/model/dbevent/db_event.proto
+++ b/airavata-api/src/main/proto/org/apache/airavata/model/dbevent/db_event.proto
@@ -68,7 +68,7 @@ message DBEventSubscriber {
   string subscriber_service = 1;
 }
 
-// Either variable set, depending on event-type (Thrift union → oneof)
+// Either variable set, depending on event-type (variant → oneof)
 message DBEventMessageContext {
   oneof context {
     DBEventPublisher publisher = 1;


### PR DESCRIPTION
The gRPC/Armeria migration already removed all functional Thrift (no IDL, runtime, or dependency remains), but Thrift-era names and comments lingered. This renames ThriftUtils to SubTaskModelDecoder (moved beside its only callers in the task package), ThriftDataModelConversion to SharingModelConverter, and the six toThrift* converters in SharingGrpcService to to*Entity (they build JPA entities, not Thrift objects), and clears the remaining Thrift references from comments, a constructor parameter, and three proto comments. No behavior change; the full reactor builds green.