### PR TITLE
Drop the JavaScript/TypeScript CodeQL analysis (no JS/TS in the repo)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,8 +49,6 @@ jobs:
           build-mode: autobuild
         - language: java-kotlin
           build-mode: none # This mode only analyzes Java. Set this to 'autobuild' or 'manual' to analyze Kotlin too.
-        - language: javascript-typescript
-          build-mode: none
         - language: python
           build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'


### PR DESCRIPTION
The repository no longer contains any JavaScript or TypeScript source (git ls-files for *.js/*.ts/*.jsx/*.tsx/*.vue returns nothing), so the javascript-typescript CodeQL job has no code to scan and fails on every PR. This removes that single entry from the CodeQL language matrix, leaving actions, go, java-kotlin and python.