### PR TITLE
Collapse duplicated method families in research-service

### DIFF
--- a/airavata-api/research-service/src/main/java/org/apache/airavata/research/repository/ExperimentSummaryRepository.java
+++ b/airavata-api/research-service/src/main/java/org/apache/airavata/research/repository/ExperimentSummaryRepository.java
@@ -26,6 +26,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import java.util.stream.Collectors;
 import org.apache.airavata.db.AbstractRepository;
 import org.apache.airavata.db.DBConstants;
@@ -300,153 +302,68 @@ public class ExperimentSummaryRepository
                 }
             }
 
-            int allExperimentsCount = getExperimentStatisticsCountForState(
-                    null,
-                    gatewayId,
-                    fromDate,
-                    toDate,
-                    userName,
-                    applicationName,
-                    resourceHostName,
-                    accessibleExperimentIds);
-            List<ExperimentSummaryModel> allExperiments = getExperimentStatisticsForState(
-                    null,
-                    gatewayId,
-                    fromDate,
-                    toDate,
-                    userName,
-                    applicationName,
-                    resourceHostName,
-                    accessibleExperimentIds,
-                    limit,
-                    offset);
-            experimentStatisticsBuilder.setAllExperimentCount(allExperimentsCount);
-            experimentStatisticsBuilder.addAllAllExperiments(allExperiments);
+            record StatGroup(
+                    List<ExperimentState> states,
+                    IntConsumer countSetter,
+                    Consumer<List<ExperimentSummaryModel>> listSetter) {}
 
-            List<ExperimentState> createdStates =
-                    Arrays.asList(ExperimentState.EXPERIMENT_STATE_CREATED, ExperimentState.EXPERIMENT_STATE_VALIDATED);
-            int createdExperimentsCount = getExperimentStatisticsCountForState(
-                    createdStates,
-                    gatewayId,
-                    fromDate,
-                    toDate,
-                    userName,
-                    applicationName,
-                    resourceHostName,
-                    accessibleExperimentIds);
-            List<ExperimentSummaryModel> createdExperiments = getExperimentStatisticsForState(
-                    createdStates,
-                    gatewayId,
-                    fromDate,
-                    toDate,
-                    userName,
-                    applicationName,
-                    resourceHostName,
-                    accessibleExperimentIds,
-                    limit,
-                    offset);
-            experimentStatisticsBuilder.setCreatedExperimentCount(createdExperimentsCount);
-            experimentStatisticsBuilder.addAllCreatedExperiments(createdExperiments);
+            List<StatGroup> statGroups = Arrays.asList(
+                    new StatGroup(
+                            null,
+                            experimentStatisticsBuilder::setAllExperimentCount,
+                            experimentStatisticsBuilder::addAllAllExperiments),
+                    new StatGroup(
+                            Arrays.asList(
+                                    ExperimentState.EXPERIMENT_STATE_CREATED,
+                                    ExperimentState.EXPERIMENT_STATE_VALIDATED),
+                            experimentStatisticsBuilder::setCreatedExperimentCount,
+                            experimentStatisticsBuilder::addAllCreatedExperiments),
+                    new StatGroup(
+                            Arrays.asList(
+                                    ExperimentState.EXPERIMENT_STATE_EXECUTING,
+                                    ExperimentState.EXPERIMENT_STATE_SCHEDULED,
+                                    ExperimentState.EXPERIMENT_STATE_LAUNCHED),
+                            experimentStatisticsBuilder::setRunningExperimentCount,
+                            experimentStatisticsBuilder::addAllRunningExperiments),
+                    new StatGroup(
+                            Arrays.asList(ExperimentState.EXPERIMENT_STATE_COMPLETED),
+                            experimentStatisticsBuilder::setCompletedExperimentCount,
+                            experimentStatisticsBuilder::addAllCompletedExperiments),
+                    new StatGroup(
+                            Arrays.asList(ExperimentState.EXPERIMENT_STATE_FAILED),
+                            experimentStatisticsBuilder::setFailedExperimentCount,
+                            experimentStatisticsBuilder::addAllFailedExperiments),
+                    new StatGroup(
+                            Arrays.asList(
+                                    ExperimentState.EXPERIMENT_STATE_CANCELED,
+                                    ExperimentState.EXPERIMENT_STATE_CANCELING),
+                            experimentStatisticsBuilder::setCancelledExperimentCount,
+                            experimentStatisticsBuilder::addAllCancelledExperiments));
 
