### PR TITLE
fix(storage-service): delete files over SFTP instead of shell rm

### DIFF
--- a/airavata-api/compute-service/src/main/java/org/apache/airavata/compute/util/SSHJStorageAdaptor.java
+++ b/airavata-api/compute-service/src/main/java/org/apache/airavata/compute/util/SSHJStorageAdaptor.java
@@ -195,6 +195,15 @@ public class SSHJStorageAdaptor implements StorageResourceAdaptor {
     }
 
     @Override
+    public void deleteFile(String path) throws AgentException {
+        try (SFTPClient sftp = openSftp()) {
+            sftp.rm(path);
+        } catch (Exception e) {
+            throw new AgentException("Failed to delete file: " + path, e);
+        }
+    }
+
+    @Override
     public void uploadFile(String localFile, String remoteFile) throws AgentException {
         try (SFTPClient sftp = openSftp()) {
             sftp.put(localFile, remoteFile);

--- a/airavata-api/src/main/java/org/apache/airavata/interfaces/StorageResourceAdaptor.java
+++ b/airavata-api/src/main/java/org/apache/airavata/interfaces/StorageResourceAdaptor.java
@@ -43,6 +43,8 @@ public interface StorageResourceAdaptor extends AgentAdaptor {
 
     public void deleteDirectory(String path) throws AgentException;
 
+    public void deleteFile(String path) throws AgentException;
+
     public List<String> listDirectory(String path) throws AgentException;
 
     public Boolean doesFileExist(String filePath) throws AgentException;

--- a/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/grpc/UserStorageGrpcService.java
+++ b/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/grpc/UserStorageGrpcService.java
@@ -276,7 +276,7 @@ public class UserStorageGrpcService extends UserStorageServiceGrpc.UserStorageSe
         try {
             StorageResourceAdaptor adaptor = getStorageAdaptor(request.getStorageResourceId());
             String path = resolvePath(request.getPath(), request.getStorageResourceId());
-            adaptor.executeCommand("rm -f " + path, "/");
+            adaptor.deleteFile(path);
             observer.onNext(Empty.getDefaultInstance());
             observer.onCompleted();
         } catch (Exception e) {


### PR DESCRIPTION
UserStorageService.deleteFile ran 'rm -f' via executeCommand, which the SFTP storage adaptor doesn't support, so every user-storage file delete failed with 'Command execution not supported on storage resources'. Add SSHJStorageAdaptor.deleteFile (SFTP remove) to the StorageResourceAdaptor interface and call it from deleteFile, mirroring how deleteDir already uses the adaptor's rmdir. Verified live: upload -> delete round-trips.