### PR TITLE
Dedup iam QueryConstants against the shared db.QueryConstants

### DIFF
--- a/airavata-api/iam-service/src/main/java/org/apache/airavata/iam/repository/UserProfileRepository.java
+++ b/airavata-api/iam-service/src/main/java/org/apache/airavata/iam/repository/UserProfileRepository.java
@@ -19,6 +19,9 @@
 */
 package org.apache.airavata.iam.repository;
 
+import static org.apache.airavata.db.QueryConstants.FIND_ALL_USER_PROFILES_BY_GATEWAY_ID;
+import static org.apache.airavata.db.QueryConstants.FIND_USER_PROFILE_BY_USER_ID;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +59,7 @@ public class UserProfileRepository extends AbstractRepository<UserProfile, UserP
         Map<String, Object> queryParam = new HashMap<String, Object>();
         queryParam.put(QueryConstants.USER_ID, userId);
         queryParam.put(QueryConstants.GATEWAY_ID, gatewayId);
-        List<UserProfile> resultList = select(QueryConstants.FIND_USER_PROFILE_BY_USER_ID, 1, 0, queryParam);
+        List<UserProfile> resultList = select(FIND_USER_PROFILE_BY_USER_ID, 1, 0, queryParam);
 
         if (resultList != null && resultList.size() > 0) userProfile = resultList.get(0);
 
@@ -70,9 +73,9 @@ public class UserProfileRepository extends AbstractRepository<UserProfile, UserP
 
         List<UserProfile> resultList = null;
         if (limit > 0) {
-            resultList = select(QueryConstants.FIND_ALL_USER_PROFILES_BY_GATEWAY_ID, limit, offset, queryParams);
+            resultList = select(FIND_ALL_USER_PROFILES_BY_GATEWAY_ID, limit, offset, queryParams);
         } else {
-            resultList = select(QueryConstants.FIND_ALL_USER_PROFILES_BY_GATEWAY_ID, queryParams);
+            resultList = select(FIND_ALL_USER_PROFILES_BY_GATEWAY_ID, queryParams);
         }
 
         return resultList;

--- a/airavata-api/iam-service/src/main/java/org/apache/airavata/iam/util/QueryConstants.java
+++ b/airavata-api/iam-service/src/main/java/org/apache/airavata/iam/util/QueryConstants.java
@@ -24,35 +24,8 @@ package org.apache.airavata.iam.util;
  */
 public class QueryConstants {
 
-    // Field name constants
+    // Field name constants used as JPQL parameter keys by UserProfileRepository.
+    // The query strings themselves live in the shared org.apache.airavata.db.QueryConstants.
     public static final String USER_ID = "userId";
     public static final String GATEWAY_ID = "gatewayId";
-    public static final String AIRAVATA_INTERNAL_GATEWAY_ID = "airavataInternalGatewayId";
-    public static final String GATEWAY_APPROVAL_STATUS = "gatewayApprovalStatus";
-    public static final String GATEWAY_NAME = "gatewayName";
-    public static final String GATEWAY_URL = "gatewayUrl";
-    public static final String REQUESTER_USERNAME = "requesterUsername";
-
-    public static final String FIND_USER_PROFILE_BY_USER_ID =
-            "SELECT u FROM UserProfileEntity u " + "where u.userId LIKE :"
-                    + USER_ID + " " + "AND u.gatewayId LIKE :"
-                    + GATEWAY_ID + "";
-
-    public static final String FIND_ALL_USER_PROFILES_BY_GATEWAY_ID =
-            "SELECT u FROM UserProfileEntity u " + "where u.gatewayId LIKE :" + GATEWAY_ID + "";
-
-    public static final String FIND_GATEWAY_BY_INTERNAL_ID = "SELECT g FROM GatewayEntity g "
-            + "where g.airavataInternalGatewayId LIKE :" + AIRAVATA_INTERNAL_GATEWAY_ID;
-
-    public static final String FIND_DUPLICATE_GATEWAY =
-            "SELECT g FROM GatewayEntity g " + "where g.gatewayApprovalStatus IN :"
-                    + GATEWAY_APPROVAL_STATUS + " " + "and (g.gatewayId LIKE :"
-                    + GATEWAY_ID + " " + "     or g.gatewayName LIKE :"
-                    + GATEWAY_NAME + " " + "     or g.gatewayUrl LIKE :"
-                    + GATEWAY_URL + " " + "    )";
-
-    public static final String GET_ALL_GATEWAYS = "SELECT g FROM GatewayEntity g";
-
-    public static final String GET_USER_GATEWAYS =
-            "SELECT g from GatewayEntity g " + "where g.requesterUsername LIKE :" + REQUESTER_USERNAME + "";
 }


### PR DESCRIPTION
iam-service's util.QueryConstants duplicated query strings that also live in the shared org.apache.airavata.db.QueryConstants. UserProfileRepository now static-imports its two JPQL queries from the shared class (the iam and core definitions resolve to byte-identical JPQL), so the iam copy drops the two duplicated user-profile queries, four gateway queries that were already dead (GatewayRepository imports and uses the core copies), and the five parameter constants only those dead queries referenced — leaving just the USER_ID/GATEWAY_ID parameter keys UserProfileRepository still needs. Behavior-preserving and the full reactor builds green.