### PR TITLE
fix(research-service): persist and read back data-product replica locations

### DIFF
--- a/airavata-api/research-service/src/main/java/org/apache/airavata/research/mapper/ResearchMapper.java
+++ b/airavata-api/research-service/src/main/java/org/apache/airavata/research/mapper/ResearchMapper.java
@@ -121,12 +121,85 @@ public interface ResearchMapper extends CommonMapperConversions {
     NotificationEntity notificationToEntity(Notification model);
 
     // --- DataProductModel ---
-    DataProductModel dataProductToModel(DataProductEntity entity);
+    // Hand-written rather than MapStruct-generated: a protobuf Builder's map getter
+    // returns an immutable view, so the generated `builder.getProductMetadata().putAll(..)`
+    // throws UnsupportedOperationException. Use the builder's putAll* accessor instead,
+    // and map the repeated replicaLocations (which MapStruct silently drops). Same proto
+    // hand-mapping pattern as appDeploymentToModel above.
+    default DataProductModel dataProductToModel(DataProductEntity entity) {
+        if (entity == null) return null;
+        DataProductModel.Builder builder = DataProductModel.newBuilder();
+        if (entity.getProductUri() != null) builder.setProductUri(entity.getProductUri());
+        if (entity.getGatewayId() != null) builder.setGatewayId(entity.getGatewayId());
+        if (entity.getParentProductUri() != null) builder.setParentProductUri(entity.getParentProductUri());
+        if (entity.getProductName() != null) builder.setProductName(entity.getProductName());
+        if (entity.getProductDescription() != null) builder.setProductDescription(entity.getProductDescription());
+        if (entity.getOwnerName() != null) builder.setOwnerName(entity.getOwnerName());
+        if (entity.getDataProductType() != null) builder.setDataProductType(entity.getDataProductType());
+        builder.setProductSize(entity.getProductSize());
+        builder.setCreationTime(timestampToLong(entity.getCreationTime()));
+        builder.setLastModifiedTime(timestampToLong(entity.getLastModifiedTime()));
+        if (entity.getProductMetadata() != null) {
+            builder.putAllProductMetadata(entity.getProductMetadata());
+        }
+        if (entity.getReplicaLocations() != null) {
+            for (DataReplicaLocationEntity replica : entity.getReplicaLocations()) {
+                builder.addReplicaLocations(dataReplicaToModel(replica));
+            }
+        }
+        return builder.build();
+    }
 
-    DataProductEntity dataProductToEntity(DataProductModel model);
+    // Hand-written so the nested replicaLocations are mapped: MapStruct silently
+    // drops the proto repeated -> entity collection mapping, so a registered data
+    // product would persist with no replica (losing its file path).
+    default DataProductEntity dataProductToEntity(DataProductModel model) {
+        if (model == null) return null;
+        DataProductEntity entity = new DataProductEntity();
+        entity.setProductUri(model.getProductUri());
+        entity.setGatewayId(model.getGatewayId());
+        entity.setProductName(model.getProductName());
+        entity.setProductDescription(model.getProductDescription());
+        entity.setOwnerName(model.getOwnerName());
+        entity.setParentProductUri(model.getParentProductUri());
+        entity.setProductSize(model.getProductSize());
+        entity.setCreationTime(longToTimestamp(model.getCreationTime()));
+        entity.setLastModifiedTime(longToTimestamp(model.getLastModifiedTime()));
+        entity.setDataProductType(model.getDataProductType());
+        if (model.getProductMetadataMap() != null) {
+            entity.setProductMetadata(new LinkedHashMap<>(model.getProductMetadataMap()));
+        }
+        List<DataReplicaLocationEntity> replicas = new ArrayList<>();
+        for (DataReplicaLocationModel replica : model.getReplicaLocationsList()) {
+            replicas.add(dataReplicaToEntity(replica));
+        }
+        entity.setReplicaLocations(replicas);
+        return entity;
+    }
 
     // --- DataReplicaLocationModel ---
-    DataReplicaLocationModel dataReplicaToModel(DataReplicaLocationEntity entity);
+    // Hand-written for the same proto immutable-map reason as dataProductToModel.
+    default DataReplicaLocationModel dataReplicaToModel(DataReplicaLocationEntity entity) {
+        if (entity == null) return null;
+        DataReplicaLocationModel.Builder builder = DataReplicaLocationModel.newBuilder();
+        if (entity.getReplicaId() != null) builder.setReplicaId(entity.getReplicaId());
+        if (entity.getProductUri() != null) builder.setProductUri(entity.getProductUri());
+        if (entity.getReplicaName() != null) builder.setReplicaName(entity.getReplicaName());
+        if (entity.getReplicaDescription() != null) builder.setReplicaDescription(entity.getReplicaDescription());
+        builder.setCreationTime(timestampToLong(entity.getCreationTime()));
+        builder.setLastModifiedTime(timestampToLong(entity.getLastModifiedTime()));
+        builder.setValidUntilTime(timestampToLong(entity.getValidUntilTime()));
+        if (entity.getReplicaLocationCategory() != null)
+            builder.setReplicaLocationCategory(entity.getReplicaLocationCategory());
+        if (entity.getReplicaPersistentType() != null)
+            builder.setReplicaPersistentType(entity.getReplicaPersistentType());
+        if (entity.getStorageResourceId() != null) builder.setStorageResourceId(entity.getStorageResourceId());
+        if (entity.getFilePath() != null) builder.setFilePath(entity.getFilePath());
+        if (entity.getReplicaMetadata() != null) {
+            builder.putAllReplicaMetadata(entity.getReplicaMetadata());
+        }
+        return builder.build();
+    }
 
     DataReplicaLocationEntity dataReplicaToEntity(DataReplicaLocationModel model);
 

--- a/airavata-api/research-service/src/main/java/org/apache/airavata/research/repository/DataProductRepository.java
+++ b/airavata-api/research-service/src/main/java/org/apache/airavata/research/repository/DataProductRepository.java
@@ -98,7 +98,12 @@ public class DataProductRepository extends AbstractRepository<DataProductModel, 
             throw new ReplicaCatalogException("Owner name and gateway ID should not be empty");
         }
 
