### PR TITLE
Maven build hygiene: centralize dependency versions

### DIFF
--- a/airavata-api/compute-service/pom.xml
+++ b/airavata-api/compute-service/pom.xml
@@ -78,13 +78,11 @@ under the License.
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -156,7 +154,7 @@ under the License.
                         <path>
                             <groupId>org.mapstruct</groupId>
                             <artifactId>mapstruct-processor</artifactId>
-                            <version>1.6.3</version>
+                            <version>${mapstruct.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/airavata-api/credential-service/pom.xml
+++ b/airavata-api/credential-service/pom.xml
@@ -75,13 +75,11 @@ under the License.
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -120,7 +118,7 @@ under the License.
                         <path>
                             <groupId>org.mapstruct</groupId>
                             <artifactId>mapstruct-processor</artifactId>
-                            <version>1.6.3</version>
+                            <version>${mapstruct.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/airavata-api/iam-service/pom.xml
+++ b/airavata-api/iam-service/pom.xml
@@ -72,13 +72,11 @@ under the License.
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/airavata-api/orchestration-service/pom.xml
+++ b/airavata-api/orchestration-service/pom.xml
@@ -112,13 +112,11 @@ under the License.
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -184,7 +182,7 @@ under the License.
                         <path>
                             <groupId>org.mapstruct</groupId>
                             <artifactId>mapstruct-processor</artifactId>
-                            <version>1.6.3</version>
+                            <version>${mapstruct.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/airavata-api/pom.xml
+++ b/airavata-api/pom.xml
@@ -107,13 +107,11 @@ under the License.
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.23.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>5.23.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -336,7 +334,7 @@ under the License.
             <path>
               <groupId>org.mapstruct</groupId>
               <artifactId>mapstruct-processor</artifactId>
-              <version>1.6.3</version>
+              <version>${mapstruct.version}</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/airavata-api/research-service/pom.xml
+++ b/airavata-api/research-service/pom.xml
@@ -107,13 +107,11 @@ under the License.
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.23.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>5.23.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -178,7 +176,7 @@ under the License.
             <path>
               <groupId>org.mapstruct</groupId>
               <artifactId>mapstruct-processor</artifactId>
-              <version>1.6.3</version>
+              <version>${mapstruct.version}</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/airavata-api/sharing-service/pom.xml
+++ b/airavata-api/sharing-service/pom.xml
@@ -60,13 +60,11 @@ under the License.
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/airavata-api/storage-service/pom.xml
+++ b/airavata-api/storage-service/pom.xml
@@ -83,13 +83,11 @@ under the License.
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/airavata-server/pom.xml
+++ b/airavata-server/pom.xml
@@ -186,7 +186,7 @@ under the License.
                         <path>
                             <groupId>org.mapstruct</groupId>
                             <artifactId>mapstruct-processor</artifactId>
-                            <version>1.6.3</version>
+                            <version>${mapstruct.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@ under the License.
         <skipTests>false</skipTests>
         <surefire.excludedGroups>integration | runtime</surefire.excludedGroups>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
+        <mapstruct.version>1.6.3</mapstruct.version>
     </properties>
 
     <dependencies>
@@ -127,6 +128,16 @@ under the License.
                 <groupId>org.junit.platform</groupId>
                 <artifactId>junit-platform-launcher</artifactId>
                 <version>1.12.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>5.23.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>5.23.0</version>
             </dependency>
             <!-- Testcontainers BOM -->
             <dependency>
@@ -332,43 +343,16 @@ under the License.
                 <version>1.81</version>
             </dependency>
 
-            <!-- Spring Boot -->
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-web</artifactId>
-                <version>3.5.12</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-data-jpa</artifactId>
-                <version>3.5.12</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-actuator</artifactId>
-                <version>3.5.12</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-aop</artifactId>
-                <version>3.5.12</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>3.5.12</version>
-            </dependency>
-
             <!-- MapStruct -->
             <dependency>
                 <groupId>org.mapstruct</groupId>
                 <artifactId>mapstruct</artifactId>
-                <version>1.6.3</version>
+                <version>${mapstruct.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mapstruct</groupId>
                 <artifactId>mapstruct-processor</artifactId>
-                <version>1.6.3</version>
+                <version>${mapstruct.version}</version>
             </dependency>
 
             <!-- gRPC -->
@@ -497,7 +481,7 @@ under the License.
                         <path>
                             <groupId>org.mapstruct</groupId>
                             <artifactId>mapstruct-processor</artifactId>
-                            <version>1.6.3</version>
+                            <version>${mapstruct.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
@@ -668,7 +652,7 @@ under the License.
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
-                    <version>3.5.3</version>
+                    <version>3.5.12</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Tidies the build without changing behavior: the Mockito version (5.23.0) and the MapStruct version (now a single mapstruct.version property) are hoisted into the root pom's dependencyManagement so the eight module poms stop repeating them — this also aligns airavata-server's test Mockito, which previously resolved to 5.17.0 from the Spring Boot BOM; and the four redundant spring-boot-starter version pins and the misplaced spring-boot-maven-plugin entry are removed from dependencyManagement (all supplied by the imported spring-boot-dependencies BOM), with the spring-boot-maven-plugin pluginManagement pin bumped 3.5.3->3.5.12 to match. The full reactor builds green and dependency:tree confirms resolved versions are unchanged except the intended Mockito alignment.