### PR TITLE
Collapse duplicated method families in storage-service

### DIFF
--- a/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/repository/DataMovementRepository.java
+++ b/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/repository/DataMovementRepository.java
@@ -19,6 +19,7 @@
 */
 package org.apache.airavata.storage.repository;
 
+import java.util.function.Function;
 import org.apache.airavata.db.AbstractRepository;
 import org.apache.airavata.db.AppCatalogUtils;
 import org.apache.airavata.interfaces.AppCatalogException;
@@ -61,15 +62,26 @@ public class DataMovementRepository
         return dataMovementInterfaceEntity.getDataMovementInterfaceId();
     }
 
+    private String addMovement(StorageDataMovementEntity entity) throws AppCatalogException {
+        execute(entityManager -> entityManager.merge(entity));
+        return entity.getDataMovementId();
+    }
+
+    private <T> T getMovement(String dataMovementId, Function<StorageDataMovementEntity, T> mapper)
+            throws AppCatalogException {
+        StorageDataMovementEntity entity =
+                execute(entityManager -> entityManager.find(StorageDataMovementEntity.class, dataMovementId));
+        if (entity == null) return null;
+        return mapper.apply(entity);
+    }
+
     // --- LOCALDataMovement CRUD ---
 
     public String addLocalDataMovement(LOCALDataMovement localDataMovement) throws AppCatalogException {
         localDataMovement = localDataMovement.toBuilder()
                 .setDataMovementInterfaceId(AppCatalogUtils.getID("LOCAL"))
                 .build();
-        StorageDataMovementEntity entity = StorageMapper.INSTANCE.localDataMovementToEntity(localDataMovement);
-        execute(entityManager -> entityManager.merge(entity));
-        return entity.getDataMovementId();
+        return addMovement(StorageMapper.INSTANCE.localDataMovementToEntity(localDataMovement));
     }
 
     public void updateLocalDataMovement(LOCALDataMovement localDataMovement) throws AppCatalogException {
@@ -78,10 +90,7 @@ public class DataMovementRepository
     }
 
     public LOCALDataMovement getLocalDataMovement(String dataMovementId) throws AppCatalogException {
-        StorageDataMovementEntity entity =
-                execute(entityManager -> entityManager.find(StorageDataMovementEntity.class, dataMovementId));
-        if (entity == null) return null;
-        return StorageMapper.INSTANCE.localDataMovementToModel(entity);
+        return getMovement(dataMovementId, StorageMapper.INSTANCE::localDataMovementToModel);
     }
 
     // --- SCPDataMovement CRUD ---
@@ -90,9 +99,7 @@ public class DataMovementRepository
         scpDataMovement = scpDataMovement.toBuilder()
                 .setDataMovementInterfaceId(AppCatalogUtils.getID("SCP"))
                 .build();
-        StorageDataMovementEntity entity = StorageMapper.INSTANCE.scpDataMovementToEntity(scpDataMovement);
-        execute(entityManager -> entityManager.merge(entity));
-        return entity.getDataMovementId();
+        return addMovement(StorageMapper.INSTANCE.scpDataMovementToEntity(scpDataMovement));
     }
 
     public void updateScpDataMovement(SCPDataMovement scpDataMovement) throws AppCatalogException {
@@ -102,10 +109,7 @@ public class DataMovementRepository
     }
 
     public SCPDataMovement getSCPDataMovement(String dataMovementId) throws AppCatalogException {
-        StorageDataMovementEntity entity =
-                execute(entityManager -> entityManager.find(StorageDataMovementEntity.class, dataMovementId));
-        if (entity == null) return null;
-        return StorageMapper.INSTANCE.scpDataMovementToModel(entity);
+        return getMovement(dataMovementId, StorageMapper.INSTANCE::scpDataMovementToModel);
     }
 
     // --- UnicoreDataMovement CRUD ---
@@ -114,16 +118,11 @@ public class DataMovementRepository
         unicoreDataMovement = unicoreDataMovement.toBuilder()
                 .setDataMovementInterfaceId(AppCatalogUtils.getID("UNICORE"))
                 .build();
-        StorageDataMovementEntity entity = StorageMapper.INSTANCE.unicoreDataMovementToEntity(unicoreDataMovement);
-        execute(entityManager -> entityManager.merge(entity));
-        return entity.getDataMovementId();
+        return addMovement(StorageMapper.INSTANCE.unicoreDataMovementToEntity(unicoreDataMovement));
     }
 
     public UnicoreDataMovement getUNICOREDataMovement(String dataMovementId) throws AppCatalogException {
-        StorageDataMovementEntity entity =
-                execute(entityManager -> entityManager.find(StorageDataMovementEntity.class, dataMovementId));
-        if (entity == null) return null;
-        return StorageMapper.INSTANCE.unicoreDataMovementToModel(entity);
+        return getMovement(dataMovementId, StorageMapper.INSTANCE::unicoreDataMovementToModel);
     }
 
     // --- GridFTPDataMovement CRUD ---
@@ -132,16 +131,11 @@ public class DataMovementRepository
         gridFTPDataMovement = gridFTPDataMovement.toBuilder()
                 .setDataMovementInterfaceId(AppCatalogUtils.getID("GRIDFTP"))
                 .build();