+        // A top-level (parentless) data product has no parent URI. Protobuf string
+        // fields default to "" rather than null, so an unset parent_product_uri
+        // arrives here as an empty string; treat that the same as null and skip the
+        // parent-Collection check (otherwise every top-level registration fails).
         if (dataProductEntity.getParentProductUri() != null
+                && !dataProductEntity.getParentProductUri().isEmpty()
                 && (!isExists(dataProductEntity.getParentProductUri())
                         || !getDataProduct(dataProductEntity.getParentProductUri())
                                 .getDataProductType()
@@ -118,7 +123,11 @@ public class DataProductRepository extends AbstractRepository<DataProductModel, 
             logger.debug("Populating the product URI for ReplicaLocations objects for the Data Product");
             dataProductEntity.getReplicaLocations().forEach(dataReplicaLocationEntity -> {
                 dataReplicaLocationEntity.setProductUri(productUri);
-                if (dataReplicaLocationEntity.getReplicaId() == null) {
+                // proto3 string fields default to "" (not null), so a replica with no
+                // client-supplied id arrives with an empty REPLICA_ID. Generate one;
+                // otherwise every replica collides on the same empty primary key.
+                if (dataReplicaLocationEntity.getReplicaId() == null
+                        || dataReplicaLocationEntity.getReplicaId().isEmpty()) {
                     dataReplicaLocationEntity.setReplicaId(UUID.randomUUID().toString());
                 }
                 if (!dataReplicaLocationRepository.isExists(dataReplicaLocationEntity.getReplicaId())) {


### PR DESCRIPTION
## Summary

Registering a data product through the gRPC `DataProductService` and reading it back did not round-trip, which breaks the storage / data-product flow the Django portal depends on (and any gRPC client that registers a data product). Four related defects, all from the Thrift→proto migration of `ResearchMapper` / `DataProductRepository` (proto3 string fields default to `""` rather than `null`, and MapStruct mishandles proto builders):

1. **Top-level (parentless) registration always failed.** `DataProductRepository.saveDataProduct` guarded the parent-Collection check with only `getParentProductUri() != null`. A proto3 string field defaults to `""`, so the check ran for every parentless product, looked up the non-existent `""` parent, and threw *"Parent product does not exist or parent type is not Collection"*. The legacy Thrift model had `parentProductUri == null`. Fix: treat an empty parent URI the same as null.

2. **Every replica collided on an empty primary key.** `REPLICA_ID` was generated only when `null`, but a proto3 replica with no client-supplied id arrives with an empty `""` id, so the UUID was never assigned. All replicas shared PK `""` — only a single replica row ever existed in the table, reused/overwritten by each registration. Fix: generate the id when empty too.

3. **Reading any data product threw `UnsupportedOperationException`.** The MapStruct-generated `dataProductToModel` did `builder.getProductMetadata().putAll(map)`, but a protobuf `Builder`'s map getter returns an **immutable** view, so `putAll` throws — surfaced to clients as gRPC `INTERNAL` *"Failed to get entity"*. The generated mapper also silently dropped the repeated `replicaLocations`.

4. **Registration persisted no replica.** `dataProductToEntity` likewise dropped `replicaLocations`, so a registered product was saved with no replica — losing its file path entirely.

## Fix

- Treat empty `parentProductUri` / `replicaId` as unset in `DataProductRepository.saveDataProduct`.
- Hand-write `dataProductToModel`, `dataProductToEntity`, and `dataReplicaToModel` as `default` interface methods that use the proto `Builder`'s `putAll*` accessors and map the nested `replicaLocations` explicitly. This matches the existing hand-written proto mappers already in `ResearchMapper` (e.g. `appDeploymentToModel`), which are hand-written for exactly this proto-builder reason.

## Validation

- **Live, against the running server (gRPC):** `upload_file` → `register_data_product` → `get_data_product` now round-trips `productName`/`ownerName`/`dataProductType`/`productMetadata`/`productSize` **and** the replica (`filePath`, category, persistent type, storage resource id); `download_file` streams the original bytes back. Confirmed in the DB that each registration now inserts a distinct replica row.
- **Unit tests:** `mvn test -pl airavata-api/research-service` → 53 pass, 0 failures.