### PR TITLE
Read the canonical kafka.broker.url key in KafkaProxyService

### DIFF
--- a/airavata-server/src/main/java/org/apache/airavata/server/kafka/KafkaProxyService.java
+++ b/airavata-server/src/main/java/org/apache/airavata/server/kafka/KafkaProxyService.java
@@ -40,7 +40,7 @@ public class KafkaProxyService {
 
     private final KafkaProducer<String, String> producer;
 
-    public KafkaProxyService(@Value("${airavata.kafka.broker-url:localhost:9092}") String brokerUrl) {
+    public KafkaProxyService(@Value("${kafka.broker.url:localhost:9092}") String brokerUrl) {
         Properties props = new Properties();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerUrl);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());

--- a/compose.yml
+++ b/compose.yml
@@ -194,7 +194,6 @@ services:
       JAVA_TOOL_OPTIONS: >-
         -Dspring.datasource.url=jdbc:mariadb://db:3306/airavata
         -Dkafka.broker.url=kafka:9092
-        -Dairavata.kafka.broker-url=kafka:9092
         -Drabbitmq.broker.url=amqp://airavata:airavata@rabbitmq:5672
         -Dspring.rabbitmq.host=rabbitmq
         -Dspring.rabbitmq.port=5672


### PR DESCRIPTION
KafkaProxyService injected the value of ${airavata.kafka.broker-url}, a hyphenated key that is set only in the local Tilt/DinD compose environment. Every real configuration source (airavata-server/src/main/resources/application.properties and the ansible templates) defines the canonical kafka.broker.url instead, so in actual deployments the proxy never saw a broker URL and silently fell back to localhost:9092. This points the @Value at kafka.broker.url (same localhost default) and removes the now-redundant -Dairavata.kafka.broker-url override from compose.yml. Compiles green.