-            List<ExperimentState> runningStates = Arrays.asList(
-                    ExperimentState.EXPERIMENT_STATE_EXECUTING,
-                    ExperimentState.EXPERIMENT_STATE_SCHEDULED,
-                    ExperimentState.EXPERIMENT_STATE_LAUNCHED);
-            int runningExperimentsCount = getExperimentStatisticsCountForState(
-                    runningStates,
-                    gatewayId,
-                    fromDate,
-                    toDate,
-                    userName,
-                    applicationName,
-                    resourceHostName,
-                    accessibleExperimentIds);
-            List<ExperimentSummaryModel> runningExperiments = getExperimentStatisticsForState(
-                    runningStates,
-                    gatewayId,
-                    fromDate,
-                    toDate,
-                    userName,
-                    applicationName,
-                    resourceHostName,
-                    accessibleExperimentIds,
-                    limit,
-                    offset);
-            experimentStatisticsBuilder.setRunningExperimentCount(runningExperimentsCount);
-            experimentStatisticsBuilder.addAllRunningExperiments(runningExperiments);
-
-            List<ExperimentState> completedStates = Arrays.asList(ExperimentState.EXPERIMENT_STATE_COMPLETED);
-            int completedExperimentsCount = getExperimentStatisticsCountForState(
-                    completedStates,
-                    gatewayId,
-                    fromDate,
-                    toDate,
-                    userName,
-                    applicationName,
-                    resourceHostName,
-                    accessibleExperimentIds);
-            List<ExperimentSummaryModel> completedExperiments = getExperimentStatisticsForState(
-                    completedStates,
-                    gatewayId,
-                    fromDate,
-                    toDate,
-                    userName,
-                    applicationName,
-                    resourceHostName,
-                    accessibleExperimentIds,
-                    limit,
-                    offset);
-            experimentStatisticsBuilder.setCompletedExperimentCount(completedExperimentsCount);
-            experimentStatisticsBuilder.addAllCompletedExperiments(completedExperiments);
-
-            List<ExperimentState> failedStates = Arrays.asList(ExperimentState.EXPERIMENT_STATE_FAILED);
-            int failedExperimentsCount = getExperimentStatisticsCountForState(
-                    failedStates,
-                    gatewayId,
-                    fromDate,
-                    toDate,
-                    userName,
-                    applicationName,
-                    resourceHostName,
-                    accessibleExperimentIds);
-            List<ExperimentSummaryModel> failedExperiments = getExperimentStatisticsForState(
-                    failedStates,
-                    gatewayId,
-                    fromDate,
-                    toDate,
-                    userName,
-                    applicationName,
-                    resourceHostName,
-                    accessibleExperimentIds,
-                    limit,
-                    offset);
-            experimentStatisticsBuilder.setFailedExperimentCount(failedExperimentsCount);
-            experimentStatisticsBuilder.addAllFailedExperiments(failedExperiments);
-
-            List<ExperimentState> cancelledStates = Arrays.asList(
-                    ExperimentState.EXPERIMENT_STATE_CANCELED, ExperimentState.EXPERIMENT_STATE_CANCELING);
-            int cancelledExperimentsCount = getExperimentStatisticsCountForState(
-                    cancelledStates,
-                    gatewayId,
-                    fromDate,
-                    toDate,
-                    userName,
-                    applicationName,
-                    resourceHostName,
-                    accessibleExperimentIds);
-            List<ExperimentSummaryModel> cancelledExperiments = getExperimentStatisticsForState(
-                    cancelledStates,
-                    gatewayId,
-                    fromDate,
-                    toDate,
-                    userName,
-                    applicationName,
-                    resourceHostName,
-                    accessibleExperimentIds,
-                    limit,
-                    offset);
-            experimentStatisticsBuilder.setCancelledExperimentCount(cancelledExperimentsCount);
-            experimentStatisticsBuilder.addAllCancelledExperiments(cancelledExperiments);
+            for (StatGroup group : statGroups) {
+                int count = getExperimentStatisticsCountForState(
+                        group.states(),
+                        gatewayId,
+                        fromDate,
+                        toDate,
+                        userName,
+                        applicationName,
+                        resourceHostName,
+                        accessibleExperimentIds);
+                List<ExperimentSummaryModel> experiments = getExperimentStatisticsForState(
+                        group.states(),
+                        gatewayId,
+                        fromDate,
+                        toDate,
+                        userName,
+                        applicationName,
+                        resourceHostName,
+                        accessibleExperimentIds,
+                        limit,
+                        offset);
+                group.countSetter().accept(count);
+                group.listSetter().accept(experiments);
+            }
 
             return experimentStatisticsBuilder.build();
         } catch (RegistryException e) {

--- a/airavata-api/research-service/src/main/java/org/apache/airavata/research/service/ResearchHubService.java
+++ b/airavata-api/research-service/src/main/java/org/apache/airavata/research/service/ResearchHubService.java
@@ -54,6 +54,7 @@ public class ResearchHubService {
     private final SessionService sessionService;
     private final ResearchProjectRepository projectRepository;
     private final ResearchProperties researchProperties;
+    private final RestTemplate restTemplate = new RestTemplate();
 
     public ResearchHubService(
             ResearchProjectService researchProjectService,
@@ -67,36 +68,30 @@ public class ResearchHubService {
     }
 
     public boolean stopSession(String sessionId) {
-        String userId = UserContext.userId();
-        String url = String.format(SERVERS_API_URL, researchProperties.getHubUrl(), userId, sessionId);
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "token " + researchProperties.getAdminApiKey());
-        HttpEntity<Void> request = new HttpEntity<>(headers);
-
-        ResponseEntity<Void> response = new RestTemplate().exchange(url, HttpMethod.DELETE, request, Void.class);
-
-        if (response.getStatusCode().is2xxSuccessful()) {
-            LOGGER.info("Successfully stopped/deleted RHub session {} for user {}", sessionId, userId);
-            return true;
-        } else {
-            throw new RuntimeException("Failed to delete RHub session " + sessionId + " for user " + userId);
-        }
+        return deleteHubSession(sessionId, false);
     }
 
     public boolean deleteSession(String sessionId) {
+        return deleteHubSession(sessionId, true);
+    }
+
+    private boolean deleteHubSession(String sessionId, boolean remove) {
         String userId = UserContext.userId();
         String url = String.format(SERVERS_API_URL, researchProperties.getHubUrl(), userId, sessionId);
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "token " + researchProperties.getAdminApiKey());
 
-        Map<String, Object> body = new HashMap<>();
-        body.put("remove", true);
+        HttpEntity<?> request;
+        if (remove) {
+            Map<String, Object> body = new HashMap<>();
+            body.put("remove", true);
+            request = new HttpEntity<>(body, headers);
+        } else {
+            request = new HttpEntity<>(headers);
+        }
 
-        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
-
-        ResponseEntity<Void> response = new RestTemplate().exchange(url, HttpMethod.DELETE, request, Void.class);
+        ResponseEntity<Void> response = restTemplate.exchange(url, HttpMethod.DELETE, request, Void.class);
 
         if (response.getStatusCode().is2xxSuccessful()) {
             LOGGER.info("Successfully stopped/deleted RHub session {} for user {}", sessionId, userId);


### PR DESCRIPTION
Two intra-class dedups in research-service. ExperimentSummaryRepository.getAccessibleExperimentStatistics repeated six near-identical count-and-list-per-state blocks (all/created/running/completed/failed/cancelled); they now drive a small table of (state list, count setter, list setter) records through a single loop, with the 'all' row carrying a null state list built via Arrays.asList (the underlying filterExperimentStatisticsQuery already treats null as 'no state filter'), and the helper methods and public signature untouched. ResearchHubService.stopSession and deleteSession differed only by a {remove:true} request body; they now delegate to a single deleteHubSession(sessionId, remove) helper that reuses one RestTemplate instance field instead of allocating one per call (matching the agent-service precedent, not a new Spring bean). Behavior-preserving; the full reactor builds green and research-service's 53 tests, including ExperimentSummaryRepositoryTest, pass.