### PR TITLE
Consolidate Testcontainers Ryuk-disable flag into root surefire

### DIFF
--- a/airavata-api/compute-service/pom.xml
+++ b/airavata-api/compute-service/pom.xml
@@ -159,18 +159,6 @@ under the License.
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-
-            <!-- Run Tests -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <inherited>true</inherited>
-                <configuration>
-                    <environmentVariables>
-                        <TESTCONTAINERS_RYUK_DISABLED>true</TESTCONTAINERS_RYUK_DISABLED>
-                    </environmentVariables>
-                </configuration>
-            </plugin>
         </plugins>
 
         <testSourceDirectory>${project.basedir}/src/test/java</testSourceDirectory>

--- a/airavata-api/iam-service/pom.xml
+++ b/airavata-api/iam-service/pom.xml
@@ -129,18 +129,6 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
-
-            <!-- Run Tests -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <inherited>true</inherited>
-                <configuration>
-                    <environmentVariables>
-                        <TESTCONTAINERS_RYUK_DISABLED>true</TESTCONTAINERS_RYUK_DISABLED>
-                    </environmentVariables>
-                </configuration>
-            </plugin>
         </plugins>
 
         <testSourceDirectory>${project.basedir}/src/test/java</testSourceDirectory>

--- a/airavata-api/orchestration-service/pom.xml
+++ b/airavata-api/orchestration-service/pom.xml
@@ -200,18 +200,6 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
-
-            <!-- Run Tests -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <inherited>true</inherited>
-                <configuration>
-                    <environmentVariables>
-                        <TESTCONTAINERS_RYUK_DISABLED>true</TESTCONTAINERS_RYUK_DISABLED>
-                    </environmentVariables>
-                </configuration>
-            </plugin>
         </plugins>
 
         <testSourceDirectory>${project.basedir}/src/test/java</testSourceDirectory>

--- a/airavata-api/pom.xml
+++ b/airavata-api/pom.xml
@@ -390,9 +390,6 @@ under the License.
           <systemPropertyVariables>
             <credential.module.directory>${basedir}</credential.module.directory>
           </systemPropertyVariables>
-          <environmentVariables>
-            <TESTCONTAINERS_RYUK_DISABLED>true</TESTCONTAINERS_RYUK_DISABLED>
-          </environmentVariables>
           <argLine>-Dapi.version=1.43</argLine>
           <excludes>
             <exclude>**/DAOBaseTestCase.java</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -496,6 +496,10 @@ under the License.
                     <useSystemClassLoader>false</useSystemClassLoader>
                     <forkCount>1C</forkCount>
                     <reuseForks>true</reuseForks>
+                    <!-- Disable the Testcontainers Ryuk reaper (incompatible with the DinD CI environment) -->
+                    <environmentVariables>
+                        <TESTCONTAINERS_RYUK_DISABLED>true</TESTCONTAINERS_RYUK_DISABLED>
+                    </environmentVariables>
                     <!-- Fail on first error for fast feedback during development -->
                     <skipAfterFailureCount>1</skipAfterFailureCount>
                     <excludes>


### PR DESCRIPTION
The TESTCONTAINERS_RYUK_DISABLED=true environment variable was copy-pasted into four module surefire configurations (airavata-api, iam-service, compute-service, orchestration-service). This hoists it into the root maven-surefire-plugin configuration so it applies to every module's tests through inheritance, and removes the three Ryuk-only surefire blocks plus airavata-api's copy. Verified with mvn help:effective-pom that the flag still reaches iam/compute/orchestration and now also the other Testcontainers-using modules, and the full reactor builds green. (The redundant default-valued testSourceDirectory/testOutputDirectory overrides in those poms are left for a separate cleanup.)