### PR TITLE
feat(storage-service): complete file-listing metadata + fix SFTP file delete

### DIFF
--- a/airavata-api/compute-service/src/main/java/org/apache/airavata/compute/util/SSHJStorageAdaptor.java
+++ b/airavata-api/compute-service/src/main/java/org/apache/airavata/compute/util/SSHJStorageAdaptor.java
@@ -148,9 +148,13 @@ public class SSHJStorageAdaptor implements StorageResourceAdaptor {
         try (SFTPClient sftp = openSftp()) {
             FileAttributes attrs = sftp.stat(remoteFile);
             FileMetadata meta = new FileMetadata();
-            meta.setName(remoteFile.substring(remoteFile.lastIndexOf('/') + 1));
+            String name = remoteFile.substring(remoteFile.lastIndexOf('/') + 1);
+            meta.setName(name);
             meta.setSize(attrs.getSize());
             meta.setDirectory(attrs.getType() == FileMode.Type.DIRECTORY);
+            // SFTP mtime is seconds since the epoch; expose it as epoch millis.
+            meta.setModifiedTime(attrs.getMtime() * 1000L);
+            meta.setContentType(java.net.URLConnection.guessContentTypeFromName(name));
             return meta;
         } catch (Exception e) {
             throw new AgentException("Failed to get file metadata: " + remoteFile, e);

--- a/airavata-api/src/main/java/org/apache/airavata/interfaces/FileMetadata.java
+++ b/airavata-api/src/main/java/org/apache/airavata/interfaces/FileMetadata.java
@@ -25,6 +25,8 @@ public class FileMetadata {
     private long size;
     private int permissions = 420;
     private boolean isDirectory;
+    private long modifiedTime;
+    private String contentType;
 
     public String getName() {
         return name;
@@ -56,5 +58,23 @@ public class FileMetadata {
 
     public void setDirectory(boolean isDirectory) {
         this.isDirectory = isDirectory;
+    }
+
+    /** Last-modified time in epoch milliseconds, or 0 if unknown. */
+    public long getModifiedTime() {
+        return modifiedTime;
+    }
+
+    public void setModifiedTime(long modifiedTime) {
+        this.modifiedTime = modifiedTime;
+    }
+
+    /** MIME content type guessed from the file name, or null if unknown. */
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
     }
 }

--- a/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/grpc/UserStorageGrpcService.java
+++ b/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/grpc/UserStorageGrpcService.java
@@ -422,6 +422,8 @@ public class UserStorageGrpcService extends UserStorageServiceGrpc.UserStorageSe
                 .setPath(path)
                 .setSize(meta.getSize())
                 .setIsDirectory(meta.isDirectory())
+                .setModifiedTime(meta.getModifiedTime())
+                .setContentType(meta.getContentType() != null ? meta.getContentType() : "")
                 .build();
     }
 }


### PR DESCRIPTION
## Summary

Make the gRPC `UserStorageService` usable as the portal's file backend: fill in the per-file listing metadata the file browser needs, and fix file deletion. Three cohesive parts (all storage-service):

### 1. modified-time + content-type in listings
`list_dir` / `get_file_metadata` / `list_experiment_dir` only carried name/path/size/is_directory. Now:
- `FileMetadata` gains `modifiedTime` (epoch millis) and `contentType`.
- `SSHJStorageAdaptor.getFileMetadata` sets `modifiedTime` from the SFTP `stat` mtime (s→ms) and guesses `contentType` from the file name. (`created_time` isn't available over SFTP, so it stays unset.)
- `UserStorageGrpcService.toFileMetadataResponse` copies both into the response.

### 2. per-file data-product URI
Listings now carry a **stable** data product URI per file, so clients reference each stored file by data product (downloads, deletes, selection) without a separate path→data-product table.
- `DataProductInterface`/`DataProductRepository`: `getDataProductByReplicaFilePath` (JPQL join on the replica `filePath` + gateway).
- `StorageProvider`/`StorageProviderImpl`: `getOrCreateDataProductByPath` returns that product's URI, registering a new `FILE` data product (single `GATEWAY_DATA_STORE` replica) if none exists.
- `UserStorageGrpcService` populates `FileMetadataResponse.data_product_uri` per file — best-effort (directories and lookup failures yield an empty URI, never a listing failure).

### 3. fix SFTP file delete
`deleteFile` ran `rm -f` via `adaptor.executeCommand`, but the SFTP adaptor does not support command execution, so every file delete failed with *"Command execution not supported on storage resources"*. Added `deleteFile` to the storage adaptor (SFTP `rm`) and call it — mirroring how `deleteDir` already uses `deleteDirectory` (SFTP `rmdir`).

Together these unblock the Django portal's storage-listing migration off the legacy Thrift SDK and remove the portal's need for its own `UserFiles` ORM mapping.

## Validation

- **Live against the running server:** an uploaded file's `get_file_metadata`/`list_dir` return `modified_time` (upload time), `content_type` (`text/plain` for `.txt`), and a `data_product_uri` that is **stable across calls** (found, not re-registered) and resolves via the data-product service to the file's replica; uploading then deleting a file now succeeds. Full portal CRUD round-trips through the views.
- `mvn test -pl airavata-api/storage-service,airavata-api/compute-service` and research-service tests pass (0 failures).