### PR TITLE
style: apply Spotless formatting to D4.3 storage/data-product files

### DIFF
--- a/airavata-api/orchestration-service/src/main/java/org/apache/airavata/orchestration/util/DevStorageInitializer.java
+++ b/airavata-api/orchestration-service/src/main/java/org/apache/airavata/orchestration/util/DevStorageInitializer.java
@@ -87,16 +87,17 @@ public class DevStorageInitializer {
                     // a partial prior init can leave it without one, which then fails
                     // the SFTP adaptor with "No SCP data movement interface".
                     String existingId = entry.getKey();
-                    boolean hasScp = registryHandler.getStorageResource(existingId).getDataMovementInterfacesList()
-                            .stream()
-                            .anyMatch(i -> i.getDataMovementProtocol() == DataMovementProtocol.SCP);
+                    boolean hasScp =
+                            registryHandler.getStorageResource(existingId).getDataMovementInterfacesList().stream()
+                                    .anyMatch(i -> i.getDataMovementProtocol() == DataMovementProtocol.SCP);
                     if (!hasScp) {
                         SCPDataMovement scpDm = SCPDataMovement.newBuilder()
                                 .setSecurityProtocol(SecurityProtocol.SSH_KEYS)
                                 .setSshPort(22)
                                 .build();
                         registryHandler.addSCPDataMovementDetails(existingId, DMType.STORAGE_RESOURCE, 0, scpDm);
-                        logger.info("Healed dev storage resource {}: added missing SCP data movement interface",
+                        logger.info(
+                                "Healed dev storage resource {}: added missing SCP data movement interface",
                                 existingId);
                     } else {
                         logger.info("Dev storage resource already exists: {} ({})", entry.getValue(), existingId);

--- a/airavata-api/src/main/java/org/apache/airavata/interfaces/DataProductInterface.java
+++ b/airavata-api/src/main/java/org/apache/airavata/interfaces/DataProductInterface.java
@@ -43,8 +43,7 @@ public interface DataProductInterface {
      * Return the data product in the gateway that has a replica at the given file path, or
      * {@code null} if none exists.
      */
-    DataProductModel getDataProductByReplicaFilePath(String gatewayId, String filePath)
-            throws ReplicaCatalogException;
+    DataProductModel getDataProductByReplicaFilePath(String gatewayId, String filePath) throws ReplicaCatalogException;
 
     boolean isDataProductExists(String productUri) throws ReplicaCatalogException;
 

--- a/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/grpc/UserStorageGrpcService.java
+++ b/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/grpc/UserStorageGrpcService.java
@@ -353,8 +353,7 @@ public class UserStorageGrpcService extends UserStorageServiceGrpc.UserStorageSe
             String path = resolvePath(request.getPath(), request.getStorageResourceId());
             String storageResourceId = resolveStorageResourceId(request.getStorageResourceId());
             FileMetadata meta = adaptor.getFileMetadata(path);
-            observer.onNext(toFileMetadataResponse(
-                    meta, path, resolveDataProductUri(meta, path, storageResourceId)));
+            observer.onNext(toFileMetadataResponse(meta, path, resolveDataProductUri(meta, path, storageResourceId)));
             observer.onCompleted();
         } catch (Exception e) {
             observer.onError(GrpcStatusMapper.toStatusException(e));
@@ -454,8 +453,7 @@ public class UserStorageGrpcService extends UserStorageServiceGrpc.UserStorageSe
         }
     }
 
-    private static FileMetadataResponse toFileMetadataResponse(
-            FileMetadata meta, String path, String dataProductUri) {
+    private static FileMetadataResponse toFileMetadataResponse(FileMetadata meta, String path, String dataProductUri) {
         return FileMetadataResponse.newBuilder()
                 .setName(meta.getName() != null ? meta.getName() : "")
                 .setPath(path)


### PR DESCRIPTION
`mvn spotless:apply` reformatting for three files from the D4.3 storage work (DevStorageInitializer, DataProductInterface, UserStorageGrpcService) that had minor line-wrapping violations the Spotless `build` check now flags on every PR. Formatting-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)