### PR TITLE
perf(research-service): index DATA_REPLICA_LOCATION.FILE_PATH

### DIFF
--- a/airavata-api/research-service/src/main/java/org/apache/airavata/research/model/DataReplicaLocationEntity.java
+++ b/airavata-api/research-service/src/main/java/org/apache/airavata/research/model/DataReplicaLocationEntity.java
@@ -30,7 +30,12 @@ import org.apache.airavata.model.data.replica.proto.ReplicaPersistentType;
  * The persistent class for the data_replica_location database table.
  */
 @Entity
-@Table(name = "DATA_REPLICA_LOCATION")
+@Table(
+        name = "DATA_REPLICA_LOCATION",
+        // Index FILE_PATH so the get-or-create-by-path lookup used when listing a
+        // directory (resolving a data product URI per file) is an index seek, not a
+        // full scan per file.
+        indexes = @Index(name = "IDX_DATA_REPLICA_FILE_PATH", columnList = "FILE_PATH"))
 public class DataReplicaLocationEntity implements Serializable {
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
## Summary

The per-file data-product-URI resolution added in #653 (file listings) looks up a data product by its replica file path (`getDataProductByReplicaFilePath`). Listing a directory resolves one such lookup **per file**, so without an index on `FILE_PATH` each lookup was a full scan of `DATA_REPLICA_LOCATION` — N scans for an N-file directory.

Add an index on `FILE_PATH` via `@Index` on `DataReplicaLocationEntity` (`IDX_DATA_REPLICA_FILE_PATH`), created by Hibernate `ddl-auto=update` on the running schema. `FILE_PATH` is `varchar(255)`, so it indexes without a prefix length.

## Validation

- **Live:** the lookup query's plan is now an index ref seek on the replica table (`type=ref, key=IDX_DATA_REPLICA_FILE_PATH, rows=1`) joining to `DATA_PRODUCT` by primary key, instead of a per-file full scan; confirmed the index is created in the DB after restart. Listing behavior is unchanged — `data_product_uri` is still stable/deduped across calls and resolves.
- `mvn test -pl airavata-api/research-service` → 53 pass, 0 failures.

Follow-up to #653 (the get-or-create-by-path feature).