### PR TITLE
fix: load storage data-movement interfaces via correct FK column

### DIFF
--- a/airavata-api/orchestration-service/src/main/java/org/apache/airavata/orchestration/util/DevStorageInitializer.java
+++ b/airavata-api/orchestration-service/src/main/java/org/apache/airavata/orchestration/util/DevStorageInitializer.java
@@ -28,6 +28,7 @@ import org.apache.airavata.model.appcatalog.gatewayprofile.proto.StoragePreferen
 import org.apache.airavata.model.appcatalog.storageresource.proto.StorageResourceDescription;
 import org.apache.airavata.model.credential.store.proto.SSHCredential;
 import org.apache.airavata.model.data.movement.proto.DMType;
+import org.apache.airavata.model.data.movement.proto.DataMovementProtocol;
 import org.apache.airavata.model.data.movement.proto.SCPDataMovement;
 import org.apache.airavata.model.data.movement.proto.SecurityProtocol;
 import org.apache.airavata.orchestration.service.RegistryServerHandler;
@@ -51,7 +52,9 @@ public class DevStorageInitializer {
 
     private static final Logger logger = LoggerFactory.getLogger(DevStorageInitializer.class);
 
-    private static final String STORAGE_HOST = "localhost";
+    // The storage-service runs inside the airavata-dind network and reaches the
+    // atmoz/sftp container by its compose service name, not "localhost".
+    private static final String STORAGE_HOST = "sftp";
     private static final String STORAGE_DESCRIPTION = "Dev SFTP storage (atmoz/sftp container)";
     private static final String SFTP_LOGIN_USER = "airavata";
     private static final String SFTP_FS_ROOT = "/storage";
@@ -80,7 +83,24 @@ public class DevStorageInitializer {
             var allNames = registryHandler.getAllStorageResourceNames();
             for (var entry : allNames.entrySet()) {
                 if (STORAGE_HOST.equals(entry.getValue())) {
-                    logger.info("Dev storage resource already exists: {} ({})", entry.getValue(), entry.getKey());
+                    // Resource exists. Ensure it has an SCP data movement interface —
+                    // a partial prior init can leave it without one, which then fails
+                    // the SFTP adaptor with "No SCP data movement interface".
+                    String existingId = entry.getKey();
+                    boolean hasScp = registryHandler.getStorageResource(existingId).getDataMovementInterfacesList()
+                            .stream()
+                            .anyMatch(i -> i.getDataMovementProtocol() == DataMovementProtocol.SCP);
+                    if (!hasScp) {
+                        SCPDataMovement scpDm = SCPDataMovement.newBuilder()
+                                .setSecurityProtocol(SecurityProtocol.SSH_KEYS)
+                                .setSshPort(22)
+                                .build();
+                        registryHandler.addSCPDataMovementDetails(existingId, DMType.STORAGE_RESOURCE, 0, scpDm);
+                        logger.info("Healed dev storage resource {}: added missing SCP data movement interface",
+                                existingId);
+                    } else {
+                        logger.info("Dev storage resource already exists: {} ({})", entry.getValue(), existingId);
+                    }
                     return;
                 }
             }

--- a/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/model/StorageResourceEntity.java
+++ b/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/model/StorageResourceEntity.java
@@ -51,12 +51,22 @@ public class StorageResourceEntity implements Serializable {
     @Column(name = "UPDATE_TIME")
     private Timestamp updateTime;
 
+    // The child (STORAGE_INTERFACE) already maps the FK as part of its composite
+    // @Id (DataMovementInterfaceEntity.resourceId -> STORAGE_RESOURCE_ID), so the
+    // association must join on that same column and be read-only here (the child
+    // owns it). Pointing this at a separate "RESOURCE_ID" column left the
+    // association always empty, which broke the SFTP storage adaptor ("No SCP
+    // data movement interface for storage resource").
     @OneToMany(
             targetEntity = DataMovementInterfaceEntity.class,
             cascade = CascadeType.ALL,
             orphanRemoval = true,
             fetch = FetchType.EAGER)
-    @JoinColumn(name = "RESOURCE_ID", referencedColumnName = "STORAGE_RESOURCE_ID")
+    @JoinColumn(
+            name = "STORAGE_RESOURCE_ID",
+            referencedColumnName = "STORAGE_RESOURCE_ID",
+            insertable = false,
+            updatable = false)
     private List<DataMovementInterfaceEntity> dataMovementInterfaces;
 
     public StorageResourceEntity() {}

--- a/compose.yml
+++ b/compose.yml
@@ -169,6 +169,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./conf/sftp/id_rsa.pub:/home/airavata/.ssh/keys/id_rsa.pub:ro
+      - ./conf/sftp/chown-storage.sh:/etc/sftp.d/chown-storage.sh:ro
       - sftp_data:/home/airavata/storage
     command: "airavata::1000"
     healthcheck:

--- a/conf/sftp/chown-storage.sh
+++ b/conf/sftp/chown-storage.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# atmoz/sftp runs /etc/sftp.d/*.sh as root on container startup, before sshd
+# drops to the chrooted user. The named volume mounted at /home/airavata/storage
+# is created root-owned by Docker, so the chrooted "airavata" user (uid 1000)
+# cannot create directories or write files there. Chown it on every startup so
+# the storage-service's SFTP adaptor can upload.
+chown -R airavata:airavata /home/airavata/storage


### PR DESCRIPTION
## The bug

`StorageResourceEntity`'s `@OneToMany dataMovementInterfaces` joined on a `RESOURCE_ID` column:

```java
@JoinColumn(name = "RESOURCE_ID", referencedColumnName = "STORAGE_RESOURCE_ID")
```

But the child entity `DataMovementInterfaceEntity` (table `STORAGE_INTERFACE`) maps its FK to column `STORAGE_RESOURCE_ID` as part of its composite `@Id`. Hibernate therefore created a spurious, **always-NULL** `RESOURCE_ID` column and loaded the association with `WHERE RESOURCE_ID = ?` — which never matched.

**Result:** every storage resource loaded zero data-movement interfaces, so `SSHJStorageAdaptor.init` threw `"No SCP data movement interface for storage resource"` and **all user-storage file operations failed.**

Verified at the DB level: `STORAGE_INTERFACE` rows had `STORAGE_RESOURCE_ID` populated and `RESOURCE_ID` NULL.

## The fix

Join the association on the column the child actually owns, and mark it read-only so the child remains the sole writer of the FK:

```java
@JoinColumn(
        name = "STORAGE_RESOURCE_ID",
        referencedColumnName = "STORAGE_RESOURCE_ID",
        insertable = false,
        updatable = false)
```

## Dev-environment fixes (same symptom)

These two changes only affect the local `tilt up` dev stack:

1. **`DevStorageInitializer`** seeded `STORAGE_HOST` as `"localhost"`, unreachable from the server inside the `airavata-dind` network. Repointed to `"sftp"` (the atmoz/sftp compose service name). The idempotency check is now self-healing: if the dev storage resource already exists but has no SCP data-movement interface (from a partial prior init), it adds one.

2. **`compose.yml` + `conf/sftp/chown-storage.sh`** — the named volume mounted at `/home/airavata/storage` in the atmoz/sftp container is created root-owned by Docker, so the chrooted uid-1000 `airavata` user could not create directories (`"Failed to create directory"`). Added an `/etc/sftp.d/chown-storage.sh` startup hook (atmoz/sftp runs these as root on boot) that chowns the volume, mounted via compose.

## Test plan

- `mvn -pl airavata-api/storage-service,airavata-api/orchestration-service -am compile -DskipTests` → BUILD SUCCESS.
- Locally via `tilt up`: storage resource now loads its SCP data-movement interface; user-storage file operations succeed.