### PR TITLE
Fix Spotless formatting violations

### DIFF
--- a/airavata-api/compute-service/src/main/java/org/apache/airavata/compute/util/SSHJStorageAdaptor.java
+++ b/airavata-api/compute-service/src/main/java/org/apache/airavata/compute/util/SSHJStorageAdaptor.java
@@ -22,18 +22,14 @@ package org.apache.airavata.compute.util;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
-
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.sftp.FileAttributes;
 import net.schmizz.sshj.sftp.FileMode;
 import net.schmizz.sshj.sftp.RemoteResourceInfo;
 import net.schmizz.sshj.sftp.SFTPClient;
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier;
-import net.schmizz.sshj.userauth.keyprovider.KeyProvider;
-
 import org.apache.airavata.interfaces.AgentException;
 import org.apache.airavata.interfaces.CommandOutput;
 import org.apache.airavata.interfaces.FileMetadata;
@@ -63,9 +59,14 @@ public class SSHJStorageAdaptor implements StorageResourceAdaptor {
     @Override
     public void init(String storageResourceId, String gatewayId, String loginUser, String token) throws AgentException {
         try {
-            log.info("Initializing SFTP adaptor: resource={}, gateway={}, user={}", storageResourceId, gatewayId, loginUser);
+            log.info(
+                    "Initializing SFTP adaptor: resource={}, gateway={}, user={}",
+                    storageResourceId,
+                    gatewayId,
+                    loginUser);
 
-            StorageResourceDescription sr = AgentUtils.getRegistryServiceClient().getStorageResource(storageResourceId);
+            StorageResourceDescription sr =
+                    AgentUtils.getRegistryServiceClient().getStorageResource(storageResourceId);
 
             Optional<DataMovementInterface> dmOp = sr.getDataMovementInterfacesList().stream()
                     .filter(iface -> iface.getDataMovementProtocol() == DataMovementProtocol.SCP)
@@ -74,7 +75,8 @@ public class SSHJStorageAdaptor implements StorageResourceAdaptor {
             DataMovementInterface dm = dmOp.orElseThrow(() ->
                     new AgentException("No SCP data movement interface for storage resource " + storageResourceId));
 
-            SCPDataMovement scp = AgentUtils.getRegistryServiceClient().getSCPDataMovement(dm.getDataMovementInterfaceId());
+            SCPDataMovement scp =
+                    AgentUtils.getRegistryServiceClient().getSCPDataMovement(dm.getDataMovementInterfaceId());
 
             SSHCredential cred = AgentUtils.getCredentialClient().getSSHCredential(token, gatewayId);
             if (cred == null) throw new AgentException("No credential for token " + token);
@@ -156,7 +158,8 @@ public class SSHJStorageAdaptor implements StorageResourceAdaptor {
     }
 
     @Override
-    public org.apache.airavata.model.appcatalog.storageresource.proto.StorageDirectoryInfo getStorageDirectoryInfo(String location) throws AgentException {
+    public org.apache.airavata.model.appcatalog.storageresource.proto.StorageDirectoryInfo getStorageDirectoryInfo(
+            String location) throws AgentException {
         return org.apache.airavata.model.appcatalog.storageresource.proto.StorageDirectoryInfo.getDefaultInstance();
     }
 
@@ -202,7 +205,8 @@ public class SSHJStorageAdaptor implements StorageResourceAdaptor {
         try (SFTPClient sftp = openSftp()) {
             java.io.File tempFile = java.io.File.createTempFile("airavata-upload-", ".tmp");
             try {
-                java.nio.file.Files.copy(localInStream, tempFile.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                java.nio.file.Files.copy(
+                        localInStream, tempFile.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
                 sftp.put(tempFile.getAbsolutePath(), remoteFile);
             } finally {
                 tempFile.delete();
@@ -222,7 +226,8 @@ public class SSHJStorageAdaptor implements StorageResourceAdaptor {
     }
 
     @Override
-    public void downloadFile(String remoteFile, OutputStream localOutStream, FileMetadata metadata) throws AgentException {
+    public void downloadFile(String remoteFile, OutputStream localOutStream, FileMetadata metadata)
+            throws AgentException {
         try (SFTPClient sftp = openSftp()) {
             java.io.File tempFile = java.io.File.createTempFile("airavata-download-", ".tmp");
             try {
@@ -257,7 +262,8 @@ public class SSHJStorageAdaptor implements StorageResourceAdaptor {
     }
 
     @Override
-    public org.apache.airavata.model.appcatalog.storageresource.proto.StorageVolumeInfo getStorageVolumeInfo(String location) throws AgentException {
+    public org.apache.airavata.model.appcatalog.storageresource.proto.StorageVolumeInfo getStorageVolumeInfo(
+            String location) throws AgentException {
         return org.apache.airavata.model.appcatalog.storageresource.proto.StorageVolumeInfo.getDefaultInstance();
     }
 

--- a/airavata-api/orchestration-service/src/main/java/org/apache/airavata/orchestration/util/DevStorageInitializer.java
+++ b/airavata-api/orchestration-service/src/main/java/org/apache/airavata/orchestration/util/DevStorageInitializer.java
@@ -1,12 +1,33 @@
+/**
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
 package org.apache.airavata.orchestration.util;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.apache.airavata.config.ServerSettings;
 import org.apache.airavata.credential.service.CredentialStoreService;
 import org.apache.airavata.model.appcatalog.gatewayprofile.proto.StoragePreference;
 import org.apache.airavata.model.appcatalog.storageresource.proto.StorageResourceDescription;
 import org.apache.airavata.model.credential.store.proto.SSHCredential;
 import org.apache.airavata.model.data.movement.proto.DMType;
-import org.apache.airavata.model.data.movement.proto.DataMovementProtocol;
 import org.apache.airavata.model.data.movement.proto.SCPDataMovement;
 import org.apache.airavata.model.data.movement.proto.SecurityProtocol;
 import org.apache.airavata.orchestration.service.RegistryServerHandler;
@@ -17,10 +38,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 /**
  * Cold-start initializer that registers a dev SFTP storage resource, SSH credential,
@@ -82,15 +99,15 @@ public class DevStorageInitializer {
                     .setSecurityProtocol(SecurityProtocol.SSH_KEYS)
                     .setSshPort(22)
                     .build();
-            registryHandler.addSCPDataMovementDetails(
-                    storageResourceId, DMType.STORAGE_RESOURCE, 0, scpDm);
+            registryHandler.addSCPDataMovementDetails(storageResourceId, DMType.STORAGE_RESOURCE, 0, scpDm);
             logger.info("Added SCP data movement interface for storage: {}", storageResourceId);
 
             // 3. Register SSH credential from Tiltfile-generated keypair
             String privateKey = readKeyFile(privateKeyPath);
             String publicKey = readKeyFile(publicKeyPath);
             if (privateKey == null || publicKey == null) {
-                logger.warn("SSH keypair not found at {} / {} — run 'tilt up' to generate", privateKeyPath, publicKeyPath);
+                logger.warn(
+                        "SSH keypair not found at {} / {} — run 'tilt up' to generate", privateKeyPath, publicKeyPath);
                 return;
             }
             SSHCredential sshCredential = SSHCredential.newBuilder()

--- a/airavata-api/orchestration-service/src/main/java/org/apache/airavata/orchestration/util/ExpCatalogDBInitConfig.java
+++ b/airavata-api/orchestration-service/src/main/java/org/apache/airavata/orchestration/util/ExpCatalogDBInitConfig.java
@@ -67,21 +67,27 @@ public class ExpCatalogDBInitConfig implements DBInitConfig {
 
     private void initializeSharingForGateway(String gatewayId) {
         // Domain
-        tryCreate("sharing domain", () ->
-                sharingFacade.createDomain(gatewayId, "Gateway " + gatewayId, "Sharing domain for " + gatewayId));
+        tryCreate(
+                "sharing domain",
+                () -> sharingFacade.createDomain(gatewayId, "Gateway " + gatewayId, "Sharing domain for " + gatewayId));
 
         // Entity types
-        String[] entityTypes = {"PROJECT", "EXPERIMENT", "FILE", "APPLICATION_DEPLOYMENT", "GROUP_RESOURCE_PROFILE", "CREDENTIAL_TOKEN"};
+        String[] entityTypes = {
+            "PROJECT", "EXPERIMENT", "FILE", "APPLICATION_DEPLOYMENT", "GROUP_RESOURCE_PROFILE", "CREDENTIAL_TOKEN"
+        };
         for (String et : entityTypes) {
-            tryCreate("entity type " + et, () ->
-                    sharingFacade.createEntityType(gatewayId + ":" + et, gatewayId, et, et + " entity type"));
+            tryCreate(
+                    "entity type " + et,
+                    () -> sharingFacade.createEntityType(gatewayId + ":" + et, gatewayId, et, et + " entity type"));
         }
 
         // Permission types
         String[] permTypes = {"READ", "WRITE", "MANAGE_SHARING"};
         for (String pt : permTypes) {
-            tryCreate("permission type " + pt, () ->
-                    sharingFacade.createPermissionType(gatewayId + ":" + pt, gatewayId, pt, pt + " permission type"));
+            tryCreate(
+                    "permission type " + pt,
+                    () -> sharingFacade.createPermissionType(
+                            gatewayId + ":" + pt, gatewayId, pt, pt + " permission type"));
         }
 
         logger.info("Sharing initialized for gateway: {}", gatewayId);

--- a/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/service/SharingService.java
+++ b/airavata-api/sharing-service/src/main/java/org/apache/airavata/sharing/service/SharingService.java
@@ -734,7 +734,9 @@ public class SharingService implements SharingFacade, SharingProvider {
             (new PermissionTypeRepository()).create(permissionType);
             return permissionType.getPermissionTypeId();
         } catch (DuplicateEntryException e) {
-            logger.warn("A permission type with id={} already exists, skipping recreation", permissionType.getPermissionTypeId());
+            logger.warn(
+                    "A permission type with id={} already exists, skipping recreation",
+                    permissionType.getPermissionTypeId());
             return permissionType.getPermissionTypeId();
         } catch (Throwable ex) {
             logger.error(ex.getMessage(), ex);

--- a/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/grpc/UserStorageGrpcService.java
+++ b/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/grpc/UserStorageGrpcService.java
@@ -69,7 +69,8 @@ public class UserStorageGrpcService extends UserStorageServiceGrpc.UserStorageSe
             return null;
         }
         String resolvedId = (storageResourceId != null && !storageResourceId.isEmpty())
-                ? storageResourceId : prefs.get(0).getStorageResourceId();
+                ? storageResourceId
+                : prefs.get(0).getStorageResourceId();
         for (var pref : prefs) {
             if (pref.getStorageResourceId().equals(resolvedId)) {
                 return pref;
@@ -117,7 +118,8 @@ public class UserStorageGrpcService extends UserStorageServiceGrpc.UserStorageSe
         if (path.startsWith("~/") || path.equals("~")) {
             StoragePreference pref = resolveStoragePreference(storageResourceId);
             String root = (pref != null && !pref.getFileSystemRootLocation().isEmpty())
-                    ? pref.getFileSystemRootLocation() : "/";
+                    ? pref.getFileSystemRootLocation()
+                    : "/";
             if (!root.endsWith("/")) root += "/";
             String suffix = path.length() > 2 ? path.substring(2) : "";
             path = root + suffix;

--- a/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/mapper/StorageMapper.java
+++ b/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/mapper/StorageMapper.java
@@ -50,10 +50,13 @@ public interface StorageMapper extends CommonMapperConversions {
         StorageResourceDescription.Builder b = StorageResourceDescription.newBuilder();
         if (entity.getStorageResourceId() != null) b.setStorageResourceId(entity.getStorageResourceId());
         if (entity.getHostName() != null) b.setHostName(entity.getHostName());
-        if (entity.getStorageResourceDescription() != null) b.setStorageResourceDescription(entity.getStorageResourceDescription());
+        if (entity.getStorageResourceDescription() != null)
+            b.setStorageResourceDescription(entity.getStorageResourceDescription());
         b.setEnabled(entity.isEnabled());
-        if (entity.getCreationTime() != null) b.setCreationTime(entity.getCreationTime().getTime());
-        if (entity.getUpdateTime() != null) b.setUpdateTime(entity.getUpdateTime().getTime());
+        if (entity.getCreationTime() != null)
+            b.setCreationTime(entity.getCreationTime().getTime());
+        if (entity.getUpdateTime() != null)
+            b.setUpdateTime(entity.getUpdateTime().getTime());
         if (entity.getDataMovementInterfaces() != null) {
             for (DataMovementInterfaceEntity dm : entity.getDataMovementInterfaces()) {
                 b.addDataMovementInterfaces(dataMovementInterfaceToModel(dm));


### PR DESCRIPTION
The Style Check workflow (mvn spotless:check) has been failing on master and on every open PR because six files carry formatting violations. This applies mvn spotless:apply to fix them — re-wrapping long lines, normalizing import grouping, and dropping unused imports in SSHJStorageAdaptor, DevStorageInitializer, ExpCatalogDBInitConfig, SharingService, UserStorageGrpcService and StorageMapper. Formatting-only with no behavior change; mvn spotless:check now passes and the reactor builds green.