### PR TITLE
fix(python-sdk): correct data-product request field name to product_uri

### DIFF
--- a/airavata-python-sdk/airavata_sdk/facade/research.py
+++ b/airavata-python-sdk/airavata_sdk/facade/research.py
@@ -552,7 +552,7 @@ class ResearchClient:
     def get_data_product(self, data_product_uri):
         pb2 = self._svc("data_product_service_pb2")
         return self._data_product.GetDataProduct(
-            pb2.GetDataProductRequest(data_product_uri=data_product_uri),
+            pb2.GetDataProductRequest(product_uri=data_product_uri),
             metadata=self._metadata,
         )
 
@@ -567,14 +567,14 @@ class ResearchClient:
     def get_parent_data_product(self, data_product_uri):
         pb2 = self._svc("data_product_service_pb2")
         return self._data_product.GetParentDataProduct(
-            pb2.GetParentDataProductRequest(data_product_uri=data_product_uri),
+            pb2.GetParentDataProductRequest(product_uri=data_product_uri),
             metadata=self._metadata,
         )
 
     def get_child_data_products(self, data_product_uri):
         pb2 = self._svc("data_product_service_pb2")
         response = self._data_product.GetChildDataProducts(
-            pb2.GetChildDataProductsRequest(data_product_uri=data_product_uri),
+            pb2.GetChildDataProductsRequest(product_uri=data_product_uri),
             metadata=self._metadata,
         )
         return list(response.data_products)


### PR DESCRIPTION
## Summary

The `DataProductService` request messages name their URI field **`product_uri`**, but three `ResearchClient` facade methods in `airavata-python-sdk/airavata_sdk/facade/research.py` constructed those requests with the keyword **`data_product_uri=`**. protobuf rejects an unknown field keyword at message construction, so every call raised:

```
ValueError: Protocol message GetDataProductRequest has no "data_product_uri" field.
```

before it ever reached the server — i.e. `get_data_product`, `get_parent_data_product`, and `get_child_data_products` were completely non-functional. This surfaced while migrating the Django portal's data-product read path onto the gRPC SDK (every `get_data_product` call hard-failed).

## Fix

Pass the correct `product_uri=` keyword in all three methods:

- `get_data_product` → `GetDataProductRequest(product_uri=...)`
- `get_parent_data_product` → `GetParentDataProductRequest(product_uri=...)`
- `get_child_data_products` → `GetChildDataProductsRequest(product_uri=...)`

## Verification

Checked every data-product request descriptor; the URI field is `product_uri` on all three (`GetDataProductRequest` / `GetParentDataProductRequest` / `GetChildDataProductsRequest`). Confirmed the corrected `product_uri=` constructions succeed and the old `data_product_uri=` keyword raises `ValueError` on each. The fixed `get_data_product` was exercised live against the running server (reaches the backend instead of failing at construction).

## Notes for reviewers

I reviewed the sibling data-product / replica methods in the same facade for the same class of mismatch:

- `register_data_product` / `update_data_product` / `delete_data_product` / `get_replica_location` use the correct keywords (`data_product`, `product_uri`, `replica_id`) — no change.
- **Separate observation (not changed here):** `register_replica_location` only passes `replica_location=...`, but `RegisterReplicaLocationRequest` also has a `product_uri` field. That is a possible *missing-association* issue rather than a wrong-name crash, and fixing it correctly needs the intended semantics (which product the replica attaches to), so I left it out of this focused field-name bug-fix. Flagging for a maintainer.