-        StorageDataMovementEntity entity = StorageMapper.INSTANCE.gridFtpDataMovementToEntity(gridFTPDataMovement);
-        execute(entityManager -> entityManager.merge(entity));
-        return entity.getDataMovementId();
+        return addMovement(StorageMapper.INSTANCE.gridFtpDataMovementToEntity(gridFTPDataMovement));
     }
 
     public GridFTPDataMovement getGridFTPDataMovement(String dataMovementId) throws AppCatalogException {
-        StorageDataMovementEntity entity =
-                execute(entityManager -> entityManager.find(StorageDataMovementEntity.class, dataMovementId));
-        if (entity == null) return null;
-        return StorageMapper.INSTANCE.gridFtpDataMovementToModel(entity);
+        return getMovement(dataMovementId, StorageMapper.INSTANCE::gridFtpDataMovementToModel);
     }
 
     // --- Data movement interface removal ---

--- a/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/task/DataStagingTask.java
+++ b/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/task/DataStagingTask.java
@@ -104,32 +104,7 @@ public abstract class DataStagingTask extends AiravataTask {
      * Use input storage resource if configured. Otherwise, falls back to default gateway storage.
      */
     protected StorageResourceAdaptor getInputStorageAdaptor(AdaptorSupport adaptorSupport) throws TaskOnFailException {
-        String storageId = null;
-        try {
-            storageId = getTaskContext().getInputStorageResourceId();
-            logger.info("Fetching input storage adaptor for input storage resource {}", storageId);
-
-            if (getTaskContext().getProcessModel().getInputStorageResourceId() != null
-                    && !getTaskContext()
-                            .getProcessModel()
-                            .getInputStorageResourceId()
-                            .trim()
-                            .isEmpty()) {
-
-                StoragePreference inputStoragePref = getTaskContext().getInputGatewayStorageResourcePreference();
-                return createStorageAdaptorFromPreference(adaptorSupport, storageId, inputStoragePref, "Input");
-            } else {
-                // Fall back to default storage resource configured
-                return getStorageAdaptor(adaptorSupport);
-            }
-        } catch (Exception e) {
-            logger.error(
-                    "Failed to obtain adaptor for input storage resource {} in task {}", storageId, getTaskId(), e);
-            throw new TaskOnFailException(
-                    "Failed to obtain adaptor for input storage resource " + storageId + " in task " + getTaskId(),
-                    false,
-                    e);
-        }
+        return getDirectionalStorageAdaptor(adaptorSupport, true);
     }
 
     /**
@@ -137,29 +112,42 @@ public abstract class DataStagingTask extends AiravataTask {
      * Use output storage resource if configured. Otherwise, falls back to default gateway storage.
      */
     protected StorageResourceAdaptor getOutputStorageAdaptor(AdaptorSupport adaptorSupport) throws TaskOnFailException {
+        return getDirectionalStorageAdaptor(adaptorSupport, false);
+    }
+
+    private StorageResourceAdaptor getDirectionalStorageAdaptor(AdaptorSupport adaptorSupport, boolean input)
+            throws TaskOnFailException {
+        String direction = input ? "input" : "output";
+        String label = input ? "Input" : "Output";
         String storageId = null;
         try {
-            storageId = getTaskContext().getOutputStorageResourceId();
-            logger.info("Fetching output storage adaptor for input storage resource {}", storageId);
+            storageId = input
+                    ? getTaskContext().getInputStorageResourceId()
+                    : getTaskContext().getOutputStorageResourceId();
+            logger.info("Fetching {} storage adaptor for {} storage resource {}", direction, direction, storageId);
 
-            if (getTaskContext().getProcessModel().getOutputStorageResourceId() != null
-                    && !getTaskContext()
-                            .getProcessModel()
-                            .getOutputStorageResourceId()
-                            .trim()
-                            .isEmpty()) {
-
-                StoragePreference outputStoragePref = getTaskContext().getOutputGatewayStorageResourcePreference();
-                return createStorageAdaptorFromPreference(adaptorSupport, storageId, outputStoragePref, "Output");
+            String processStorageId = input
+                    ? getTaskContext().getProcessModel().getInputStorageResourceId()
+                    : getTaskContext().getProcessModel().getOutputStorageResourceId();
+            if (processStorageId != null && !processStorageId.trim().isEmpty()) {
+                StoragePreference storagePref = input
+                        ? getTaskContext().getInputGatewayStorageResourcePreference()
+                        : getTaskContext().getOutputGatewayStorageResourcePreference();
+                return createStorageAdaptorFromPreference(adaptorSupport, storageId, storagePref, label);
             } else {
                 // Fall back to default storage resource configured
                 return getStorageAdaptor(adaptorSupport);
             }
         } catch (Exception e) {
             logger.error(
-                    "Failed to obtain adaptor for output storage resource {} in task {}", storageId, getTaskId(), e);
+                    "Failed to obtain adaptor for {} storage resource {} in task {}",
+                    direction,
+                    storageId,
+                    getTaskId(),
+                    e);
             throw new TaskOnFailException(
-                    "Failed to obtain adaptor for output storage resource " + storageId + " in task " + getTaskId(),
+                    "Failed to obtain adaptor for " + direction + " storage resource " + storageId + " in task "
+                            + getTaskId(),
                     false,
                     e);
         }


### PR DESCRIPTION
Two intra-class dedups in storage-service. In DataMovementRepository the four per-protocol getters (LOCAL/SCP/UNICORE/GridFTP) were identical except for the mapper, and the four adders except for the id prefix and mapper; they now delegate to two private helpers — getMovement(id, mapper) and addMovement(entity) — with the per-protocol toBuilder().setDataMovementInterfaceId(getID(PREFIX)) injection kept in each typed wrapper, the asymmetric update* methods left untouched, and null-on-missing semantics preserved. In DataStagingTask the structurally identical getInputStorageAdaptor/getOutputStorageAdaptor now delegate to a single direction-parameterized helper, which along the way fixes the output method's log line that mislabeled the resource as 'input'. Behavior-preserving; the full reactor builds green and storage-service tests pass.