### PR TITLE
fix(storage-service): move/symlink over SFTP instead of shell commands

### DIFF
--- a/airavata-api/compute-service/src/main/java/org/apache/airavata/compute/util/SSHJStorageAdaptor.java
+++ b/airavata-api/compute-service/src/main/java/org/apache/airavata/compute/util/SSHJStorageAdaptor.java
@@ -204,6 +204,24 @@ public class SSHJStorageAdaptor implements StorageResourceAdaptor {
     }
 
     @Override
+    public void moveFile(String sourcePath, String destinationPath) throws AgentException {
+        try (SFTPClient sftp = openSftp()) {
+            sftp.rename(sourcePath, destinationPath);
+        } catch (Exception e) {
+            throw new AgentException("Failed to move file: " + sourcePath + " -> " + destinationPath, e);
+        }
+    }
+
+    @Override
+    public void createSymlink(String targetPath, String linkPath) throws AgentException {
+        try (SFTPClient sftp = openSftp()) {
+            sftp.symlink(linkPath, targetPath);
+        } catch (Exception e) {
+            throw new AgentException("Failed to create symlink: " + linkPath + " -> " + targetPath, e);
+        }
+    }
+
+    @Override
     public void uploadFile(String localFile, String remoteFile) throws AgentException {
         try (SFTPClient sftp = openSftp()) {
             sftp.put(localFile, remoteFile);

--- a/airavata-api/src/main/java/org/apache/airavata/interfaces/StorageResourceAdaptor.java
+++ b/airavata-api/src/main/java/org/apache/airavata/interfaces/StorageResourceAdaptor.java
@@ -45,6 +45,10 @@ public interface StorageResourceAdaptor extends AgentAdaptor {
 
     public void deleteFile(String path) throws AgentException;
 
+    public void moveFile(String sourcePath, String destinationPath) throws AgentException;
+
+    public void createSymlink(String targetPath, String linkPath) throws AgentException;
+
     public List<String> listDirectory(String path) throws AgentException;
 
     public Boolean doesFileExist(String filePath) throws AgentException;

--- a/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/grpc/UserStorageGrpcService.java
+++ b/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/grpc/UserStorageGrpcService.java
@@ -303,7 +303,7 @@ public class UserStorageGrpcService extends UserStorageServiceGrpc.UserStorageSe
             StorageResourceAdaptor adaptor = getStorageAdaptor(request.getStorageResourceId());
             String src = resolvePath(request.getSourcePath(), request.getStorageResourceId());
             String dst = resolvePath(request.getDestinationPath(), request.getStorageResourceId());
-            adaptor.executeCommand("mv " + src + " " + dst, "/");
+            adaptor.moveFile(src, dst);
 
             DataProductModel product = DataProductModel.newBuilder()
                     .setProductName(Paths.get(request.getDestinationPath())
@@ -338,7 +338,7 @@ public class UserStorageGrpcService extends UserStorageServiceGrpc.UserStorageSe
             StorageResourceAdaptor adaptor = getStorageAdaptor(request.getStorageResourceId());
             String target = resolvePath(request.getTargetPath(), request.getStorageResourceId());
             String source = resolvePath(request.getSourcePath(), request.getStorageResourceId());
-            adaptor.executeCommand("ln -s " + target + " " + source, "/");
+            adaptor.createSymlink(target, source);
             observer.onNext(Empty.getDefaultInstance());
             observer.onCompleted();
         } catch (Exception e) {


### PR DESCRIPTION
## Summary

`UserStorageService.moveFile` and `createSymlink` ran `mv` / `ln -s` via `adaptor.executeCommand`, but the SFTP storage adaptor does not support command execution, so both failed with *"Command execution not supported on storage resources"* — the same class of bug just fixed for `deleteFile` (#654). Add `moveFile` (SFTP `rename`) and `createSymlink` (SFTP `symlink`) to the storage adaptor and call them.

## Validation

- **Live against the running server:** moving a file relocates it (source gone, destination has the content); creating a symlink to a directory resolves through the link (listing the link shows the target's contents).
- `mvn test -pl airavata-api/storage-service,airavata-api/compute-service` → 35 pass, 0 failures.