### PR TITLE
Proto-direct airavata-python-sdk + Keycloak self-service realm config

### DIFF
--- a/airavata-python-sdk/airavata_sdk/client.py
+++ b/airavata-python-sdk/airavata_sdk/client.py
@@ -24,6 +24,8 @@ class AiravataClient:
         else:
             self._channel = grpc.insecure_channel(target, options=options)
 
+        self.claims = claims or {}
+
         self._metadata = []
         if token:
             self._metadata.append(("authorization", f"Bearer {token}"))
@@ -44,6 +46,16 @@ class AiravataClient:
         self.iam = IamClient(self._channel, self._metadata, self._gateway_id)
         self.sharing = SharingClient(self._channel, self._metadata, self._gateway_id)
         self.agent = AgentClient(self._channel, self._metadata, self._gateway_id)
+
+    @property
+    def username(self):
+        """Return the caller's username from JWT claims, or None if unavailable."""
+        return (self.claims or {}).get("userName")
+
+    @property
+    def gateway_id(self):
+        """Return the gateway ID this client was initialised with."""
+        return self._gateway_id
 
     def close(self):
         self._channel.close()

--- a/airavata-python-sdk/airavata_sdk/helpers/__init__.py
+++ b/airavata-python-sdk/airavata_sdk/helpers/__init__.py
@@ -1,8 +1,6 @@
-"""Framework-agnostic helpers relocated from the Django portal SDK.
+"""Framework-agnostic resource helpers relocated from the Django portal SDK.
 
-These modules carry behavior that used to live in
-``airavata_django_portal_sdk`` but contain no Django/DRF/Thrift dependencies.
-All backend access is routed through the gRPC facades exposed by
-:class:`airavata_sdk.client.AiravataClient` (``client.research``,
-``client.storage``, ``client.sharing``).
+No Django/DRF/Thrift dependencies — all backend access goes through the gRPC
+facades on :class:`airavata_sdk.client.AiravataClient` (``client.research``,
+``client.storage``, ``client.sharing``, ...).
 """

--- a/airavata-python-sdk/airavata_sdk/helpers/_envelope.py
+++ b/airavata-python-sdk/airavata_sdk/helpers/_envelope.py
@@ -1,0 +1,52 @@
+"""Typed containers that union a proto message with chained-call scalars.
+
+The proto-direct architecture returns the gRPC message as-is whenever that is
+sufficient. Some resources need a few extra fields the owning service cannot
+compute without breaking service isolation — most commonly the sharing-access
+flags, which live in the SHARING service while the resource is owned elsewhere.
+Rather than couple the two services, the SDK makes a chained follow-up call and
+carries the result alongside the proto here. The proto is never re-modelled: it
+flows through under ``.message``; the portal renderer flattens each container to
+``MessageToDict(message)`` merged with the extra scalars.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+M = TypeVar("M")
+G = TypeVar("G")
+
+
+@dataclass
+class WithAccess(Generic[M]):
+    """A proto message unioned with the caller's sharing-access flags.
+
+    ``is_owner`` is SDK-trivial for protos carrying an ``owner`` field (else
+    always ``False``). ``user_has_write_access`` is the chained
+    ``sharing.user_has_access`` lookup the proto is wrapped for.
+    """
+
+    message: M
+    is_owner: bool
+    user_has_write_access: bool
+
+
+@dataclass
+class WithGroupAccess(Generic[G]):
+    """A ``GroupModel`` proto unioned with the caller's six group-access flags.
+
+    Same pattern as :class:`WithAccess`, but a group needs six cross-context
+    booleans (a GroupManager admin lookup, the acting user's ``user@gateway`` id,
+    and the gateway-group identity ids) the ``GroupModel`` proto cannot compute
+    without coupling GroupManager to the gateway-groups catalog.
+    """
+
+    message: G
+    is_admin: bool
+    is_owner: bool
+    is_member: bool
+    is_gateway_admins_group: bool
+    is_read_only_gateway_admins_group: bool
+    is_default_gateway_users_group: bool

--- a/airavata-python-sdk/airavata_sdk/helpers/compute_resources.py
+++ b/airavata-python-sdk/airavata_sdk/helpers/compute_resources.py
@@ -1,0 +1,666 @@
+"""Compute-domain helpers.
+
+Read paths are proto-direct: ``get_gateway_resource_profile`` /
+``get_group_resource_profile`` return a ``WithAccess`` (``is_owner`` always
+``False``, ``user_has_write_access`` supplied by the ViewSet as *has_write*);
+``get_compute_resource`` and the four ``get_*_job_submission`` helpers return the
+bare proto.
+
+The protocol-enum int bridges below exist ONLY for the group-resource-profile
+WRITE builders, which still accept the historical Thrift-int wire format (proto
+and Thrift assign different ints to the same member, so the bridge maps by member
+NAME). Read paths render enum NAMES via ``MessageToDict`` and do not use them.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from airavata_sdk.helpers._envelope import WithAccess
+from airavata_sdk.helpers.models import (
+    GroupResourceProfileCreate,
+    WorkspaceDefaultsModel,
+)
+
+if TYPE_CHECKING:
+    from airavata_sdk.client import AiravataClient
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.computeresource import (  # noqa: E501
+        compute_resource_pb2,
+    )
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.gatewayprofile import (  # noqa: E501
+        gateway_profile_pb2,
+    )
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.groupresourceprofile import (  # noqa: E501
+        group_resource_profile_pb2,
+    )
+
+
+# Historical Thrift enum integers, keyed by member NAME.
+_THRIFT_JOB_SUBMISSION_PROTOCOL = {
+    'CLOUD': 4, 'GLOBUS': 2, 'LOCAL': 0, 'LOCAL_FORK': 6,
+    'SSH': 1, 'SSH_FORK': 5, 'UNICORE': 3,
+}
+_THRIFT_DATA_MOVEMENT_PROTOCOL = {
+    'GridFTP': 3, 'LOCAL': 0, 'SCP': 1, 'SFTP': 2,
+    'UNICORE_STORAGE_SERVICE': 4,
+}
+
+# proto member name -> Thrift member name for members whose proto3 names diverge
+# beyond a simple prefix strip.
+_JSP_NAME_MAP = {'JSP_CLOUD': 'CLOUD'}
+_DMP_NAME_MAP = {'DATA_MOVEMENT_PROTOCOL_LOCAL': 'LOCAL'}
+
+
+def _build_proto_to_thrift(enum_descriptor, thrift_ints, prefix, name_map):
+    """``{proto int: Thrift int or None}``: a proto member is resolved to a Thrift
+    member name (via *name_map* or by stripping *prefix*), then looked up;
+    members absent from *thrift_ints* map to ``None``.
+    """
+    out = {}
+    for v in enum_descriptor.values:
+        if v.name in name_map:
+            name = name_map[v.name]
+        else:
+            name = v.name
+            if prefix and name.startswith(prefix):
+                name = name[len(prefix):]
+        out[v.number] = thrift_ints.get(name)
+    return out
+
+
+_JSP_PROTO_TO_THRIFT: Optional[dict] = None
+_DMP_PROTO_TO_THRIFT: Optional[dict] = None
+
+
+def _job_submission_protocol_int(proto_int: int) -> Optional[int]:
+    global _JSP_PROTO_TO_THRIFT
+    if _JSP_PROTO_TO_THRIFT is None:
+        from airavata_sdk.generated.org.apache.airavata.model.appcatalog.computeresource import (  # noqa: E501
+            compute_resource_pb2,
+        )
+        _JSP_PROTO_TO_THRIFT = _build_proto_to_thrift(
+            compute_resource_pb2.JobSubmissionProtocol.DESCRIPTOR,
+            _THRIFT_JOB_SUBMISSION_PROTOCOL,
+            'JOB_SUBMISSION_PROTOCOL_',
+            _JSP_NAME_MAP,
+        )
+    return _JSP_PROTO_TO_THRIFT.get(proto_int)
+
+
+def _data_movement_protocol_int(proto_int: int) -> Optional[int]:
+    global _DMP_PROTO_TO_THRIFT
+    if _DMP_PROTO_TO_THRIFT is None:
+        from airavata_sdk.generated.org.apache.airavata.model.data.movement import (  # noqa: E501
+            data_movement_pb2,
+        )
+        _DMP_PROTO_TO_THRIFT = _build_proto_to_thrift(
+            data_movement_pb2.DataMovementProtocol.DESCRIPTOR,
+            _THRIFT_DATA_MOVEMENT_PROTOCOL,
+            'DATA_MOVEMENT_PROTOCOL_',
+            _DMP_NAME_MAP,
+        )
+    return _DMP_PROTO_TO_THRIFT.get(proto_int)
+
+
+# StoragePreference — bare proto, no envelope (a flat message with no ownership
+# or sharing fields). Write path builds the proto via _build_storage_preference.
+
+
+def list_gateway_storage_preferences(
+    client: "AiravataClient",
+    gateway_id: str,
+) -> "list[gateway_profile_pb2.StoragePreference]":
+    return list(client.compute.get_all_gateway_storage_preferences(gateway_id))
+
+
+def get_gateway_storage_preference(
+    client: "AiravataClient",
+    gateway_id: str,
+    storage_resource_id: str,
+) -> "gateway_profile_pb2.StoragePreference":
+    return client.compute.get_gateway_storage_preference(
+        gateway_id, storage_resource_id)
+
+
+def create_gateway_storage_preference(
+    client: "AiravataClient",
+    gateway_id: str,
+    data: dict,
+) -> "gateway_profile_pb2.StoragePreference":
+    pref = _build_storage_preference(data)
+    client.compute.add_gateway_storage_preference(
+        gateway_id, pref.storage_resource_id, pref)
+    return get_gateway_storage_preference(
+        client, gateway_id, pref.storage_resource_id)
+
+
+def update_gateway_storage_preference(
+    client: "AiravataClient",
+    gateway_id: str,
+    storage_resource_id: str,
+    data: dict,
+) -> "gateway_profile_pb2.StoragePreference":
+    """The ``storage_resource_id`` path value overrides any value in *data*."""
+    merged = dict(data)
+    merged["storage_resource_id"] = storage_resource_id
+    pref = _build_storage_preference(merged)
+    client.compute.update_gateway_storage_preference(
+        gateway_id, storage_resource_id, pref)
+    return get_gateway_storage_preference(
+        client, gateway_id, storage_resource_id)
+
+
+def delete_gateway_storage_preference(
+    client: "AiravataClient",
+    gateway_id: str,
+    storage_resource_id: str,
+) -> None:
+    client.compute.delete_gateway_storage_preference(
+        gateway_id, storage_resource_id)
+
+
+# GatewayResourceProfile — WithAccess (gateway-catalog: no owner, so is_owner is
+# always False; user_has_write_access is the gateway-admin flag the ViewSet
+# supplies as has_write, not a sharing lookup).
+
+
+def get_gateway_resource_profile(
+    client: "AiravataClient",
+    gateway_id: str,
+    *,
+    has_write: bool,
+) -> "WithAccess":
+    p = client.compute.get_gateway_resource_profile(gateway_id)
+    return WithAccess(
+        message=p,
+        is_owner=False,
+        user_has_write_access=has_write,
+    )
+
+
+def _build_storage_preference(data: dict):
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.gatewayprofile import (  # noqa: E501
+        gateway_profile_pb2,
+    )
+    return gateway_profile_pb2.StoragePreference(
+        storage_resource_id=data.get("storage_resource_id") or "",
+        login_user_name=data.get("login_user_name") or "",
+        file_system_root_location=data.get("file_system_root_location") or "",
+        resource_specific_credential_store_token=data.get(
+            "resource_specific_credential_store_token") or "",
+    )
+
+
+def _build_compute_resource_preference(data: dict):
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.gatewayprofile import (  # noqa: E501
+        gateway_profile_pb2,
+    )
+    return gateway_profile_pb2.ComputeResourcePreference(
+        compute_resource_id=data.get("compute_resource_id") or "",
+        # decamelized incoming ``overridebyAiravata`` -> ``overrideby_airavata``
+        override_by_airavata=bool(data.get("overrideby_airavata", False)),
+        login_user_name=data.get("login_user_name") or "",
+        preferred_job_submission_protocol=_job_submission_protocol_proto(
+            data.get("preferred_job_submission_protocol")),
+        preferred_data_movement_protocol=_data_movement_protocol_proto(
+            data.get("preferred_data_movement_protocol")),
+        preferred_batch_queue=data.get("preferred_batch_queue") or "",
+        scratch_location=data.get("scratch_location") or "",
+        allocation_project_number=data.get("allocation_project_number") or "",
+        resource_specific_credential_store_token=data.get(
+            "resource_specific_credential_store_token") or "",
+        usage_reporting_gateway_id=data.get("usage_reporting_gateway_id") or "",
+        quality_of_service=data.get("quality_of_service") or "",
+        reservation=data.get("reservation") or "",
+        reservation_start_time=data.get("reservation_start_time") or 0,
+        reservation_end_time=data.get("reservation_end_time") or 0,
+        ssh_account_provisioner=data.get("ssh_account_provisioner") or "",
+        ssh_account_provisioner_config=dict(
+            data.get("ssh_account_provisioner_config") or {}),
+        ssh_account_provisioner_additional_info=data.get(
+            "ssh_account_provisioner_additional_info") or "",
+    )
+
+
+# Reverse lookups (Thrift int -> proto int), built lazily from the forward maps.
+_JSP_THRIFT_TO_PROTO: Optional[dict] = None
+_DMP_THRIFT_TO_PROTO: Optional[dict] = None
+
+
+def _job_submission_protocol_proto(thrift_int: Optional[int]) -> int:
+    global _JSP_THRIFT_TO_PROTO
+    if _JSP_THRIFT_TO_PROTO is None:
+        _job_submission_protocol_int(0)  # ensure forward map built
+        _JSP_THRIFT_TO_PROTO = {
+            t: p for p, t in _JSP_PROTO_TO_THRIFT.items() if t is not None}
+    if not thrift_int:
+        return 0
+    return _JSP_THRIFT_TO_PROTO.get(int(thrift_int), 0)
+
+
+def _data_movement_protocol_proto(thrift_int: Optional[int]) -> int:
+    global _DMP_THRIFT_TO_PROTO
+    if _DMP_THRIFT_TO_PROTO is None:
+        _data_movement_protocol_int(0)  # ensure forward map built
+        _DMP_THRIFT_TO_PROTO = {
+            t: p for p, t in _DMP_PROTO_TO_THRIFT.items() if t is not None}
+    if not thrift_int:
+        return 0
+    return _DMP_THRIFT_TO_PROTO.get(int(thrift_int), 0)
+
+
+def build_gateway_resource_profile(
+    data: dict,
+) -> "gateway_profile_pb2.GatewayResourceProfile":
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.gatewayprofile import (  # noqa: E501
+        gateway_profile_pb2,
+    )
+    return gateway_profile_pb2.GatewayResourceProfile(
+        gateway_id=data.get("gateway_id") or "",
+        credential_store_token=data.get("credential_store_token") or "",
+        compute_resource_preferences=[
+            _build_compute_resource_preference(c)
+            for c in (data.get("compute_resource_preferences") or [])
+        ],
+        storage_preferences=[
+            _build_storage_preference(s)
+            for s in (data.get("storage_preferences") or [])
+        ],
+        identity_server_tenant=data.get("identity_server_tenant") or "",
+        identity_server_pwd_cred_token=data.get(
+            "identity_server_pwd_cred_token") or "",
+    )
+
+
+def update_gateway_resource_profile(
+    client: "AiravataClient",
+    gateway_id: str,
+    data: dict,
+    *,
+    has_write: bool,
+) -> "WithAccess":
+    profile = build_gateway_resource_profile(data)
+    client.compute.update_gateway_resource_profile(gateway_id, profile)
+    return get_gateway_resource_profile(
+        client, gateway_id, has_write=has_write)
+
+
+# ComputeResourceDescription — bare proto, no envelope (no ownership/sharing).
+
+
+def get_compute_resource(
+    client: "AiravataClient",
+    compute_resource_id: str,
+) -> "compute_resource_pb2.ComputeResourceDescription":
+    return client.compute.get_compute_resource(compute_resource_id)
+
+
+def list_compute_resource_names(client: "AiravataClient") -> dict[str, str]:
+    """The ``{compute_resource_id: host_name}`` map, passed straight through."""
+    return client.compute.get_all_compute_resource_names()
+
+
+# GroupResourceProfile — WithAccess. The profile has no owner (is_owner always
+# False). user_has_write_access is NOT a single chained sharing lookup but a
+# COMPOSITE request-bound boolean (WRITE on the profile AND READ on every
+# credential token), so the ViewSet computes it and passes it in as has_write.
+# The WRITE builders below still accept the historical Thrift-int wire format, so
+# the enum int->proto bridges remain.
+
+
+def _grp_pb2():
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.groupresourceprofile import (  # noqa: E501
+        group_resource_profile_pb2,
+    )
+    return group_resource_profile_pb2
+
+
+# GroupResourceProfile: write builders (snake_case dict -> proto).
+
+
+def _resource_type_proto(thrift_int: Optional[int]) -> int:
+    """Thrift/proto ``resource_type`` int -> proto int. Thrift SLURM(0)->proto
+    SLURM(1), Thrift AWS(1)->proto AWS(2); None/unknown -> 0.
+    """
+    if thrift_int is None:
+        return 0
+    grp = _grp_pb2()
+    thrift_to_proto = {0: grp.ResourceType.SLURM, 1: grp.ResourceType.AWS}
+    return thrift_to_proto.get(int(thrift_int), 0)
+
+
+def _build_ssh_provisioner_config(c: dict):
+    grp = _grp_pb2()
+    return grp.GroupAccountSSHProvisionerConfig(
+        resource_id=c.get("resource_id", "") or "",
+        group_resource_profile_id=c.get("group_resource_profile_id", "") or "",
+        config_name=c.get("config_name", "") or "",
+        config_value=c.get("config_value", "") or "",
+    )
+
+
+def _build_reservation(r: dict):
+    grp = _grp_pb2()
+    return grp.ComputeResourceReservation(
+        reservation_id=r.get("reservation_id", "") or "",
+        reservation_name=r.get("reservation_name", "") or "",
+        queue_names=list(r.get("queue_names", []) or []),
+        start_time=r.get("start_time", 0) or 0,
+        end_time=r.get("end_time", 0) or 0,
+    )
+
+
+def _build_slurm_pref(s: dict):
+    grp = _grp_pb2()
+    return grp.SlurmComputeResourcePreference(
+        allocation_project_number=s.get("allocation_project_number", "") or "",
+        preferred_batch_queue=s.get("preferred_batch_queue", "") or "",
+        quality_of_service=s.get("quality_of_service", "") or "",
+        usage_reporting_gateway_id=s.get("usage_reporting_gateway_id", "") or "",
+        ssh_account_provisioner=s.get("ssh_account_provisioner", "") or "",
+        group_ssh_account_provisioner_configs=[
+            _build_ssh_provisioner_config(c)
+            for c in (s.get("group_ssh_account_provisioner_configs", []) or [])],
+        ssh_account_provisioner_additional_info=s.get(
+            "ssh_account_provisioner_additional_info", "") or "",
+        reservations=[
+            _build_reservation(r)
+            for r in (s.get("reservations", []) or [])],
+    )
+
+
+def _build_aws_pref(a: dict):
+    grp = _grp_pb2()
+    return grp.AwsComputeResourcePreference(
+        region=a.get("region", "") or "",
+        preferred_ami_id=a.get("preferred_ami_id", "") or "",
+        preferred_instance_type=a.get("preferred_instance_type", "") or "",
+    )
+
+
+def _build_group_compute_resource_preference(d: dict):
+    """The write payload's ``specific_preferences`` (a ``{'slurm': {...}}`` / AWS
+    dict) plus a flattened ``allocation_project_number`` / ``resource_type`` are
+    mapped into the proto oneof. Protocol enums accept the Thrift-int wire format.
+    """
+    grp = _grp_pb2()
+    sp = d.get("specific_preferences")
+    resource_type = _resource_type_proto(d.get("resource_type"))
+    msg = grp.GroupComputeResourcePreference(
+        compute_resource_id=d.get("compute_resource_id", "") or "",
+        group_resource_profile_id=d.get("group_resource_profile_id", "") or "",
+        override_by_airavata=bool(d.get("overrideby_airavata", False)),
+        login_user_name=d.get("login_user_name", "") or "",
+        scratch_location=d.get("scratch_location", "") or "",
+        preferred_job_submission_protocol=_job_submission_protocol_proto(
+            d.get("preferred_job_submission_protocol")),
+        preferred_data_movement_protocol=_data_movement_protocol_proto(
+            d.get("preferred_data_movement_protocol")),
+        resource_specific_credential_store_token=d.get(
+            "resource_specific_credential_store_token", "") or "",
+        resource_type=resource_type,
+    )
+    # Resolve the union: prefer an explicit specific_preferences, else infer
+    # from the flattened allocation_project_number / resource_type / aws fields.
+    slurm_data = None
+    aws_data = None
+    if isinstance(sp, dict):
+        if "slurm" in sp and isinstance(sp["slurm"], dict):
+            slurm_data = dict(sp["slurm"])
+        elif "aws" in sp and isinstance(sp["aws"], dict):
+            aws_data = dict(sp["aws"])
+        elif "region" in sp or "preferred_ami_id" in sp:
+            aws_data = dict(sp)
+        elif sp:
+            slurm_data = dict(sp)
+    if slurm_data is None and aws_data is None:
+        proto_resource_type = grp.ResourceType
+        if resource_type == proto_resource_type.AWS or "region" in d:
+            aws_data = {}
+        elif ("allocation_project_number" in d
+                or resource_type == proto_resource_type.SLURM):
+            slurm_data = {}
+    if "allocation_project_number" in d and slurm_data is not None:
+        slurm_data.setdefault(
+            "allocation_project_number", d["allocation_project_number"])
+    if slurm_data is not None:
+        msg.specific_preferences.CopyFrom(grp.EnvironmentSpecificPreferences(
+            slurm=_build_slurm_pref(slurm_data)))
+    elif aws_data is not None:
+        msg.specific_preferences.CopyFrom(grp.EnvironmentSpecificPreferences(
+            aws=_build_aws_pref(aws_data)))
+    return msg
+
+
+def _build_compute_resource_policy(d: dict):
+    grp = _grp_pb2()
+    return grp.ComputeResourcePolicy(
+        resource_policy_id=d.get("resource_policy_id", "") or "",
+        compute_resource_id=d.get("compute_resource_id", "") or "",
+        group_resource_profile_id=d.get("group_resource_profile_id", "") or "",
+        allowed_batch_queues=list(d.get("allowed_batch_queues", []) or []),
+    )
+
+
+def _build_batch_queue_resource_policy(d: dict):
+    grp = _grp_pb2()
+    return grp.BatchQueueResourcePolicy(
+        resource_policy_id=d.get("resource_policy_id", "") or "",
+        compute_resource_id=d.get("compute_resource_id", "") or "",
+        group_resource_profile_id=d.get("group_resource_profile_id", "") or "",
+        queuename=d.get("queuename", "") or "",
+        max_allowed_nodes=d.get("max_allowed_nodes", 0) or 0,
+        max_allowed_cores=d.get("max_allowed_cores", 0) or 0,
+        max_allowed_walltime=d.get("max_allowed_walltime", 0) or 0,
+    )
+
+
+def build_group_resource_profile(
+    client: "AiravataClient",
+    data: dict,
+) -> "group_resource_profile_pb2.GroupResourceProfile":
+    """``gateway_id`` is forced from the client context."""
+    grp = _grp_pb2()
+    return grp.GroupResourceProfile(
+        gateway_id=client.gateway_id or "",
+        group_resource_profile_id=data.get(
+            "group_resource_profile_id", "") or "",
+        group_resource_profile_name=data.get(
+            "group_resource_profile_name", "") or "",
+        compute_preferences=[
+            _build_group_compute_resource_preference(p)
+            for p in (data.get("compute_preferences", []) or [])],
+        compute_resource_policies=[
+            _build_compute_resource_policy(p)
+            for p in (data.get("compute_resource_policies", []) or [])],
+        batch_queue_resource_policies=[
+            _build_batch_queue_resource_policy(p)
+            for p in (data.get("batch_queue_resource_policies", []) or [])],
+        default_credential_store_token=data.get(
+            "default_credential_store_token", "") or "",
+    )
+
+
+def list_group_resource_profiles(
+    client: "AiravataClient",
+    *,
+    has_write_by_id: Optional[dict] = None,
+) -> "list[WithAccess]":
+    """*has_write_by_id* maps ``group_resource_profile_id`` -> the composite
+    write flag the ViewSet resolved; ids absent from the map default to ``False``.
+    """
+    by_id = has_write_by_id or {}
+    profiles = client.compute.get_group_resource_list()
+    return [
+        WithAccess(
+            message=g,
+            is_owner=False,
+            user_has_write_access=bool(
+                by_id.get(g.group_resource_profile_id, False)),
+        )
+        for g in profiles
+    ]
+
+
+def get_group_resource_profile(
+    client: "AiravataClient",
+    group_resource_profile_id: str,
+    *,
+    has_write: bool,
+) -> "WithAccess":
+    g = client.compute.get_group_resource_profile(group_resource_profile_id)
+    return WithAccess(
+        message=g,
+        is_owner=False,
+        user_has_write_access=has_write,
+    )
+
+
+def create_group_resource_profile(
+    client: "AiravataClient",
+    data: "GroupResourceProfileCreate | dict",
+    *,
+    has_write: bool = True,
+) -> "WithAccess":
+    """The server mints the id; the creator can write, so *has_write* defaults
+    to ``True``.
+    """
+    data = GroupResourceProfileCreate.model_validate(data).model_dump(
+        exclude_unset=True)
+    grp = build_group_resource_profile(client, data)
+    created = client.compute.create_group_resource_profile(grp)
+    return WithAccess(
+        message=created,
+        is_owner=False,
+        user_has_write_access=has_write,
+    )
+
+
+def update_group_resource_profile(
+    client: "AiravataClient",
+    group_resource_profile_id: str,
+    data: "GroupResourceProfileCreate | dict",
+    *,
+    has_write: bool = True,
+) -> "WithAccess":
+    """Orphaned compute prefs / policies no longer present are removed
+    individually before ``UpdateGroupResourceProfile``. The path id is
+    authoritative; the updated proto is re-fetched (the update RPC returns Empty).
+    """
+    data = GroupResourceProfileCreate.model_validate(data).model_dump(
+        exclude_unset=True)
+    grp = build_group_resource_profile(client, data)
+    grp.group_resource_profile_id = group_resource_profile_id
+    original = client.compute.get_group_resource_profile(
+        group_resource_profile_id)
+    # Remove compute prefs / policies that are no longer present.
+    new_pref_ids = {
+        cp.compute_resource_id for cp in grp.compute_preferences}
+    for cp in original.compute_preferences:
+        if cp.compute_resource_id not in new_pref_ids:
+            client.compute.remove_group_compute_prefs(
+                cp.group_resource_profile_id, cp.compute_resource_id)
+    new_policy_ids = {
+        p.resource_policy_id for p in grp.compute_resource_policies}
+    for p in original.compute_resource_policies:
+        if p.resource_policy_id and p.resource_policy_id not in new_policy_ids:
+            client.compute.remove_group_compute_resource_policy(
+                p.resource_policy_id)
+    new_bq_ids = {
+        p.resource_policy_id for p in grp.batch_queue_resource_policies}
+    for p in original.batch_queue_resource_policies:
+        if p.resource_policy_id and p.resource_policy_id not in new_bq_ids:
+            client.compute.remove_group_batch_queue_resource_policy(
+                p.resource_policy_id)
+    client.compute.update_group_resource_profile(
+        group_resource_profile_id, grp)
+    return get_group_resource_profile(
+        client, group_resource_profile_id, has_write=has_write)
+
+
+def delete_group_resource_profile(
+    client: "AiravataClient",
+    group_resource_profile_id: str,
+) -> None:
+    client.compute.remove_group_resource_profile(group_resource_profile_id)
+
+
+# Per-protocol job submission (Local / SSH / Unicore / Cloud) — bare proto.
+
+
+def get_local_job_submission(
+    client: "AiravataClient",
+    submission_id: str,
+):
+    return client.compute.get_local_job_submission(submission_id)
+
+
+def get_ssh_job_submission(
+    client: "AiravataClient",
+    submission_id: str,
+):
+    return client.compute.get_ssh_job_submission(submission_id)
+
+
+def get_unicore_job_submission(
+    client: "AiravataClient",
+    submission_id: str,
+):
+    return client.compute.get_unicore_job_submission(submission_id)
+
+
+def get_cloud_job_submission(
+    client: "AiravataClient",
+    submission_id: str,
+):
+    return client.compute.get_cloud_job_submission(submission_id)
+
+
+# Workspace defaults: the "talk to Airavata" grunt the portal
+# WorkspacePreferencesHelper did inline — resolve sensible defaults for a fresh
+# record and validate a stored record against the server. Return plain
+# scalars/lists (no contract dict); the ORM read/write stays in the portal.
+
+
+def user_can_write(client: "AiravataClient", resource_id: str) -> bool:
+    return client.sharing.user_has_access(
+        resource_id=resource_id,
+        user_id=client.username,
+        permission_type="WRITE",
+    )
+
+
+def most_recent_writeable_project_id(
+    client: "AiravataClient",
+) -> Optional[str]:
+    """Id of the caller's first WRITE-accessible project (newest first), or None."""
+    projects = client.research.get_user_projects(
+        gateway_id=client.gateway_id,
+        user_name=client.username,
+        limit=-1,
+        offset=0,
+    )
+    for project in projects:
+        if user_can_write(client, project.project_id):
+            return project.project_id
+    return None
+
+
+def accessible_group_resource_profile_ids(
+    client: "AiravataClient",
+) -> list[str]:
+    profiles = client.compute.get_group_resource_list()
+    return [g.group_resource_profile_id for g in profiles]
+
+
+def resolve_workspace_defaults(client: "AiravataClient") -> dict:
+    """Server-derived defaults the portal persists into its own ORM record:
+    first WRITE-accessible project id, all accessible group-resource-profile ids
+    (server order), and the first of those.
+    """
+    grp_ids = accessible_group_resource_profile_ids(client)
+    return WorkspaceDefaultsModel.model_validate({
+        "most_recent_project_id": most_recent_writeable_project_id(client),
+        "group_resource_profile_ids": grp_ids,
+        "most_recent_group_resource_profile_id": grp_ids[0] if grp_ids else None,
+    }).model_dump()

--- a/airavata-python-sdk/airavata_sdk/helpers/credential_resources.py
+++ b/airavata-python-sdk/airavata_sdk/helpers/credential_resources.py
@@ -1,0 +1,120 @@
+"""Credential-domain helpers. A ``CredentialSummary`` is returned in a
+:class:`~airavata_sdk.helpers._envelope.WithAccess`: ``is_owner`` is always
+``False`` (a credential has no owner) and ``user_has_write_access`` is a chained
+``sharing.user_has_access`` WRITE lookup keyed on the credential ``token``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from airavata_sdk.helpers._envelope import WithAccess
+
+if TYPE_CHECKING:
+    from airavata_sdk.client import AiravataClient
+
+
+def _has_write(client: "AiravataClient", token: str) -> bool:
+    return client.sharing.user_has_access(
+        resource_id=token,
+        user_id=client.username,
+        permission_type="WRITE",
+    )
+
+
+def get_credential_summary(
+    client: "AiravataClient",
+    token_id: str,
+) -> "WithAccess":
+    c = client.credential.get_credential_summary(token_id, client.gateway_id)
+    return WithAccess(
+        message=c,
+        is_owner=False,
+        user_has_write_access=_has_write(client, c.token),
+    )
+
+
+def get_all_credential_summaries(
+    client: "AiravataClient",
+    *,
+    summary_type=None,
+) -> "list[WithAccess]":
+    """When *summary_type* is ``None`` the SSH and PASSWD summaries are
+    concatenated (the portal list endpoint); otherwise only that type is fetched.
+    """
+    from airavata_sdk.generated.org.apache.airavata.model.credential.store import (  # noqa: E501
+        credential_store_pb2,
+    )
+
+    if summary_type is None:
+        summaries = (
+            client.credential.get_all_credential_summaries(
+                client.gateway_id, credential_store_pb2.SummaryType.SSH)
+            + client.credential.get_all_credential_summaries(
+                client.gateway_id, credential_store_pb2.SummaryType.PASSWD)
+        )
+    else:
+        summaries = client.credential.get_all_credential_summaries(
+            client.gateway_id, summary_type)
+    return [
+        WithAccess(
+            message=c,
+            is_owner=False,
+            user_has_write_access=_has_write(client, c.token),
+        )
+        for c in summaries
+    ]
+
+
+def create_ssh_credential(
+    client: "AiravataClient",
+    data: dict,
+) -> "WithAccess":
+    """``gateway_id`` / ``username`` come from the client context; only
+    ``description`` is read from *data*. Re-fetched so the shape matches the read
+    path.
+    """
+    token_id = client.credential.generate_and_register_ssh_keys(
+        client.gateway_id,
+        client.username,
+        data.get("description") or "",
+    )
+    return get_credential_summary(client, token_id)
+
+
+def create_password_credential(
+    client: "AiravataClient",
+    data: dict,
+) -> "WithAccess":
+    """``gateway_id`` / ``portal_user_name`` come from the client context;
+    ``login_user_name`` (wire ``username``) / ``password`` / ``description`` from
+    *data*. Re-fetched so the shape matches the read path.
+    """
+    from airavata_sdk.generated.org.apache.airavata.model.credential.store import (  # noqa: E501
+        credential_store_pb2,
+    )
+
+    password_credential = credential_store_pb2.PasswordCredential(
+        gateway_id=client.gateway_id or "",
+        portal_user_name=client.username or "",
+        login_user_name=data.get("username") or "",
+        password=data.get("password") or "",
+        description=data.get("description") or "",
+    )
+    token_id = client.credential.register_pwd_credential(
+        client.gateway_id, password_credential)
+    return get_credential_summary(client, token_id)
+
+
+def delete_credential_summary(client: "AiravataClient", summary) -> None:
+    """Dispatch on *summary*'s ``SummaryType``: SSH via ``DeleteSSHPubKey``,
+    PASSWD via ``DeletePWDCredential``.
+    """
+    from airavata_sdk.generated.org.apache.airavata.model.credential.store import (  # noqa: E501
+        credential_store_pb2,
+    )
+
+    if summary.type == credential_store_pb2.SummaryType.SSH:
+        client.credential.delete_ssh_pub_key(summary.token, client.gateway_id)
+    elif summary.type == credential_store_pb2.SummaryType.PASSWD:
+        client.credential.delete_pwd_credential(summary.token, client.gateway_id)

--- a/airavata-python-sdk/airavata_sdk/helpers/experiment_orchestration.py
+++ b/airavata-python-sdk/airavata_sdk/helpers/experiment_orchestration.py
@@ -1,20 +1,13 @@
-"""Framework-agnostic experiment orchestration helpers.
-
-Relocated (in behavior) from
-``airavata_django_portal_sdk.experiment_util`` (``api.py`` and
-``intermediate_output.py``) and repointed from Thrift
-(``request.airavata_client.*``) plus the Django ``user_storage`` module onto the
-gRPC facades exposed by :class:`airavata_sdk.client.AiravataClient`
-(``client.research``, ``client.storage``, ``client.sharing``).
-
-There is no Django, DRF, ``request`` object, or Thrift here. Every function
-takes an :class:`~airavata_sdk.client.AiravataClient` (named ``client``) plus
-explicit keyword arguments. ``experiment`` arguments are proto
-``ExperimentModel`` instances (snake_case field names).
+"""Experiment orchestration helpers over the gRPC facades. Every function takes
+an :class:`~airavata_sdk.client.AiravataClient` plus explicit keyword arguments;
+``experiment`` arguments are proto ``ExperimentModel`` instances.
 """
+
+from __future__ import annotations
 
 import logging
 import os
+from typing import TYPE_CHECKING, Optional
 from urllib.parse import unquote, urlparse
 
 # Importing ``airavata_sdk.generated`` puts the generated proto root on sys.path
@@ -28,6 +21,12 @@ from airavata_sdk.generated.org.apache.airavata.model.data.replica import (
 )
 from airavata_sdk.generated.org.apache.airavata.model.status import status_pb2
 from airavata_sdk.generated.org.apache.airavata.model.task import task_pb2
+
+if TYPE_CHECKING:
+    from airavata_sdk.client import AiravataClient
+    from airavata_sdk.generated.org.apache.airavata.model.experiment import (
+        experiment_pb2,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -47,12 +46,8 @@ _TERMINAL_PROCESS_STATES = (
 )
 
 
-# ---------------------------------------------------------------------------
-# Replica / data-product helpers (pure, no backend calls)
-# ---------------------------------------------------------------------------
-
 def _gateway_data_store_replica(data_product):
-    """Return the GATEWAY_DATA_STORE replica of a data product, or None."""
+    """The GATEWAY_DATA_STORE replica, or the first replica, or None."""
     replicas = [
         rep
         for rep in data_product.replica_locations
@@ -60,30 +55,23 @@ def _gateway_data_store_replica(data_product):
     ]
     if replicas:
         return replicas[0]
-    # Fall back to the first replica if none is explicitly GATEWAY_DATA_STORE.
     return data_product.replica_locations[0] if data_product.replica_locations else None
 
 
 def _replica_filesystem_path(replica):
-    """Return the plain filesystem path encoded in a replica's file_path.
-
-    Mirrors the old portal's ``_get_replica_filepath``: replica file paths may be
-    stored as ``file://<host>:<path>`` (or URL-encoded), so parse out and unquote
-    just the path component.
+    """The plain filesystem path from a replica's file_path (which may be stored
+    as ``file://<host>:<path>`` or URL-encoded).
     """
     if replica is None or not replica.file_path:
         return None
     return unquote(urlparse(replica.file_path).path)
 
 
-def is_input_file(data_product) -> bool:
-    """Return True if the data product is a tmp input-file upload.
-
-    A data product is a tmp input-file upload iff its (gateway-data-store)
-    replica's file_path lives directly under the ``tmp`` directory
-    (TMP_INPUT_FILE_UPLOAD_DIR). Derived entirely from the DataProductModel proto
-    — no backend call (the old portal hit the storage backend; the proto already
-    carries the replica file path).
+def is_input_file(
+    data_product: "replica_catalog_pb2.DataProductModel",
+) -> bool:
+    """True iff the gateway-data-store replica's file_path lives directly under
+    the tmp upload dir.
     """
     replica = _gateway_data_store_replica(data_product)
     path = _replica_filesystem_path(replica)
@@ -92,17 +80,13 @@ def is_input_file(data_product) -> bool:
     return os.path.basename(os.path.dirname(path)) == TMP_INPUT_FILE_UPLOAD_DIR
 
 
-# ---------------------------------------------------------------------------
-# Launch
-# ---------------------------------------------------------------------------
-
-def launch(client, experiment_id, *, username) -> None:
-    """Launch an experiment.
-
-    Equivalent to the old ``experiment_util.api.launch`` non-remote-API branch:
-    set storage ids + per-experiment data dir, move any tmp input-file uploads
-    into that data dir, persist the experiment, then launch it.
-    """
+def launch(
+    client: "AiravataClient",
+    experiment_id: str,
+    *,
+    username: str,
+) -> None:
+    """Set storage ids + data dir, move tmp input uploads into it, persist, launch."""
     experiment = client.research.get_experiment(experiment_id)
     _set_storage_id_and_data_dir(client, experiment, username=username)
     _move_tmp_input_file_uploads_to_data_dir(client, experiment)
@@ -111,11 +95,8 @@ def launch(client, experiment_id, *, username) -> None:
 
 
 def _set_storage_id_and_data_dir(client, experiment, *, username):
-    """Set input/output storage resource ids and the per-experiment data dir.
-
-    Defaults both input and output storage to the gateway default storage
-    resource, then ensures ``experiment_data_dir`` is set, creating the directory
-    on storage when necessary.
+    """Default input/output storage to the gateway default, then ensure
+    ``experiment_data_dir`` is set, creating the directory on storage if needed.
     """
     default_storage_id = client.storage.get_default_storage_resource_id()
 
@@ -125,41 +106,31 @@ def _set_storage_id_and_data_dir(client, experiment, *, username):
 
     if not user_config.experiment_data_dir:
         project = client.research.get_project(experiment.project_id)
-        # Path convention mirrors the old create_user_dir(dir_names=(project.name,
-        # experiment_name)): "<project>/<experiment>" under the storage root.
-        # Names are sanitized for filesystem safety (spaces -> underscores).
+        # "<project>/<experiment>" under the storage root (spaces -> underscores).
         exp_dir = "/".join(
             _sanitize_path_component(part)
             for part in (project.name, experiment.experiment_name)
         )
-        # TODO(sdk-consolidation): the old create_user_dir(create_unique=True)
-        # guaranteed a non-colliding directory by suffixing on collision. The
-        # storage facade's create_dir has no uniqueness guarantee, so two
-        # experiments with the same project+name share a data dir. A
-        # create_unique option on the storage facade would restore old behavior.
+        # TODO(sdk-consolidation): the storage facade's create_dir has no
+        # uniqueness guarantee, so two experiments with the same project+name
+        # share a data dir (the old create_user_dir(create_unique=True) suffixed
+        # on collision). A create_unique option would restore old behavior.
         resp = client.storage.create_dir(exp_dir, storage_resource_id=default_storage_id)
-        # create_dir returns the created path; fall back to the requested path.
         created = getattr(resp, "created_path", "") or exp_dir
         user_config.experiment_data_dir = created
     else:
-        # Ensure the directory exists on storage (the old code re-validated and
-        # created the absolute path via create_user_dir).
         client.storage.create_dir(
             user_config.experiment_data_dir, storage_resource_id=default_storage_id
         )
 
 
 def _sanitize_path_component(name):
-    """Sanitize a single path component for use in a storage path."""
     return (name or "").strip().replace(" ", "_")
 
 
 def _move_tmp_input_file_uploads_to_data_dir(client, experiment):
-    """Move any tmp input-file uploads into the experiment data dir.
-
-    Walks the experiment's URI / URI_COLLECTION inputs and relocates any data
-    product that is a tmp input-file upload, rewriting the input value to the
-    (possibly unchanged) data-product URI.
+    """Relocate any URI / URI_COLLECTION input that is a tmp upload into the
+    experiment data dir, rewriting the input value to the (same) data-product URI.
     """
     exp_data_dir = experiment.user_configuration_data.experiment_data_dir
     storage_id = experiment.user_configuration_data.input_storage_resource_id or None
@@ -181,12 +152,8 @@ def _move_tmp_input_file_uploads_to_data_dir(client, experiment):
 
 
 def _move_if_tmp_input_file_upload(client, data_product_uri, experiment_data_dir, storage_id):
-    """Move a tmp input-file upload into the data dir; return its (same) URI.
-
-    Reads the data product, and if it is a tmp upload, relocates the underlying
-    bytes and repoints its replica's file_path in place — preserving the
-    data-product URI (unlike the old portal, which created a copy + new URI; the
-    gRPC facade lets us keep the same product).
+    """If a tmp upload, relocate the bytes and repoint the replica's file_path in
+    place — preserving the data-product URI. Returns the (same) URI.
     """
     data_product = client.research.get_data_product(data_product_uri)
     if not is_input_file(data_product):
@@ -221,23 +188,21 @@ def _move_if_tmp_input_file_upload(client, data_product_uri, experiment_data_dir
 
 
 def _join_storage_path(directory, name):
-    """Join a storage directory and a file name with a single separator."""
     if not directory:
         return name
     return directory.rstrip("/") + "/" + name
 
 
-# ---------------------------------------------------------------------------
-# Clone
-# ---------------------------------------------------------------------------
-
-def clone(client, experiment_id, *, username, project_id=None) -> str:
-    """Clone an experiment and return the cloned experiment's id.
-
-    Picks a writeable target project (the given ``project_id`` if provided and
-    writeable, else the source experiment's project if writeable, else the first
-    writeable project), clones the experiment, copies its input files into fresh
-    tmp uploads, nulls out the data dir, and persists.
+def clone(
+    client: "AiravataClient",
+    experiment_id: str,
+    *,
+    username: str,
+    project_id: Optional[str] = None,
+) -> str:
+    """Clone into a writeable project (the given *project_id*, else the source's,
+    else the first writeable), copy input files into fresh tmp uploads, null the
+    data dir, persist. Returns the cloned id.
     """
     experiment = client.research.get_experiment(experiment_id)
     target_project_id = project_id or _get_writeable_project(client, experiment, username=username)
@@ -249,21 +214,16 @@ def clone(client, experiment_id, *, username, project_id=None) -> str:
     )
     cloned_experiment = client.research.get_experiment(cloned_experiment_id)
 
-    # Create a copy of the experiment input files.
     _copy_cloned_experiment_input_uris(client, cloned_experiment, username=username)
 
-    # Null out experiment_data_dir so a new one is created at launch time.
+    # Null experiment_data_dir so a fresh one is created at launch time.
     cloned_experiment.user_configuration_data.experiment_data_dir = ""
     client.research.update_experiment(cloned_experiment.experiment_id, cloned_experiment)
     return cloned_experiment_id
 
 
 def _get_writeable_project(client, experiment, *, username):
-    """Return a project id the user can write to.
-
-    Preference order: the experiment's own project (if writeable), else the
-    first writeable project among the user's projects.
-    """
+    """The experiment's own project if writeable, else the first writeable one."""
     project_id = experiment.project_id
     if _can_write(client, project_id, username=username):
         return project_id
@@ -281,21 +241,13 @@ def _get_writeable_project(client, experiment, *, username):
 
 
 def _can_write(client, entity_id, *, username) -> bool:
-    """Return True if the calling user has WRITE access to the entity.
-
-    The sharing service evaluates access for the authenticated request user; the
-    ``username`` is passed through as the request's user_id for completeness.
-    """
     return client.sharing.user_has_access(entity_id, username, _WRITE_PERMISSION)
 
 
 def _copy_cloned_experiment_input_uris(client, cloned_experiment, *, username):
-    """Copy URI / URI_COLLECTION input files for a freshly cloned experiment.
-
-    Each referenced data product is copied into a fresh tmp upload and the input
-    value is rewritten to the new data-product URI. Inputs whose source file is
-    missing are dropped (URI) or omitted (URI_COLLECTION), matching the old
-    portal.
+    """Copy each referenced data product into a fresh tmp upload and rewrite the
+    input value to the new URI. Missing source files are dropped (URI) / omitted
+    (URI_COLLECTION).
     """
     for experiment_input in cloned_experiment.experiment_inputs:
         if not experiment_input.value:
@@ -320,14 +272,9 @@ def _copy_cloned_experiment_input_uris(client, cloned_experiment, *, username):
 
 
 def _copy_experiment_input_uri(client, data_product_uri, *, username):
-    """Copy the file behind a data product into a fresh tmp upload.
-
-    Returns the new data-product URI, or None if the source file does not exist.
-
-    The storage facade has no copy primitive, so this downloads the source bytes
-    and re-uploads them to a fresh ``tmp`` path, then registers a new data
-    product pointing at the uploaded copy (the old portal's ``_copy_input_file``
-    -> ``_save_copy_of_data_product``).
+    """The storage facade has no copy primitive, so download the source bytes,
+    re-upload to a fresh tmp path, and register a new data product. Returns the
+    new URI, or None if the source file does not exist.
     """
     source_product = client.research.get_data_product(data_product_uri)
     replica = _gateway_data_store_replica(source_product)
@@ -353,9 +300,8 @@ def _copy_experiment_input_uri(client, data_product_uri, *, username):
         content_type=content_type,
     )
 
-    # Register a new data product for the uploaded copy (the storage facade's
-    # upload returns a minimal DataProductModel without a URI, so register it
-    # explicitly to obtain a persistent URI).
+    # The facade's upload returns a DataProductModel without a URI; register it
+    # explicitly to mint a persistent URI.
     new_product = _build_copy_data_product(
         client, source_product, dest_path, file_name, storage_id, username
     )
@@ -401,16 +347,14 @@ def _get_output_fetching_processes(experiment):
     ]
 
 
-def get_intermediate_output_process_status(client, experiment, *output_names):
-    """Return the ProcessStatus of the intermediate-output fetch process, or None.
-
-    Returns None when the experiment has no output-fetching processes or the
-    backend call fails.
-
-    NOTE: the gRPC facade's ``get_intermediate_output_process_status`` takes only
-    the experiment id (no per-output filtering), unlike the old Thrift call which
-    passed the output names. ``output_names`` is accepted for signature
-    compatibility but not forwarded.
+def get_intermediate_output_process_status(
+    client: "AiravataClient",
+    experiment: "experiment_pb2.ExperimentModel",
+    *output_names: str,
+) -> "Optional[status_pb2.ProcessStatus]":
+    """ProcessStatus of the intermediate-output fetch process, or None (no
+    output-fetching processes / backend error). ``output_names`` is accepted for
+    signature compatibility but the facade does not filter by it (see TODO).
     """
     output_fetching_processes = _get_output_fetching_processes(experiment)
     if not output_fetching_processes:
@@ -427,11 +371,13 @@ def get_intermediate_output_process_status(client, experiment, *output_names):
         return None
 
 
-def can_fetch_intermediate_output(client, experiment, output_name) -> bool:
-    """Return True if intermediate output can be fetched for the named output.
-
-    True only when at least one job is currently ACTIVE and there is no
-    in-progress (non-terminal) intermediate-output process.
+def can_fetch_intermediate_output(
+    client: "AiravataClient",
+    experiment: "experiment_pb2.ExperimentModel",
+    output_name: str,
+) -> bool:
+    """True only when at least one job is ACTIVE and there is no in-progress
+    (non-terminal) intermediate-output process.
     """
     jobs = []
     for process in experiment.processes:
@@ -458,19 +404,24 @@ def can_fetch_intermediate_output(client, experiment, output_name) -> bool:
         return True
 
 
-def fetch_intermediate_output(client, experiment_id, *output_names):
+def fetch_intermediate_output(
+    client: "AiravataClient",
+    experiment_id: str,
+    *output_names: str,
+):
     """Start a fetch of the output file(s) for a currently running experiment."""
     return client.research.get_intermediate_outputs(
         experiment_id, output_names=list(output_names)
     )
 
 
-def get_intermediate_output_data_products(client, experiment, output_name):
-    """Return the DataProduct instance(s) for the named intermediate output.
-
-    Looks at the most-recent completed output-fetching process, finds the
-    matching process output, and resolves its (comma-separated) data-product
-    URIs.
+def get_intermediate_output_data_products(
+    client: "AiravataClient",
+    experiment: "experiment_pb2.ExperimentModel",
+    output_name: str,
+) -> list:
+    """DataProduct(s) for the named output: the most-recent completed
+    output-fetching process's matching output, with its data-product URIs resolved.
     """
     output_fetching_processes = _get_output_fetching_processes(experiment)
 
@@ -480,7 +431,6 @@ def get_intermediate_output_data_products(client, experiment, output_name):
 
     most_recent_completed_output = None
     for process in output_fetching_processes:
-        # Skip processes that aren't completed.
         if (
             not process.process_statuses
             or process.process_statuses[-1].state != status_pb2.PROCESS_STATE_COMPLETED

--- a/airavata-python-sdk/airavata_sdk/helpers/iam_resources.py
+++ b/airavata-python-sdk/airavata_sdk/helpers/iam_resources.py
@@ -1,0 +1,169 @@
+"""IAM / user-profile helpers.
+
+Two families:
+
+* **user-profiles** (``get_user_profile`` / ``get_all_user_profiles_in_gateway``)
+  — read-only; the ``UserProfile`` proto is returned as-is (nothing
+  cross-service is computed).
+* **IAM users** (:class:`IAMUser` / :class:`UnverifiedEmailUser`) — the
+  administrator-facing managed-account view backed by the Keycloak IAM-admin
+  facade (``GetUsers`` / ``GetUser``). A genuinely composed multi-source shape
+  (proto-derived scalars unioned with a sharing group list, two Django-ORM
+  lookups, a gateway-admin flag, and a ``DoesUserExist`` result), so it is a
+  pydantic model carrying plain JSON-able values the ViewSet supplies.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+if TYPE_CHECKING:
+    from airavata_sdk.client import AiravataClient
+    from airavata_sdk.generated.org.apache.airavata.model.user import (
+        user_profile_pb2,
+    )
+
+
+def get_user_profile(
+    client: "AiravataClient",
+    user_id: str,
+) -> "user_profile_pb2.UserProfile":
+    return client.iam.get_user_profile_by_id(user_id, client.gateway_id)
+
+
+def get_all_user_profiles_in_gateway(
+    client: "AiravataClient",
+    *,
+    offset: int = 0,
+    limit: int = -1,
+) -> "list[user_profile_pb2.UserProfile]":
+    return list(client.iam.get_all_user_profiles_in_gateway(
+        client.gateway_id, offset, limit,
+    ))
+
+
+# IAM user (managed Keycloak user). enabled/email_verified/email/creation_time
+# are derived from the proto; the rest (DoesUserExist result, sharing group
+# list, gateway-admin flag, two Django-ORM lookups) the ViewSet passes in.
+
+
+class IAMUser(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    airavata_internal_user_id: str
+    user_id: str
+    gateway_id: str
+    email: str
+    first_name: str
+    last_name: str
+    enabled: bool
+    email_verified: bool
+    creation_time: str
+    airavata_user_profile_exists: bool
+    user_has_write_access: bool
+    groups: list[dict[str, Any]]
+    external_idp_user_info: dict[str, Any]
+    user_profile_invalid_fields: list[Any]
+
+
+class UnverifiedEmailUser(BaseModel):
+    """A strict subset of :class:`IAMUser`: proto-derived scalars plus
+    ``user_has_write_access``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    user_id: str
+    gateway_id: str
+    email: str
+    first_name: str
+    last_name: str
+    enabled: bool
+    email_verified: bool
+    creation_time: str
+    user_has_write_access: bool
+
+
+def _iam_user_state_flags(state) -> tuple[bool, bool]:
+    """``(enabled, email_verified)``: enabled iff ACTIVE; email_verified iff
+    CONFIRMED or ACTIVE.
+    """
+    from airavata_sdk.generated.org.apache.airavata.model.user import (
+        user_profile_pb2,
+    )
+
+    Status = user_profile_pb2.Status
+    enabled = state == Status.ACTIVE
+    email_verified = state in (Status.CONFIRMED, Status.ACTIVE)
+    return enabled, email_verified
+
+
+def get_iam_user(
+    client: "AiravataClient",
+    user_profile,
+    *,
+    airavata_user_profile_exists: bool,
+    user_has_write_access: bool,
+    groups: "Optional[list[dict[str, Any]]]" = None,
+    external_idp_user_info: "Optional[dict[str, Any]]" = None,
+    user_profile_invalid_fields: "Optional[list[Any]]" = None,
+) -> IAMUser:
+    """Compose an already-fetched IAM ``UserProfile`` proto into an ``IAMUser``.
+
+    The cross-service / request-scoped / ORM parts are supplied by the caller.
+    """
+    enabled, email_verified = _iam_user_state_flags(user_profile.state)
+    return IAMUser(
+        airavata_internal_user_id=user_profile.airavata_internal_user_id,
+        user_id=user_profile.user_id,
+        gateway_id=user_profile.gateway_id,
+        email=user_profile.emails[0] if user_profile.emails else "",
+        first_name=user_profile.first_name,
+        last_name=user_profile.last_name,
+        enabled=enabled,
+        email_verified=email_verified,
+        creation_time=str(user_profile.creation_time),
+        airavata_user_profile_exists=airavata_user_profile_exists,
+        user_has_write_access=user_has_write_access,
+        groups=groups or [],
+        external_idp_user_info=external_idp_user_info or {},
+        user_profile_invalid_fields=(
+            [] if user_profile_invalid_fields is None
+            else user_profile_invalid_fields),
+    )
+
+
+def get_unverified_email_user(
+    client: "AiravataClient",
+    user_profile,
+    *,
+    user_has_write_access: bool,
+) -> UnverifiedEmailUser:
+    enabled, email_verified = _iam_user_state_flags(user_profile.state)
+    return UnverifiedEmailUser(
+        user_id=user_profile.user_id,
+        gateway_id=user_profile.gateway_id,
+        email=user_profile.emails[0] if user_profile.emails else "",
+        first_name=user_profile.first_name,
+        last_name=user_profile.last_name,
+        enabled=enabled,
+        email_verified=email_verified,
+        creation_time=str(user_profile.creation_time),
+        user_has_write_access=user_has_write_access,
+    )
+
+
+def list_iam_users(
+    client: "AiravataClient",
+    *,
+    offset: int = 0,
+    limit: int = -1,
+    search: str = "",
+) -> list:
+    """Raw IAM ``UserProfile`` protos (``GetUsers``); the caller composes each
+    :class:`IAMUser` via :func:`get_iam_user` (per-user enrichment needs
+    per-user lookups).
+    """
+    return client.iam.get_iam_users(offset=offset, limit=limit, search=search)

--- a/airavata-python-sdk/airavata_sdk/helpers/models.py
+++ b/airavata-python-sdk/airavata_sdk/helpers/models.py
@@ -1,0 +1,99 @@
+"""Write-path input models: permissive pydantic shapes naming the writable
+fields the ``create_*`` / ``update_*`` helpers accept, so a caller can hand in a
+plain snake_case dict and have it validated before it is assembled into a proto.
+
+Enum fields are ``int | str | None`` (member NAME string or historical Thrift
+int); timestamp fields are ``int | str | None`` (epoch millis or ISO string).
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from pydantic import BaseModel, ConfigDict
+
+
+class _Base(BaseModel):
+    # extra='allow' so an unexpected key round-trips untouched.
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+
+class WorkspaceDefaultsModel(_Base):
+    most_recent_project_id: Optional[str] = None
+    group_resource_profile_ids: list[str] = []
+    most_recent_group_resource_profile_id: Optional[str] = None
+
+
+class ProjectCreate(_Base):
+    name: Optional[str] = None
+    description: Optional[str] = None
+
+
+class ExperimentCreate(_Base):
+    experiment_id: Optional[str] = None
+    project_id: Optional[str] = None
+    experiment_type: Union[int, str, None] = None
+    experiment_name: Optional[str] = None
+    description: Optional[str] = None
+    execution_id: Optional[str] = None
+    enable_email_notification: Optional[bool] = None
+    email_addresses: Optional[list[str]] = None
+    experiment_inputs: Optional[list[dict]] = None
+    experiment_outputs: Optional[list[dict]] = None
+    user_configuration_data: Optional[dict] = None
+
+
+class NotificationCreate(_Base):
+    title: Optional[str] = None
+    notification_message: Optional[str] = None
+    creation_time: Union[int, str, None] = None
+    published_time: Union[int, str, None] = None
+    expiration_time: Union[int, str, None] = None
+    priority: Union[int, str, None] = None
+
+
+class ParserCreate(_Base):
+    id: Optional[str] = None
+    image_name: Optional[str] = None
+    output_dir_path: Optional[str] = None
+    input_dir_path: Optional[str] = None
+    execution_command: Optional[str] = None
+    input_files: Optional[list[dict]] = None
+    output_files: Optional[list[dict]] = None
+
+
+class ApplicationInterfaceCreate(_Base):
+    application_interface_id: Optional[str] = None
+    application_name: Optional[str] = None
+    application_description: Optional[str] = None
+    application_modules: Optional[list[str]] = None
+    application_inputs: Optional[list[dict]] = None
+    application_outputs: Optional[list[dict]] = None
+    archive_working_directory: Optional[bool] = None
+
+
+class ApplicationDeploymentCreate(_Base):
+    app_module_id: Optional[str] = None
+    compute_host_id: Optional[str] = None
+    executable_path: Optional[str] = None
+    parallelism: Union[int, str, None] = None
+    app_deployment_description: Optional[str] = None
+    module_load_cmds: Optional[list[dict]] = None
+    lib_prepend_paths: Optional[list[dict]] = None
+    lib_append_paths: Optional[list[dict]] = None
+    set_environment: Optional[list[dict]] = None
+    pre_job_commands: Optional[list[dict]] = None
+    post_job_commands: Optional[list[dict]] = None
+    default_queue_name: Optional[str] = None
+    default_node_count: Optional[int] = None
+    default_cpu_count: Optional[int] = None
+    default_walltime: Optional[int] = None
+    editable_by_user: Optional[bool] = None
+
+
+class GroupResourceProfileCreate(_Base):
+    group_resource_profile_id: Optional[str] = None
+    group_resource_profile_name: Optional[str] = None
+    compute_preferences: Optional[list[dict]] = None
+    compute_resource_policies: Optional[list[dict]] = None
+    batch_queue_resource_policies: Optional[list[dict]] = None

--- a/airavata-python-sdk/airavata_sdk/helpers/queue_settings.py
+++ b/airavata-python-sdk/airavata_sdk/helpers/queue_settings.py
@@ -1,16 +1,8 @@
-"""Queue-settings calculator registry.
+"""In-process queue-settings calculator registry (no framework deps).
 
-Relocated verbatim (in behavior) from
-``airavata_django_portal_sdk.queue_settings_calculators`` plus the
-``queue_settings_calculator`` decorator from ``decorators.py``. This is a pure
-in-process registry with no framework dependencies.
-
-A gateway registers calculator functions with the
-:func:`queue_settings_calculator` decorator, then invokes them by id via
-:func:`calculate_queue_settings`. The registered callable receives whatever
-positional/keyword arguments the caller passes through, so an existing portal
-caller can keep invoking ``calculate_queue_settings(id, request, experiment_model)``
-unchanged.
+A gateway registers calculators with :func:`queue_settings_calculator`, then
+invokes them by id via :func:`calculate_queue_settings`; positional/keyword args
+are forwarded verbatim to the registered callable.
 """
 
 from typing import Callable, NamedTuple
@@ -25,9 +17,7 @@ class QueueSettingsCalculator(NamedTuple):
 
 
 def queue_settings_calculator(_func=None, *, id=None, name=None, **kwargs):
-    """Decorator for registering queue settings calculator functions."""
     def decorator(func):
-        # Register decorator
         name_ = name
         if name_ is None:
             name_ = func.__name__
@@ -45,11 +35,6 @@ def queue_settings_calculator(_func=None, *, id=None, name=None, **kwargs):
 
 
 def calculate_queue_settings(calculator_id, *args, **kwargs):
-    """Invoke a queue settings calculator by id.
-
-    Any positional and keyword arguments are forwarded verbatim to the
-    registered calculator function.
-    """
     calcs = [calc for calc in QUEUE_SETTINGS_CALCULATORS if calc.id == calculator_id]
     if len(calcs) == 0:
         raise LookupError(f"Could not find queue settings calculator for {calculator_id}")
@@ -61,7 +46,6 @@ def calculate_queue_settings(calculator_id, *args, **kwargs):
 
 
 def get_all():
-    """Return a list of all registered queue settings calculators."""
     return QUEUE_SETTINGS_CALCULATORS.copy()
 
 
@@ -71,6 +55,5 @@ def exists(calculator_id):
 
 
 def reset_registry():
-    """Reset registry, used for testing."""
     global QUEUE_SETTINGS_CALCULATORS
     QUEUE_SETTINGS_CALCULATORS = []

--- a/airavata-python-sdk/airavata_sdk/helpers/research_resources.py
+++ b/airavata-python-sdk/airavata_sdk/helpers/research_resources.py
@@ -1,0 +1,1430 @@
+"""Research-domain helpers (proto-direct). Each family returns objects, not dicts:
+
+* a plain resource -> its proto, returned wholesale;
+* a resource needing cross-service sharing-access flags ->
+  :class:`~airavata_sdk.helpers._envelope.WithAccess` (proto + chained scalars);
+* a composed multi-proto shape (full-experiment) -> a pydantic model carrying
+  the component protos / envelopes wholesale.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+from airavata_sdk.helpers._envelope import WithAccess
+from airavata_sdk.helpers.models import (
+    ApplicationDeploymentCreate,
+    ApplicationInterfaceCreate,
+    ExperimentCreate,
+    NotificationCreate,
+    ParserCreate,
+    ProjectCreate,
+)
+
+if TYPE_CHECKING:
+    from airavata_sdk.client import AiravataClient
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.appdeployment import (  # noqa: E501
+        app_deployment_pb2,
+    )
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.appinterface import (  # noqa: E501
+        app_interface_pb2,
+    )
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.parser import (  # noqa: E501
+        parser_pb2,
+    )
+    from airavata_sdk.generated.org.apache.airavata.model.data.replica import (
+        replica_catalog_pb2,
+    )
+    from airavata_sdk.generated.org.apache.airavata.model.experiment import (
+        experiment_pb2,
+    )
+    from airavata_sdk.generated.org.apache.airavata.model.job import (
+        job_pb2,
+    )
+    from airavata_sdk.generated.org.apache.airavata.model.workspace import (
+        workspace_pb2,
+    )
+
+
+# Project (reference family) — WithAccess. is_owner is SDK-trivial
+# (proto.owner == client.username); user_has_write_access is a chained
+# sharing.user_has_access WRITE lookup.
+
+
+def get_project(client: "AiravataClient", project_id: str) -> "WithAccess":
+    p = client.research.get_project(project_id)
+    return WithAccess(
+        message=p,
+        is_owner=(p.owner == client.username),
+        user_has_write_access=client.sharing.user_has_access(
+            resource_id=project_id,
+            user_id=client.username,
+            permission_type="WRITE",
+        ),
+    )
+
+
+def list_projects(
+    client: "AiravataClient",
+    *,
+    limit: int = -1,
+    offset: int = 0,
+) -> "list[WithAccess]":
+    projects = client.research.get_user_projects(
+        gateway_id=client.gateway_id,
+        user_name=client.username,
+        limit=limit,
+        offset=offset,
+    )
+    return [
+        WithAccess(
+            message=p,
+            is_owner=(p.owner == client.username),
+            user_has_write_access=client.sharing.user_has_access(
+                resource_id=p.project_id,
+                user_id=client.username,
+                permission_type="WRITE",
+            ),
+        )
+        for p in projects
+    ]
+
+
+def create_project(
+    client: "AiravataClient",
+    data: "ProjectCreate | dict",
+) -> "WithAccess":
+    """``owner`` / ``gateway_id`` are forced from the client context. Re-fetched
+    so the shape matches the read path.
+    """
+    from airavata_sdk.generated.org.apache.airavata.model.workspace import (
+        workspace_pb2,
+    )
+
+    data = ProjectCreate.model_validate(data).model_dump(exclude_unset=True)
+    project = workspace_pb2.Project(
+        owner=client.username or "",
+        gateway_id=client.gateway_id or "",
+        name=data.get("name") or "",
+        description=data.get("description") or "",
+    )
+    project_id = client.research.create_project(client.gateway_id, project)
+    return get_project(client, project_id)
+
+
+def update_project(
+    client: "AiravataClient",
+    project_id: str,
+    data: "ProjectCreate | dict",
+) -> "WithAccess":
+    """Only ``name`` / ``description`` are mutable. Re-fetched so the shape
+    matches the read path.
+    """
+    data = ProjectCreate.model_validate(data).model_dump(exclude_unset=True)
+    project = client.research.get_project(project_id)
+    if "name" in data:
+        project.name = data["name"] or ""
+    if "description" in data:
+        project.description = data["description"] or ""
+    client.research.update_project(project_id, project)
+    return get_project(client, project_id)
+
+
+# Gateway-catalog families (ApplicationModule, ApplicationInterface,
+# Notification, GatewayResourceProfile) — WithAccess with no owner (is_owner
+# always False) and user_has_write_access = the gateway-admin flag the ViewSet
+# supplies as has_write (not a sharing lookup).
+
+
+def get_application_module(
+    client: "AiravataClient",
+    app_module_id: str,
+    *,
+    has_write: bool,
+) -> "WithAccess":
+    m = client.research.get_application_module(app_module_id)
+    return WithAccess(
+        message=m,
+        is_owner=False,
+        user_has_write_access=has_write,
+    )
+
+
+def list_application_modules(
+    client: "AiravataClient",
+    *,
+    has_write: bool,
+    accessible_only: bool = True,
+) -> "list[WithAccess]":
+    """*accessible_only* True (default) -> only modules the caller can access;
+    False -> every module in the gateway (the ``list_all`` action).
+    """
+    if accessible_only:
+        modules = client.research.get_accessible_app_modules(
+            gateway_id=client.gateway_id)
+    else:
+        modules = client.research.get_all_app_modules(
+            gateway_id=client.gateway_id)
+    return [
+        WithAccess(message=m, is_owner=False, user_has_write_access=has_write)
+        for m in modules
+    ]
+
+
+def create_application_module(
+    client: "AiravataClient",
+    data: dict,
+    *,
+    has_write: bool,
+) -> "WithAccess":
+    """Re-fetched so the server-assigned ``app_module_id`` is populated and the
+    shape matches the read path.
+    """
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.appdeployment import (  # noqa: E501
+        app_deployment_pb2,
+    )
+
+    module = app_deployment_pb2.ApplicationModule(
+        app_module_name=data.get("app_module_name") or "",
+        app_module_version=data.get("app_module_version") or "",
+        app_module_description=data.get("app_module_description") or "",
+    )
+    app_module_id = client.research.register_application_module(
+        client.gateway_id, module)
+    return get_application_module(client, app_module_id, has_write=has_write)
+
+
+def update_application_module(
+    client: "AiravataClient",
+    app_module_id: str,
+    data: dict,
+    *,
+    has_write: bool,
+) -> "WithAccess":
+    """``app_module_name`` / ``app_module_version`` / ``app_module_description``
+    are mutable. Re-fetched so the shape matches the read path.
+    """
+    module = client.research.get_application_module(app_module_id)
+    if "app_module_name" in data:
+        module.app_module_name = data["app_module_name"] or ""
+    if "app_module_version" in data:
+        module.app_module_version = data["app_module_version"] or ""
+    if "app_module_description" in data:
+        module.app_module_description = data["app_module_description"] or ""
+    client.research.update_application_module(app_module_id, module)
+    return get_application_module(client, app_module_id, has_write=has_write)
+
+
+# Experiment (experiments-core) — WithAccess. The whole process/task/job tree
+# flows through the proto wholesale. is_owner is always False (the read model has
+# no ownership flag); user_has_write_access is a chained sharing WRITE lookup.
+
+
+def get_experiment(
+    client: "AiravataClient",
+    experiment_id: str,
+) -> "WithAccess":
+    e = client.research.get_experiment(experiment_id)
+    return WithAccess(
+        message=e,
+        is_owner=False,
+        user_has_write_access=client.sharing.user_has_access(
+            resource_id=experiment_id,
+            user_id=client.username,
+            permission_type="WRITE",
+        ),
+    )
+
+
+def get_experiment_proto(
+    client: "AiravataClient",
+    experiment_id: str,
+) -> "experiment_pb2.ExperimentModel":
+    """The bare proto (vs. the :func:`get_experiment` envelope), for callers that
+    work with proto fields directly — notably portal output-view-provider data
+    generation.
+    """
+    return client.research.get_experiment(experiment_id)
+
+
+def get_experiments_in_project(
+    client: "AiravataClient",
+    project_id: str,
+    *,
+    limit: int = -1,
+    offset: int = 0,
+) -> "list[WithAccess]":
+    experiments = client.research.get_experiments_in_project(
+        project_id, limit, offset)
+    return [
+        WithAccess(
+            message=e,
+            is_owner=False,
+            user_has_write_access=client.sharing.user_has_access(
+                resource_id=e.experiment_id,
+                user_id=client.username,
+                permission_type="WRITE",
+            ),
+        )
+        for e in experiments
+    ]
+
+
+def list_experiment_jobs(
+    client: "AiravataClient",
+    experiment_id: str,
+) -> "list[job_pb2.JobModel]":
+    """Bare ``JobModel`` protos (``GetJobDetails``) — a job has no ownership or
+    sharing concept.
+    """
+    return list(client.research.get_job_details(experiment_id))
+
+
+# FullExperiment — a composed multi-proto shape: the experiment plus every
+# resolved reference (project, app module, compute resource, input/output data
+# products, job details) and the portal-computed output_views map. Each
+# component is produced by the proto-direct component function above and carried
+# wholesale, so the family inherits each family's field handling / access flags.
+# Optional references resolve to None on lookup failure / no READ access.
+
+
+class FullExperiment(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    experiment_id: str
+    experiment: Any
+    project: Optional[Any]
+    application_module: Optional[Any]
+    compute_resource: Optional[Any]
+    input_data_products: list[Any]
+    output_data_products: list[Any]
+    job_details: list[Any]
+    output_views: dict
+
+
+def _data_type_pb2():
+    from airavata_sdk.generated.org.apache.airavata.model.application.io import (
+        application_io_pb2 as io,
+    )
+    return io.DataType
+
+
+def _collect_data_product_uris(io_objects) -> list[str]:
+    """``airavata-dp`` URIs referenced by input/output protos: single-URI types
+    (URI / STDOUT / STDERR) contribute their ``value``, URI_COLLECTION each
+    comma-separated member. All single URIs first, then collection members.
+    """
+    DT = _data_type_pb2()
+    single = [
+        o.value for o in io_objects
+        if (o.value and o.value.startswith("airavata-dp") and
+            o.type in (DT.URI, DT.STDOUT, DT.STDERR))
+    ]
+    collection = [
+        dp
+        for o in io_objects
+        if o.value and o.type == DT.URI_COLLECTION
+        for dp in o.value.split(",")
+        if o.value.startswith("airavata-dp")
+    ]
+    return single + collection
+
+
+def get_full_experiment(
+    client: "AiravataClient",
+    experiment_id: str,
+    *,
+    project_has_read: bool,
+    module_has_write: bool,
+    data_product_write_fn,
+    output_views_fn,
+) -> "FullExperiment":
+    """Compose the full-experiment view. Request-bound inputs the SDK cannot
+    derive are supplied by the ViewSet:
+
+    * *project_has_read* — when ``False`` the project is omitted.
+    * *module_has_write* — the gateway-admin write flag for the nested module.
+    * *data_product_write_fn* — ``(data_product_proto) -> bool``, the per-product
+      ``user_has_write_access`` flag.
+    * *output_views_fn* — ``(experiment, app_interface_or_None) -> dict``, the
+      portal-computed view-provider map.
+
+    Errors resolving an optional reference leave it ``None``.
+    """
+    from airavata_sdk.helpers import compute_resources
+
+    experiment_env = get_experiment(client, experiment_id)
+    experiment = experiment_env.message
+
+    # Resolve referenced data products for outputs then inputs (order matches
+    # the old view).
+    output_uris = _collect_data_product_uris(experiment.experiment_outputs)
+    input_uris = _collect_data_product_uris(experiment.experiment_inputs)
+    output_products = [
+        client.research.get_data_product(uri) for uri in output_uris]
+    input_products = [
+        client.research.get_data_product(uri) for uri in input_uris]
+
+    # Resolve the application interface (execution_id) → module.
+    application_interface = None
+    try:
+        application_interface = client.research.get_application_interface(
+            experiment.execution_id)
+    except Exception:
+        application_interface = None
+
+    output_views = output_views_fn(experiment, application_interface)
+
+    application_module = None
+    try:
+        if (application_interface is not None and
+                application_interface.application_modules):
+            application_module = get_application_module(
+                client,
+                application_interface.application_modules[0],
+                has_write=module_has_write,
+            )
+    except Exception:
+        application_module = None
+
+    # Resolve the compute resource from the scheduling host id, when set.
+    compute_resource = None
+    compute_resource_id = None
+    if experiment.HasField("user_configuration_data"):
+        ucd = experiment.user_configuration_data
+        if ucd.HasField("computational_resource_scheduling"):
+            compute_resource_id = (
+                ucd.computational_resource_scheduling.resource_host_id)
+    if compute_resource_id:
+        try:
+            compute_resource = compute_resources.get_compute_resource(
+                client, compute_resource_id)
+        except Exception:
+            compute_resource = None
+
+    # Resolve the project (only when the caller may READ it).
+    project = None
+    if project_has_read:
+        project = get_project(client, experiment.project_id)
+
+    job_details = list_experiment_jobs(client, experiment_id)
+
+    input_data_products = [
+        WithAccess(
+            message=dp,
+            is_owner=bool(dp.owner_name) and (dp.owner_name == client.username),
+            user_has_write_access=data_product_write_fn(dp),
+        )
+        for dp in input_products
+    ]
+    output_data_products = [
+        WithAccess(
+            message=dp,
+            is_owner=bool(dp.owner_name) and (dp.owner_name == client.username),
+            user_has_write_access=data_product_write_fn(dp),
+        )
+        for dp in output_products
+    ]
+
+    return FullExperiment(
+        experiment_id=experiment.experiment_id,
+        experiment=experiment_env,
+        project=project,
+        application_module=application_module,
+        compute_resource=compute_resource,
+        input_data_products=input_data_products,
+        output_data_products=output_data_products,
+        job_details=job_details,
+        output_views=output_views,
+    )
+
+
+def _build_input_data_object(data: dict):
+    return _proto_input_data_object(data)
+
+
+def _build_output_data_object(data: dict):
+    return _proto_output_data_object(data)
+
+
+def _build_computational_resource_scheduling(data: dict):
+    from airavata_sdk.generated.org.apache.airavata.model.scheduling import (
+        scheduling_pb2,
+    )
+
+    return scheduling_pb2.ComputationalResourceSchedulingModel(
+        resource_host_id=data.get("resource_host_id") or "",
+        total_cpu_count=data.get("total_cpu_count") or 0,
+        node_count=data.get("node_count") or 0,
+        number_of_threads=data.get("number_of_threads") or 0,
+        queue_name=data.get("queue_name") or "",
+        wall_time_limit=data.get("wall_time_limit") or 0,
+        total_physical_memory=data.get("total_physical_memory") or 0,
+        chessis_number=data.get("chessis_number") or "",
+        static_working_dir=data.get("static_working_dir") or "",
+        override_login_user_name=data.get("override_login_user_name") or "",
+        override_scratch_location=data.get("override_scratch_location") or "",
+        override_allocation_project_number=data.get(
+            "override_allocation_project_number") or "",
+        m_group_count=data.get("m_group_count") or 0,
+    )
+
+
+def _build_user_configuration_data(data: dict):
+    """Only the user-submittable scalar fields, plus the singular
+    ``computational_resource_scheduling`` when present.
+    """
+    from airavata_sdk.generated.org.apache.airavata.model.experiment import (
+        experiment_pb2,
+    )
+
+    crs = data.get("computational_resource_scheduling")
+    kwargs = dict(
+        airavata_auto_schedule=bool(data.get("airavata_auto_schedule", False)),
+        override_manual_scheduled_params=bool(
+            data.get("override_manual_scheduled_params", False)),
+        share_experiment_publicly=bool(
+            data.get("share_experiment_publicly", False)),
+        throttle_resources=bool(data.get("throttle_resources", False)),
+        user_dn=data.get("user_dn") or "",
+        generate_cert=bool(data.get("generate_cert", False)),
+        input_storage_resource_id=data.get("input_storage_resource_id") or "",
+        output_storage_resource_id=data.get("output_storage_resource_id") or "",
+        experiment_data_dir=data.get("experiment_data_dir") or "",
+        use_user_cr_pref=bool(data.get("use_user_cr_pref", False)),
+        group_resource_profile_id=data.get("group_resource_profile_id") or "",
+    )
+    if crs is not None:
+        kwargs["computational_resource_scheduling"] = (
+            _build_computational_resource_scheduling(crs))
+    return experiment_pb2.UserConfigurationDataModel(**kwargs)
+
+
+def _build_experiment(client: "AiravataClient", data: dict):
+    """Only the user-submittable fields (status / errors / processes / workflow
+    are server-managed). ``gateway_id`` / ``user_name`` are forced from the
+    client context.
+    """
+    from airavata_sdk.generated.org.apache.airavata.model.experiment import (
+        experiment_pb2,
+    )
+
+    ucd = data.get("user_configuration_data")
+    kwargs = dict(
+        experiment_id=data.get("experiment_id") or "",
+        project_id=data.get("project_id") or "",
+        gateway_id=client.gateway_id or "",
+        experiment_type=_experiment_type_int(data.get("experiment_type")),
+        user_name=client.username or "",
+        experiment_name=data.get("experiment_name") or "",
+        description=data.get("description") or "",
+        execution_id=data.get("execution_id") or "",
+        enable_email_notification=bool(
+            data.get("enable_email_notification", False)),
+        email_addresses=list(data.get("email_addresses") or []),
+        experiment_inputs=[
+            _build_input_data_object(i)
+            for i in (data.get("experiment_inputs") or [])],
+        experiment_outputs=[
+            _build_output_data_object(o)
+            for o in (data.get("experiment_outputs") or [])],
+    )
+    if ucd is not None:
+        kwargs["user_configuration_data"] = _build_user_configuration_data(ucd)
+    return experiment_pb2.ExperimentModel(**kwargs)
+
+
+def _experiment_type_int(value) -> int:
+    """``experiment_type`` -> proto enum int. Accepts the Thrift int (0 ->
+    SINGLE_APPLICATION/1, 1 -> WORKFLOW/2) or the member NAME; None/"" -> 0.
+    """
+    from airavata_sdk.generated.org.apache.airavata.model.experiment import (
+        experiment_pb2,
+    )
+
+    if value is None or value == "":
+        return 0
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        thrift_to_proto = {0: 1, 1: 2}
+        return thrift_to_proto.get(value, 0)
+    name = str(value)
+    enum = experiment_pb2.ExperimentType
+    try:
+        return enum.Value(name)
+    except ValueError:
+        prefixed = "EXPERIMENT_TYPE_" + name
+        try:
+            return enum.Value(prefixed)
+        except ValueError:
+            return 0
+
+
+def build_experiment(
+    client: "AiravataClient",
+    data: "ExperimentCreate | dict",
+):
+    """Validate *data* and assemble a proto ``ExperimentModel`` (no RPC).
+
+    The public parse entry point for callers that need only the model — e.g. the
+    queue-settings calculator. ``create_experiment`` / ``update_experiment`` use
+    the same validate-then-build path before submitting.
+    """
+    data = ExperimentCreate.model_validate(data).model_dump(exclude_unset=True)
+    return _build_experiment(client, data)
+
+
+def create_experiment(
+    client: "AiravataClient",
+    data: "ExperimentCreate | dict",
+) -> "WithAccess":
+    """The server mints the ``experiment_id``; re-fetched so the shape matches
+    the read path. New id at ``result.message.experiment_id``.
+    """
+    experiment = build_experiment(client, data)
+    experiment_id = client.research.create_experiment(
+        client.gateway_id, experiment)
+    return get_experiment(client, experiment_id)
+
+
+def update_experiment(
+    client: "AiravataClient",
+    experiment_id: str,
+    data: "ExperimentCreate | dict",
+) -> "WithAccess":
+    """The proto is rebuilt wholesale from *data* (``experiment_id`` forced),
+    pushed, and re-fetched so the shape matches the read path.
+    """
+    experiment = build_experiment(client, data)
+    experiment.experiment_id = experiment_id
+    client.research.update_experiment(experiment_id, experiment)
+    return get_experiment(client, experiment_id)
+
+
+# ExperimentSummary (experiment-search) — WithAccess. is_owner always False (no
+# owner field); user_has_write_access is a per-summary chained sharing WRITE
+# lookup.
+
+
+def search_experiments(
+    client: "AiravataClient",
+    *,
+    filters: Optional[dict] = None,
+    limit: int = -1,
+    offset: int = 0,
+) -> "list[WithAccess]":
+    """*filters* is a ``map<string, string>`` keyed by ``ExperimentSearchFields``
+    member name, passed straight through to ``SearchExperiments``.
+    """
+    summaries = client.research.search_experiments(
+        gateway_id=client.gateway_id,
+        user_name=client.username,
+        filters=filters or {},
+        limit=limit,
+        offset=offset,
+    )
+    return [
+        WithAccess(
+            message=e,
+            is_owner=False,
+            user_has_write_access=client.sharing.user_has_access(
+                resource_id=e.experiment_id,
+                user_id=client.username,
+                permission_type="WRITE",
+            ),
+        )
+        for e in summaries
+    ]
+
+
+# ExperimentStatistics — bare proto (already carries the full shape: six
+# per-state counts plus six per-state summary lists; nothing cross-service).
+
+
+def get_experiment_statistics(
+    client: "AiravataClient",
+    *,
+    from_time: int,
+    to_time: int,
+    user_name: Optional[str] = None,
+    application_name: Optional[str] = None,
+    resource_host_name: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> "experiment_pb2.ExperimentStatistics":
+    """``from_time`` / ``to_time`` are epoch-millis bounds; the optional filters
+    map to string fields (``None`` -> ``""``).
+    """
+    return client.research.get_experiment_statistics(
+        gateway_id=client.gateway_id,
+        from_time=from_time,
+        to_time=to_time,
+        user_name=user_name or "",
+        application_name=application_name or "",
+        resource_host_name=resource_host_name or "",
+        limit=limit,
+        offset=offset,
+    )
+
+
+# Notification — gateway-catalog WithAccess (is_owner always False;
+# user_has_write_access = has_write). The portal-only show_in_dashboard flag
+# lives in a Django table and is merged by the ViewSet, not here.
+
+
+def _to_epoch_ms(value) -> int:
+    """Timestamp -> epoch-millis int. ``None`` / ``""`` / ``0`` -> 0; int as-is;
+    ISO-8601 string -> epoch millis.
+    """
+    if not value:
+        return 0
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    # ISO-8601 string — normalise a trailing ``Z`` to ``+00:00`` for fromisoformat.
+    s = str(value)
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    dt = datetime.fromisoformat(s)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1000)
+
+
+def _to_priority_int(value) -> int:
+    """priority -> proto ``NotificationPriority`` int. Member NAME (e.g.
+    ``"HIGH"``) or int; None/""/unknown -> 0.
+    """
+    from airavata_sdk.generated.org.apache.airavata.model.workspace import (
+        workspace_pb2,
+    )
+
+    if not value:
+        return 0
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    name = str(value)
+    enum = workspace_pb2.NotificationPriority
+    try:
+        return enum.Value(name)
+    except ValueError:
+        prefixed = "NOTIFICATION_PRIORITY_" + name
+        try:
+            return enum.Value(prefixed)
+        except ValueError:
+            return 0
+
+
+def _build_notification(
+    client: "AiravataClient",
+    data: dict,
+    *,
+    base: "Optional[workspace_pb2.Notification]" = None,
+) -> "workspace_pb2.Notification":
+    """*base* (the update path) seeds the proto; absent keys keep the base value
+    or the proto default. ``gateway_id`` is forced to the client's gateway.
+    """
+    from airavata_sdk.generated.org.apache.airavata.model.workspace import (
+        workspace_pb2,
+    )
+
+    n = workspace_pb2.Notification()
+    if base is not None:
+        n.CopyFrom(base)
+    n.gateway_id = client.gateway_id or ""
+    if "title" in data:
+        n.title = data["title"] or ""
+    if "notification_message" in data:
+        n.notification_message = data["notification_message"] or ""
+    if "creation_time" in data:
+        n.creation_time = _to_epoch_ms(data["creation_time"])
+    if "published_time" in data:
+        n.published_time = _to_epoch_ms(data["published_time"])
+    if "expiration_time" in data:
+        n.expiration_time = _to_epoch_ms(data["expiration_time"])
+    if "priority" in data:
+        n.priority = _to_priority_int(data["priority"])
+    return n
+
+
+def get_notification(
+    client: "AiravataClient",
+    notification_id: str,
+    *,
+    has_write: bool,
+) -> "WithAccess":
+    n = client.research.get_notification(client.gateway_id, notification_id)
+    return WithAccess(
+        message=n,
+        is_owner=False,
+        user_has_write_access=has_write,
+    )
+
+
+def list_notifications(
+    client: "AiravataClient",
+    *,
+    has_write: bool,
+) -> "list[WithAccess]":
+    notifications = client.research.get_all_notifications(client.gateway_id)
+    return [
+        WithAccess(message=n, is_owner=False, user_has_write_access=has_write)
+        for n in notifications
+    ]
+
+
+def create_notification(
+    client: "AiravataClient",
+    data: "NotificationCreate | dict",
+    *,
+    has_write: bool,
+) -> "WithAccess":
+    """The created proto is re-built with the server-assigned ``notification_id``."""
+    data = NotificationCreate.model_validate(data).model_dump(
+        exclude_unset=True)
+    n = _build_notification(client, data)
+    notification_id = client.research.create_notification(n)
+    n.notification_id = notification_id
+    return WithAccess(
+        message=n,
+        is_owner=False,
+        user_has_write_access=has_write,
+    )
+
+
+def update_notification(
+    client: "AiravataClient",
+    notification_id: str,
+    data: "NotificationCreate | dict",
+    *,
+    has_write: bool,
+) -> "WithAccess":
+    data = NotificationCreate.model_validate(data).model_dump(
+        exclude_unset=True)
+    base = client.research.get_notification(client.gateway_id, notification_id)
+    n = _build_notification(client, data, base=base)
+    n.notification_id = notification_id
+    client.research.update_notification(n)
+    return WithAccess(
+        message=n,
+        is_owner=False,
+        user_has_write_access=has_write,
+    )
+
+
+def delete_notification(
+    client: "AiravataClient",
+    notification_id: str,
+) -> None:
+    client.research.delete_notification(client.gateway_id, notification_id)
+
+
+# Parser — bare proto, gateway catalog (no ownership/sharing).
+
+
+def _io_type_value(value) -> int:
+    """parser ``type`` -> proto ``IOType`` int. Member NAME (with or without the
+    ``IO_TYPE_`` prefix) or int; None/""/unknown -> 0.
+    """
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.parser import (  # noqa: E501
+        parser_pb2,
+    )
+
+    enum = parser_pb2.IOType
+    if value is None or value == "":
+        return 0
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value if value in enum.values() else 0
+    name = str(value)
+    try:
+        return enum.Value(name)
+    except ValueError:
+        try:
+            return enum.Value("IO_TYPE_" + name)
+        except ValueError:
+            return 0
+
+
+def _build_parser(
+    client: "AiravataClient",
+    data: dict,
+) -> "parser_pb2.Parser":
+    """``gateway_id`` is forced to the client's gateway."""
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.parser import (  # noqa: E501
+        parser_pb2,
+    )
+
+    return parser_pb2.Parser(
+        id=data.get("id") or "",
+        image_name=data.get("image_name") or "",
+        output_dir_path=data.get("output_dir_path") or "",
+        input_dir_path=data.get("input_dir_path") or "",
+        execution_command=data.get("execution_command") or "",
+        gateway_id=client.gateway_id or "",
+        input_files=[
+            parser_pb2.ParserInput(
+                id=i.get("id") or "",
+                name=i.get("name") or "",
+                required_input=bool(i.get("required_input", False)),
+                parser_id=i.get("parser_id") or "",
+                type=_io_type_value(i.get("type")),
+            )
+            for i in (data.get("input_files") or [])
+        ],
+        output_files=[
+            parser_pb2.ParserOutput(
+                id=o.get("id") or "",
+                name=o.get("name") or "",
+                required_output=bool(o.get("required_output", False)),
+                parser_id=o.get("parser_id") or "",
+                type=_io_type_value(o.get("type")),
+            )
+            for o in (data.get("output_files") or [])
+        ],
+    )
+
+
+def get_parser(client: "AiravataClient", parser_id: str) -> "parser_pb2.Parser":
+    """Fetch a single parser and return the raw ``parser_pb2.Parser`` proto."""
+    return client.research.get_parser(parser_id, client.gateway_id)
+
+
+def list_parsers(client: "AiravataClient") -> "list[parser_pb2.Parser]":
+    """Return the gateway's parsers as a list of ``parser_pb2.Parser`` protos."""
+    return list(client.research.list_all_parsers(client.gateway_id))
+
+
+def create_parser(
+    client: "AiravataClient",
+    data: "ParserCreate | dict",
+) -> "parser_pb2.Parser":
+    """Re-fetched so read and write paths emit the same shape."""
+    data = ParserCreate.model_validate(data).model_dump(exclude_unset=True)
+    parser = _build_parser(client, data)
+    parser_id = client.research.save_parser(parser)
+    return get_parser(client, parser_id)
+
+
+def update_parser(
+    client: "AiravataClient",
+    parser_id: str,
+    data: "ParserCreate | dict",
+) -> "parser_pb2.Parser":
+    """The proto is re-assembled from *data* (``id`` forced), saved, re-fetched."""
+    data = ParserCreate.model_validate(data).model_dump(exclude_unset=True)
+    merged = dict(data)
+    merged["id"] = parser_id
+    parser = _build_parser(client, merged)
+    client.research.save_parser(parser)
+    return get_parser(client, parser_id)
+
+
+def delete_parser(client: "AiravataClient", parser_id: str) -> None:
+    """Delete a parser by id."""
+    client.research.remove_parser(parser_id, client.gateway_id)
+
+
+# DataProduct — WithAccess. is_owner is SDK-trivial
+# (proto.owner_name == client.username); user_has_write_access is the
+# request-bound flag the ViewSet computes (owner / shared-dir gateway-admin /
+# otherwise-allowed) and supplies as has_write.
+
+
+def get_data_product(
+    client: "AiravataClient",
+    product_uri: str,
+    *,
+    has_write: bool,
+) -> "WithAccess":
+    p = client.research.get_data_product(product_uri)
+    return WithAccess(
+        message=p,
+        is_owner=bool(p.owner_name) and (p.owner_name == client.username),
+        user_has_write_access=has_write,
+    )
+
+
+def data_product_for_upload(
+    *,
+    gateway_id: str,
+    owner_name: str,
+    product_name: str,
+    file_path: str,
+    storage_resource_id: str,
+    content_type: Optional[str] = None,
+    product_size: int = 0,
+) -> "replica_catalog_pb2.DataProductModel":
+    """``storage.upload_file`` only transfers bytes, so the upload flow registers
+    the product to mint a canonical URI. A single GATEWAY_DATA_STORE / TRANSIENT
+    replica points at *file_path*; content type goes under ``mime-type`` metadata.
+    """
+    from airavata_sdk.generated.org.apache.airavata.model.data.replica import (
+        replica_catalog_pb2 as rc,
+    )
+
+    product_metadata = {"mime-type": content_type} if content_type else {}
+    return rc.DataProductModel(
+        gateway_id=gateway_id or "",
+        owner_name=owner_name or "",
+        product_name=product_name or "",
+        data_product_type=rc.DataProductType.FILE,
+        product_size=product_size or 0,
+        product_metadata=product_metadata,
+        replica_locations=[rc.DataReplicaLocationModel(
+            replica_name="{} gateway data store copy".format(product_name),
+            replica_location_category=rc.ReplicaLocationCategory.GATEWAY_DATA_STORE,
+            replica_persistent_type=rc.ReplicaPersistentType.TRANSIENT,
+            storage_resource_id=storage_resource_id or "",
+            file_path=file_path,
+        )],
+    )
+
+
+def register_data_product(
+    client: "AiravataClient",
+    data_product: "replica_catalog_pb2.DataProductModel",
+) -> str:
+    """Pass-through used by the upload flow after :func:`data_product_for_upload`."""
+    return client.research.register_data_product(data_product)
+
+
+# ApplicationInterface — gateway-catalog WithAccess (is_owner always False;
+# user_has_write_access = has_write). The portal-only show_queue_settings /
+# queue_settings_calculator_id overrides are persisted by the ViewSet, not here.
+
+
+def get_application_interface(
+    client: "AiravataClient",
+    app_interface_id: str,
+    *,
+    has_write: bool,
+) -> "WithAccess":
+    ai = client.research.get_application_interface(app_interface_id)
+    return WithAccess(
+        message=ai,
+        is_owner=False,
+        user_has_write_access=has_write,
+    )
+
+
+def list_application_interfaces(
+    client: "AiravataClient",
+    *,
+    has_write: bool,
+) -> "list[WithAccess]":
+    interfaces = client.research.get_all_application_interfaces(
+        client.gateway_id)
+    return [
+        WithAccess(message=ai, is_owner=False, user_has_write_access=has_write)
+        for ai in interfaces
+    ]
+
+
+def _proto_input_data_object(data: dict):
+    from airavata_sdk.generated.org.apache.airavata.model.application.io import (
+        application_io_pb2 as io,
+    )
+
+    return io.InputDataObjectType(
+        name=data.get("name") or "",
+        value=data.get("value") or "",
+        type=_data_type_int(data.get("type")),
+        application_argument=data.get("application_argument") or "",
+        standard_input=bool(data.get("standard_input", False)),
+        user_friendly_description=data.get("user_friendly_description") or "",
+        meta_data=_meta_data_str(data.get("meta_data")),
+        input_order=data.get("input_order") or 0,
+        is_required=bool(data.get("is_required", False)),
+        required_to_added_to_command_line=bool(
+            data.get("required_to_added_to_command_line", False)),
+        data_staged=bool(data.get("data_staged", False)),
+        storage_resource_id=data.get("storage_resource_id") or "",
+        is_read_only=bool(data.get("is_read_only", False)),
+        override_filename=data.get("override_filename") or "",
+    )
+
+
+def _proto_output_data_object(data: dict):
+    from airavata_sdk.generated.org.apache.airavata.model.application.io import (
+        application_io_pb2 as io,
+    )
+
+    return io.OutputDataObjectType(
+        name=data.get("name") or "",
+        value=data.get("value") or "",
+        type=_data_type_int(data.get("type")),
+        application_argument=data.get("application_argument") or "",
+        is_required=bool(data.get("is_required", False)),
+        required_to_added_to_command_line=bool(
+            data.get("required_to_added_to_command_line", False)),
+        data_movement=bool(data.get("data_movement", False)),
+        location=data.get("location") or "",
+        search_query=data.get("search_query") or "",
+        output_streaming=bool(data.get("output_streaming", False)),
+        storage_resource_id=data.get("storage_resource_id") or "",
+        meta_data=_meta_data_str(data.get("meta_data")),
+    )
+
+
+def _data_type_int(value) -> int:
+    """``DataType`` -> proto enum int. Member NAME (e.g. ``"URI"``) or int;
+    None/""/unknown -> 0.
+    """
+    from airavata_sdk.generated.org.apache.airavata.model.application.io import (
+        application_io_pb2 as io,
+    )
+
+    if not value:
+        return 0
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    name = str(value)
+    enum = io.DataType
+    try:
+        return enum.Value(name)
+    except ValueError:
+        prefixed = "DATA_TYPE_" + name
+        try:
+            return enum.Value(prefixed)
+        except ValueError:
+            return 0
+
+
+def _meta_data_str(value) -> str:
+    """``meta_data`` -> proto JSON string. A str passes through; other values are
+    ``json.dumps``ed; ``None`` -> ``""``.
+    """
+    import json
+
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value)
+    except (TypeError, ValueError):
+        return ""
+
+
+def _build_application_interface(
+    client: "AiravataClient",
+    data: dict,
+    *,
+    base: "Optional[app_interface_pb2.ApplicationInterfaceDescription]" = None,
+) -> "app_interface_pb2.ApplicationInterfaceDescription":
+    """*base* (the update path) seeds the proto. Nested input/output lists are
+    replaced wholesale when present in *data*.
+    """
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.appinterface import (  # noqa: E501
+        app_interface_pb2 as ai_pb2,
+    )
+
+    ai = ai_pb2.ApplicationInterfaceDescription()
+    if base is not None:
+        ai.CopyFrom(base)
+    if "application_interface_id" in data:
+        ai.application_interface_id = data["application_interface_id"] or ""
+    if "application_name" in data:
+        ai.application_name = data["application_name"] or ""
+    if "application_description" in data:
+        ai.application_description = data["application_description"] or ""
+    if "application_modules" in data:
+        ai.application_modules[:] = list(data["application_modules"] or [])
+    if "archive_working_directory" in data:
+        ai.archive_working_directory = bool(data["archive_working_directory"])
+    if "application_inputs" in data:
+        del ai.application_inputs[:]
+        ai.application_inputs.extend(
+            _proto_input_data_object(i)
+            for i in (data["application_inputs"] or []))
+    if "application_outputs" in data:
+        del ai.application_outputs[:]
+        ai.application_outputs.extend(
+            _proto_output_data_object(o)
+            for o in (data["application_outputs"] or []))
+    return ai
+
+
+def create_application_interface(
+    client: "AiravataClient",
+    data: "ApplicationInterfaceCreate | dict",
+    *,
+    has_write: bool,
+) -> "WithAccess":
+    """Re-fetched so the server-assigned ``application_interface_id`` is populated."""
+    data = ApplicationInterfaceCreate.model_validate(data).model_dump(
+        exclude_unset=True)
+    ai = _build_application_interface(client, data)
+    app_interface_id = client.research.register_application_interface(
+        client.gateway_id, ai)
+    return get_application_interface(
+        client, app_interface_id, has_write=has_write)
+
+
+def update_application_interface(
+    client: "AiravataClient",
+    app_interface_id: str,
+    data: "ApplicationInterfaceCreate | dict",
+    *,
+    has_write: bool,
+) -> "WithAccess":
+    data = ApplicationInterfaceCreate.model_validate(data).model_dump(
+        exclude_unset=True)
+    base = client.research.get_application_interface(app_interface_id)
+    ai = _build_application_interface(client, data, base=base)
+    ai.application_interface_id = app_interface_id
+    client.research.update_application_interface(app_interface_id, ai)
+    return get_application_interface(
+        client, app_interface_id, has_write=has_write)
+
+
+def delete_application_interface(
+    client: "AiravataClient",
+    app_interface_id: str,
+) -> None:
+    """Delete an application interface by id."""
+    client.research.delete_application_interface(app_interface_id)
+
+
+# ApplicationDeployment — WithAccess. is_owner always False (catalog entry, no
+# owner). Unlike the other gateway-catalog families, user_has_write_access is a
+# genuine per-resource CHAINED sharing WRITE lookup keyed on app_deployment_id.
+
+
+def get_application_deployment(
+    client: "AiravataClient",
+    app_deployment_id: str,
+) -> "WithAccess":
+    d = client.research.get_application_deployment(app_deployment_id)
+    return WithAccess(
+        message=d,
+        is_owner=False,
+        user_has_write_access=client.sharing.user_has_access(
+            resource_id=app_deployment_id,
+            user_id=client.username,
+            permission_type="WRITE",
+        ),
+    )
+
+
+def list_application_deployments(
+    client: "AiravataClient",
+) -> "list[WithAccess]":
+    deployments = client.research.get_accessible_application_deployments(
+        client.gateway_id)
+    return [
+        WithAccess(
+            message=d,
+            is_owner=False,
+            user_has_write_access=client.sharing.user_has_access(
+                resource_id=d.app_deployment_id,
+                user_id=client.username,
+                permission_type="WRITE",
+            ),
+        )
+        for d in deployments
+    ]
+
+
+def list_application_deployments_for_module(
+    client: "AiravataClient",
+    app_module_id: str,
+) -> "list[WithAccess]":
+    """Accessible deployments for a single app module (the gateway-wide
+    accessible set filtered by ``app_module_id``)."""
+    deployments = client.research.get_accessible_application_deployments(
+        client.gateway_id)
+    return [
+        WithAccess(
+            message=d,
+            is_owner=False,
+            user_has_write_access=client.sharing.user_has_access(
+                resource_id=d.app_deployment_id,
+                user_id=client.username,
+                permission_type="WRITE",
+            ),
+        )
+        for d in deployments
+        if d.app_module_id == app_module_id
+    ]
+
+
+def list_application_deployments_for_module_and_profile(
+    client: "AiravataClient",
+    app_module_id: str,
+    group_resource_profile_id: str,
+) -> "list[WithAccess]":
+    deployments = client.research.\
+        get_application_deployments_for_app_module_and_group_resource_profile(
+            app_module_id, group_resource_profile_id)
+    return [
+        WithAccess(
+            message=d,
+            is_owner=False,
+            user_has_write_access=client.sharing.user_has_access(
+                resource_id=d.app_deployment_id,
+                user_id=client.username,
+                permission_type="WRITE",
+            ),
+        )
+        for d in deployments
+    ]
+
+
+def _proto_command_object(data: dict):
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.appdeployment import (  # noqa: E501
+        app_deployment_pb2,
+    )
+
+    return app_deployment_pb2.CommandObject(
+        command=data.get("command") or "",
+        command_order=data.get("command_order") or 0,
+    )
+
+
+def _proto_set_env_paths(data: dict):
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.appdeployment import (  # noqa: E501
+        app_deployment_pb2,
+    )
+
+    return app_deployment_pb2.SetEnvPaths(
+        name=data.get("name") or "",
+        value=data.get("value") or "",
+        env_path_order=data.get("env_path_order") or 0,
+    )
+
+
+def _parallelism_input_to_proto_int(value) -> int:
+    """``parallelism`` -> proto enum int. Member NAME (the name lookup tries the
+    value verbatim, then with the ``APPLICATION_PARALLELISM_TYPE_`` prefix
+    stripped, then added) or int; None/""/unresolvable -> 0.
+    """
+    from airavata_sdk.generated.org.apache.airavata.model.parallelism import (
+        parallelism_pb2,
+    )
+
+    if value is None or value == "":
+        return 0
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    name = str(value)
+    enum = parallelism_pb2.ApplicationParallelismType
+    prefix = "APPLICATION_PARALLELISM_TYPE_"
+    candidates = [name]
+    if name.startswith(prefix):
+        candidates.append(name[len(prefix):])
+    else:
+        candidates.append(prefix + name)
+    for candidate in candidates:
+        try:
+            return enum.Value(candidate)
+        except ValueError:
+            continue
+    return 0
+
+
+def _build_application_deployment(
+    client: "AiravataClient",
+    data: dict,
+) -> "app_deployment_pb2.ApplicationDeploymentDescription":
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.appdeployment import (  # noqa: E501
+        app_deployment_pb2,
+    )
+
+    return app_deployment_pb2.ApplicationDeploymentDescription(
+        app_module_id=data.get("app_module_id") or "",
+        compute_host_id=data.get("compute_host_id") or "",
+        executable_path=data.get("executable_path") or "",
+        parallelism=_parallelism_input_to_proto_int(data.get("parallelism")),
+        app_deployment_description=data.get("app_deployment_description") or "",
+        module_load_cmds=[
+            _proto_command_object(c)
+            for c in (data.get("module_load_cmds") or [])
+        ],
+        lib_prepend_paths=[
+            _proto_set_env_paths(p)
+            for p in (data.get("lib_prepend_paths") or [])
+        ],
+        lib_append_paths=[
+            _proto_set_env_paths(p)
+            for p in (data.get("lib_append_paths") or [])
+        ],
+        set_environment=[
+            _proto_set_env_paths(p)
+            for p in (data.get("set_environment") or [])
+        ],
+        pre_job_commands=[
+            _proto_command_object(c)
+            for c in (data.get("pre_job_commands") or [])
+        ],
+        post_job_commands=[
+            _proto_command_object(c)
+            for c in (data.get("post_job_commands") or [])
+        ],
+        default_queue_name=data.get("default_queue_name") or "",
+        default_node_count=data.get("default_node_count") or 0,
+        default_cpu_count=data.get("default_cpu_count") or 0,
+        default_walltime=data.get("default_walltime") or 0,
+        editable_by_user=bool(data.get("editable_by_user", False)),
+    )
+
+
+def create_application_deployment(
+    client: "AiravataClient",
+    data: "ApplicationDeploymentCreate | dict",
+    *,
+    has_write: bool,
+) -> "WithAccess":
+    """Re-fetched so the server-assigned ``app_deployment_id`` is populated.
+    *has_write* is forwarded (the creator has write access) rather than chained.
+    """
+    data = ApplicationDeploymentCreate.model_validate(data).model_dump(
+        exclude_unset=True)
+    deployment = _build_application_deployment(client, data)
+    app_deployment_id = client.research.register_application_deployment(
+        client.gateway_id, deployment)
+    created = client.research.get_application_deployment(app_deployment_id)
+    return WithAccess(
+        message=created, is_owner=False, user_has_write_access=has_write)
+
+
+def update_application_deployment(
+    client: "AiravataClient",
+    app_deployment_id: str,
+    data: "ApplicationDeploymentCreate | dict",
+    *,
+    has_write: bool,
+) -> "WithAccess":
+    """The proto is rebuilt wholesale from *data* (``app_deployment_id`` forced),
+    pushed, and re-fetched. *has_write* is forwarded (the ViewSet resolves it).
+    """
+    data = ApplicationDeploymentCreate.model_validate(data).model_dump(
+        exclude_unset=True)
+    deployment = _build_application_deployment(client, data)
+    deployment.app_deployment_id = app_deployment_id
+    client.research.update_application_deployment(
+        app_deployment_id, deployment)
+    updated = client.research.get_application_deployment(app_deployment_id)
+    return WithAccess(
+        message=updated, is_owner=False, user_has_write_access=has_write)
+
+
+def delete_application_deployment(
+    client: "AiravataClient",
+    app_deployment_id: str,
+) -> None:
+    """Delete an application deployment by id."""
+    client.research.delete_application_deployment(app_deployment_id)

--- a/airavata-python-sdk/airavata_sdk/helpers/sharing_resources.py
+++ b/airavata-python-sdk/airavata_sdk/helpers/sharing_resources.py
@@ -1,0 +1,438 @@
+"""Sharing-domain helpers, two families:
+
+* **groups** (``GroupViewSet``) — the ``GroupModel`` proto wrapped in a
+  :class:`~airavata_sdk.helpers._envelope.WithGroupAccess` carrying the six
+  cross-context booleans (:func:`_group_flags`) the proto cannot compute on its
+  own without coupling GroupManager to the gateway-groups catalog.
+* **shared-entities** (``SharedEntityViewSet``) — a composed multi-proto shape
+  (owner / per-user ``UserProfile`` protos + per-group ``WithGroupAccess``
+  envelopes), returned as a pydantic :class:`SharedEntity` carrying them
+  wholesale. ``permission_type`` is the permission member NAME string.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+from airavata_sdk.helpers._envelope import WithGroupAccess
+
+if TYPE_CHECKING:
+    from airavata_sdk.client import AiravataClient
+
+
+def _user_at_gateway(client: "AiravataClient") -> str:
+    return f"{client.username}@{client.gateway_id}"
+
+
+def _gateway_groups(client: "AiravataClient") -> dict:
+    """The three gateway-group identity ids (``admins_group_id`` /
+    ``read_only_admins_group_id`` / ``default_gateway_users_group_id``).
+    """
+    gg = client.compute.get_gateway_groups()
+    return {
+        "admins_group_id": gg.admins_group_id,
+        "read_only_admins_group_id": gg.read_only_admins_group_id,
+        "default_gateway_users_group_id": gg.default_gateway_users_group_id,
+    }
+
+
+def _group_flags(
+    client: "AiravataClient",
+    g,
+    *,
+    gateway_groups: Optional[dict] = None,
+) -> dict:
+    """The six per-group access booleans. *gateway_groups* may be supplied by the
+    caller (a session-cached copy) to avoid a redundant ``GetGatewayGroups`` RPC.
+    """
+    me = _user_at_gateway(client)
+    gg = gateway_groups if gateway_groups is not None else _gateway_groups(client)
+    return dict(
+        is_admin=client.sharing.gm_has_admin_access(g.id, me),
+        is_owner=(g.owner_id == me),
+        is_member=bool(g.members) and me in g.members,
+        is_gateway_admins_group=(g.id == gg["admins_group_id"]),
+        is_read_only_gateway_admins_group=(
+            g.id == gg["read_only_admins_group_id"]),
+        is_default_gateway_users_group=(
+            g.id == gg["default_gateway_users_group_id"]),
+    )
+
+
+def get_group(
+    client: "AiravataClient",
+    group_id: str,
+    *,
+    gateway_groups: Optional[dict] = None,
+) -> "WithGroupAccess":
+    g = client.sharing.gm_get_group(group_id)
+    return WithGroupAccess(
+        message=g,
+        **_group_flags(client, g, gateway_groups=gateway_groups),
+    )
+
+
+def wrap_groups(
+    client: "AiravataClient",
+    group_protos,
+    *,
+    gateway_groups: Optional[dict] = None,
+) -> "list[WithGroupAccess]":
+    """Wrap already-fetched ``GroupModel`` protos in ``WithGroupAccess`` (e.g. the
+    groups a user belongs to). *gateway_groups* is resolved once and reused."""
+    groups = list(group_protos)
+    gg = gateway_groups if gateway_groups is not None else _gateway_groups(client)
+    return [
+        WithGroupAccess(message=g, **_group_flags(client, g, gateway_groups=gg))
+        for g in groups
+    ]
+
+
+def list_groups(
+    client: "AiravataClient",
+    *,
+    limit: int = -1,
+    offset: int = 0,
+    gateway_groups: Optional[dict] = None,
+) -> "list[WithGroupAccess]":
+    """``GetGroups`` returns the full list; *limit* / *offset* slice it
+    in-process. *gateway_groups* is resolved once and reused across the page.
+    """
+    groups = list(client.sharing.gm_get_groups())
+    end = offset + limit if limit > 0 else len(groups)
+    page = groups[offset:end] if groups else []
+    gg = gateway_groups if gateway_groups is not None else _gateway_groups(client)
+    return [
+        WithGroupAccess(message=g, **_group_flags(client, g, gateway_groups=gg))
+        for g in page
+    ]
+
+
+def _group_manager_pb2():
+    from airavata_sdk.generated.org.apache.airavata.model.group import (
+        group_manager_pb2,
+    )
+    return group_manager_pb2
+
+
+def _build_group(client: "AiravataClient", data: dict):
+    """``owner_id`` is forced from the client context (``user@gateway``)."""
+    return _group_manager_pb2().GroupModel(
+        name=data.get("name") or "",
+        description=data.get("description") or "",
+        members=list(data.get("members") or []),
+        admins=list(data.get("admins") or []),
+        owner_id=_user_at_gateway(client),
+    )
+
+
+def _member_admin_diff(existing, data: dict) -> dict:
+    """Added/removed member & admin id lists. New lists default to the existing
+    proto values when absent from *data*. Admins not already members are added to
+    both the member list and ``added_members``.
+    """
+    old_members = set(existing.members)
+    new_members = set(data["members"]) if "members" in data else set(existing.members)
+    removed_members = list(old_members - new_members)
+    added_members = list(new_members - old_members)
+
+    old_admins = set(existing.admins)
+    new_admins = set(data["admins"]) if "admins" in data else set(existing.admins)
+    removed_admins = list(old_admins - new_admins)
+    added_admins = list(new_admins - old_admins)
+
+    final_members = list(new_members)
+    # Admins not yet members become members too.
+    extra = list(new_admins - new_members)
+    added_members = added_members + extra
+    final_members = final_members + extra
+
+    return dict(
+        members=final_members,
+        admins=list(new_admins),
+        added_members=added_members,
+        removed_members=removed_members,
+        added_admins=added_admins,
+        removed_admins=removed_admins,
+    )
+
+
+def create_group(
+    client: "AiravataClient",
+    data: dict,
+    *,
+    gateway_groups: Optional[dict] = None,
+) -> tuple:
+    """Returns ``(WithGroupAccess, group_proto, added_member_ids)``: the read
+    shape plus the raw proto + newly added members the ViewSet needs to fan out
+    ``user_added_to_group`` notifications (which stay in the portal).
+    """
+    group = _build_group(client, data)
+    group_id = client.sharing.gm_create_group(group)
+    group.id = group_id
+    added_members = list(set(group.members) - {group.owner_id})
+    result = WithGroupAccess(
+        message=group,
+        **_group_flags(client, group, gateway_groups=gateway_groups))
+    return result, group, added_members
+
+
+def update_group(
+    client: "AiravataClient",
+    group_id: str,
+    data: dict,
+    *,
+    gateway_groups: Optional[dict] = None,
+) -> tuple:
+    """Patch ``name`` / ``description``, fire the membership / admin mutator RPCs
+    for each non-empty diff, then ``UpdateGroup``. Returns ``(WithGroupAccess,
+    group_proto, added_member_ids)`` (see :func:`create_group`).
+    """
+    group = client.sharing.gm_get_group(group_id)
+    if "name" in data:
+        group.name = data["name"] or ""
+    if "description" in data:
+        group.description = data["description"] or ""
+
+    diff = _member_admin_diff(group, data)
+
+    sharing = client.sharing
+    if diff["added_members"]:
+        sharing.gm_add_users_to_group(diff["added_members"], group.id)
+    if diff["removed_members"]:
+        sharing.gm_remove_users_from_group(diff["removed_members"], group.id)
+    if diff["added_admins"]:
+        sharing.gm_add_group_admins(group.id, diff["added_admins"])
+    if diff["removed_admins"]:
+        sharing.gm_remove_group_admins(group.id, diff["removed_admins"])
+
+    group.members[:] = diff["members"]
+    group.admins[:] = diff["admins"]
+    sharing.gm_update_group(group)
+
+    result = WithGroupAccess(
+        message=group,
+        **_group_flags(client, group, gateway_groups=gateway_groups))
+    return result, group, diff["added_members"]
+
+
+def delete_group(client: "AiravataClient", group_id: str) -> None:
+    """The proto is fetched to recover the ``owner_id`` the delete RPC requires."""
+    group = client.sharing.gm_get_group(group_id)
+    client.sharing.gm_delete_group(group.id, group.owner_id)
+
+
+# SharedEntity — a composed multi-proto shape (owner / per-user UserProfile
+# protos + per-group WithGroupAccess envelopes from two services), returned as a
+# pydantic model carrying them wholesale. permission_type is the member NAME
+# string. is_owner = owner.user_id == client.username; has_sharing_permission is
+# a chained MANAGE_SHARING lookup.
+
+# Precedence: a later (more privileged) grant overwrites an earlier one, so WRITE
+# (which implies READ) wins over a bare READ.
+_PERMISSION_PRECEDENCE = ("READ", "WRITE", "MANAGE_SHARING")
+
+
+class UserPermission(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    user: Any  # raw UserProfile proto
+    permission_type: str
+
+
+class GroupPermission(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    group: Any  # WithGroupAccess envelope
+    permission_type: str
+
+
+class SharedEntity(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    entity_id: str
+    owner: Any
+    user_permissions: list[UserPermission]
+    group_permissions: list[GroupPermission]
+    is_owner: bool
+    has_sharing_permission: bool
+
+
+def _username_from_internal_id(internal_user_id: str) -> str:
+    """The accessible-users RPCs return ``user@gateway`` ids but
+    ``GetUserProfileById`` keys on the bare username.
+    """
+    return internal_user_id[0:internal_user_id.rindex("@")]
+
+
+def _collect_permissions(accessor, entity_id: str) -> dict:
+    """``{id -> permission_name}`` across the precedence order (most privileged
+    grant wins). *accessor* is ``(entity_id, permission_name) -> list[id]``.
+    """
+    result: dict = {}
+    for name in _PERMISSION_PRECEDENCE:
+        for resource_id in accessor(entity_id, name):
+            result[resource_id] = name
+    return result
+
+
+def _load_shared_entity(
+    client: "AiravataClient",
+    entity_id: str,
+    *,
+    directly: bool,
+    gateway_groups: Optional[dict] = None,
+) -> "SharedEntity":
+    """*directly* selects the direct-only (True) vs. accessible-including-inherited
+    (False) accessor pair. Loads the user/group permission maps, drops the owner
+    from the users list, fetches every profile/group, and composes a
+    :class:`SharedEntity`.
+    """
+    sharing = client.sharing
+    if directly:
+        users_accessor = sharing.get_all_directly_accessible_users
+        groups_accessor = sharing.get_all_directly_accessible_groups
+    else:
+        users_accessor = sharing.get_all_accessible_users
+        groups_accessor = sharing.get_all_accessible_groups
+
+    users = _collect_permissions(users_accessor, entity_id)
+    # The owner is the single DIRECT owner (the OWNER grant); there is exactly
+    # one (indirect cascading owners are not returned by these RPCs).
+    owner_ids = users_accessor(entity_id, "OWNER")
+    owner_id = list(owner_ids)[0]
+    users.pop(owner_id, None)
+
+    groups = _collect_permissions(groups_accessor, entity_id)
+
+    gg = (
+        gateway_groups if gateway_groups is not None
+        else _gateway_groups(client))
+
+    def _load_profile(user_internal_id):
+        return client.iam.get_user_profile_by_id(
+            _username_from_internal_id(user_internal_id), client.gateway_id)
+
+    user_permissions = [
+        UserPermission(user=_load_profile(uid), permission_type=users[uid])
+        for uid in users
+    ]
+    group_permissions = [
+        GroupPermission(
+            group=get_group(client, gid, gateway_groups=gg),
+            permission_type=groups[gid])
+        for gid in groups
+    ]
+    owner_profile = _load_profile(owner_id)
+
+    return SharedEntity(
+        entity_id=entity_id,
+        owner=owner_profile,
+        user_permissions=user_permissions,
+        group_permissions=group_permissions,
+        is_owner=(owner_profile.user_id == client.username),
+        has_sharing_permission=client.sharing.user_has_access(
+            resource_id=entity_id,
+            user_id=client.username,
+            permission_type="MANAGE_SHARING",
+        ),
+    )
+
+
+def get_shared_entity(
+    client: "AiravataClient",
+    entity_id: str,
+    *,
+    gateway_groups: Optional[dict] = None,
+) -> "SharedEntity":
+    """Only directly granted permissions (the only ones the portal UI can edit)."""
+    return _load_shared_entity(
+        client, entity_id, directly=True, gateway_groups=gateway_groups)
+
+
+def get_all_shared_entity(
+    client: "AiravataClient",
+    entity_id: str,
+    *,
+    gateway_groups: Optional[dict] = None,
+) -> "SharedEntity":
+    """All (direct + inherited) sharing settings."""
+    return _load_shared_entity(
+        client, entity_id, directly=False, gateway_groups=gateway_groups)
+
+
+# Implied-permission sets for grant/revoke deltas: WRITE implies READ;
+# MANAGE_SHARING implies READ + WRITE.
+_IMPLIED_PERMISSIONS = {
+    "READ": {"READ"},
+    "WRITE": {"READ", "WRITE"},
+    "MANAGE_SHARING": {"READ", "WRITE", "MANAGE_SHARING"},
+}
+
+
+def _compute_revokes_and_grants(current_name, new_name) -> tuple:
+    """``(revokes, grants)`` permission-NAME sets for one id: diff the
+    implied-permission sets of *current_name* / *new_name* (``None`` -> empty).
+    """
+    current = _IMPLIED_PERMISSIONS.get(current_name, set()) \
+        if current_name is not None else set()
+    new = _IMPLIED_PERMISSIONS.get(new_name, set()) \
+        if new_name is not None else set()
+    return (current - new, new - current)
+
+
+def compute_sharing_deltas(existing: dict, new: dict) -> dict:
+    """*existing* / *new* are ``{id -> permission_name}`` maps. Returns
+    ``{"grant": {perm_name: [ids]}, "revoke": {...}}``.
+    """
+    grant = {"READ": [], "WRITE": [], "MANAGE_SHARING": []}
+    revoke = {"READ": [], "WRITE": [], "MANAGE_SHARING": []}
+    all_ids = set(existing.keys()) | set(new.keys())
+    for resource_id in all_ids:
+        revokes, grants = _compute_revokes_and_grants(
+            existing.get(resource_id), new.get(resource_id))
+        for name in revokes:
+            revoke[name].append(resource_id)
+        for name in grants:
+            grant[name].append(resource_id)
+    return {"grant": grant, "revoke": revoke}
+
+
+def apply_sharing_update(
+    client: "AiravataClient",
+    entity_id: str,
+    *,
+    existing_user_permissions: dict,
+    new_user_permissions: dict,
+    existing_group_permissions: dict,
+    new_group_permissions: dict,
+) -> None:
+    """Fire ``share_resource_with_*`` / ``revoke_sharing_of_resource_from_*`` for
+    each non-empty delta bucket. The ``*_permissions`` args are
+    ``{id -> permission_name}`` maps the caller assembles.
+    """
+    sharing = client.sharing
+
+    user_deltas = compute_sharing_deltas(
+        existing_user_permissions, new_user_permissions)
+    for name, ids in user_deltas["grant"].items():
+        if ids:
+            sharing.share_resource_with_users(
+                entity_id, {uid: name for uid in ids})
+    for name, ids in user_deltas["revoke"].items():
+        if ids:
+            sharing.revoke_sharing_of_resource_from_users(
+                entity_id, {uid: name for uid in ids})
+
+    group_deltas = compute_sharing_deltas(
+        existing_group_permissions, new_group_permissions)
+    for name, ids in group_deltas["grant"].items():
+        if ids:
+            sharing.share_resource_with_groups(
+                entity_id, {gid: name for gid in ids})
+    for name, ids in group_deltas["revoke"].items():
+        if ids:
+            sharing.revoke_sharing_of_resource_from_groups(
+                entity_id, {gid: name for gid in ids})

--- a/airavata-python-sdk/airavata_sdk/helpers/storage_resources.py
+++ b/airavata-python-sdk/airavata_sdk/helpers/storage_resources.py
@@ -1,0 +1,201 @@
+"""Storage-domain helpers.
+
+Storage resources, per-protocol data movement, and user-storage file/directory
+listings are proto-direct: each ``get_*`` / ``list_*`` returns its proto (or the
+raw ``{storage_resource_id: host_name}`` map) as-is — these are gateway-level
+catalog / metadata entries with no ownership or sharing fields. The data-product
+download orchestration at the bottom spans the research + storage facades and
+returns plain file-like objects (not part of the read contract).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from airavata_sdk.client import AiravataClient
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.storageresource import (  # noqa: E501
+        storage_resource_pb2,
+    )
+    from airavata_sdk.generated.org.apache.airavata.model.data.movement import (  # noqa: E501
+        data_movement_pb2,
+    )
+    from airavata_sdk.generated.services import file_service_pb2
+
+
+def get_storage_resource(
+    client: "AiravataClient",
+    storage_resource_id: str,
+) -> "storage_resource_pb2.StorageResourceDescription":
+    return client.storage.get_storage_resource(storage_resource_id)
+
+
+def list_storage_resource_names(client: "AiravataClient") -> dict[str, str]:
+    """The ``{storage_resource_id: host_name}`` map, passed straight through."""
+    return client.storage.get_all_storage_resource_names()
+
+
+# Per-protocol data movement (Local / SCP / GridFTP) — bare proto, no envelope.
+
+
+def get_local_data_movement(
+    client: "AiravataClient",
+    data_movement_id: str,
+) -> "data_movement_pb2.LOCALDataMovement":
+    return client.storage.get_local_data_movement(data_movement_id)
+
+
+def get_scp_data_movement(
+    client: "AiravataClient",
+    data_movement_id: str,
+) -> "data_movement_pb2.SCPDataMovement":
+    return client.storage.get_scp_data_movement(data_movement_id)
+
+
+def get_grid_ftp_data_movement(
+    client: "AiravataClient",
+    data_movement_id: str,
+) -> "data_movement_pb2.GridFTPDataMovement":
+    return client.storage.get_grid_ftp_data_movement(data_movement_id)
+
+
+# User-storage paths (file/directory listings) — proto-direct. The per-entry
+# write/shared-dir flags, hyperlinks, and the experiment-dir relative-path
+# rewrite are portal path-decisions the ViewSet layers on the rendered proto.
+# The orchestration helpers resolve the bare portal path to the absolute
+# ``~/``-prefixed path the facade expects, then wrap the raw facade.
+
+
+def resolve_user_storage_path(
+    client: "AiravataClient",
+    path: str,
+    experiment_id: Optional[str] = None,
+) -> str:
+    """Resolve a portal user-storage path to the absolute facade path.
+
+    A bare relative path is relative to the user's storage root (``~/``); with
+    *experiment_id* it is relative to that experiment's data directory.
+    """
+    rel = (path or "").lstrip("/")
+    if experiment_id:
+        experiment = client.research.get_experiment(experiment_id)
+        data_dir = (
+            experiment.user_configuration_data.experiment_data_dir
+            if experiment.HasField("user_configuration_data")
+            else None
+        ) or ""
+        base = data_dir.rstrip("/")
+        full = base + ("/" + rel if rel else "")
+        if full.startswith("/") or full.startswith("~/"):
+            return full
+        return "~/" + full
+    if rel.startswith("~"):
+        return rel
+    return "~/" + rel
+
+
+def dir_exists(
+    client: "AiravataClient",
+    resolved_path: str,
+) -> bool:
+    return client.storage.dir_exists(resolved_path)
+
+
+def create_dir(
+    client: "AiravataClient",
+    resolved_path: str,
+) -> None:
+    client.storage.create_dir(resolved_path)
+
+
+def delete_file(
+    client: "AiravataClient",
+    resolved_path: str,
+) -> None:
+    client.storage.delete_file(resolved_path)
+
+
+def delete_dir(
+    client: "AiravataClient",
+    resolved_path: str,
+) -> None:
+    client.storage.delete_dir(resolved_path)
+
+
+def get_file_metadata(
+    client: "AiravataClient",
+    resolved_path: str,
+) -> "file_service_pb2.FileMetadataResponse":
+    return client.storage.get_file_metadata(resolved_path)
+
+
+def list_dir(
+    client: "AiravataClient",
+    resolved_path: str,
+) -> "file_service_pb2.ListDirResponse":
+    return client.storage.list_dir(resolved_path)
+
+
+def list_experiment_dir(
+    client: "AiravataClient",
+    resolved_path: str,
+) -> "file_service_pb2.ListDirResponse":
+    """Same proto shape as :func:`list_dir`; the ViewSet rewrites each entry's
+    ``path`` relative to the experiment data dir.
+    """
+    return client.storage.list_dir(resolved_path)
+
+
+# Data-product file download (output-view-provider data generation). Thin
+# orchestration over the research (``GetDataProduct``) + storage
+# (``FileExists`` / ``DownloadFile``) facades.
+
+
+def data_product_file_path(data_product) -> Optional[str]:
+    """First replica's ``file_path``, or None.
+
+    The storage facade expects the FULL path, absolute or ``~/``-prefixed (a bare
+    relative path NPEs server-side); a relative replica path is ``~/``-prefixed.
+    """
+    replicas = data_product.replica_locations
+    if not replicas:
+        return None
+    file_path = replicas[0].file_path
+    if not file_path:
+        return None
+    if not (file_path.startswith("/") or file_path.startswith("~/")):
+        file_path = "~/" + file_path
+    return file_path
+
+
+def file_exists(
+    client: "AiravataClient",
+    resolved_path: str,
+) -> bool:
+    return client.storage.file_exists(resolved_path)
+
+
+def download_data_product_files(
+    client: "AiravataClient",
+    data_product_uris,
+) -> list:
+    """For each ``airavata-dp://`` URI, fetch the product, resolve its first
+    replica's file path, and download its bytes when the file exists.
+
+    Returns a list of :class:`io.BytesIO` (``.name`` set to the download name or
+    the path basename), in input-URI order. URIs with no replica / missing file
+    contribute nothing.
+    """
+    import io
+    import os
+
+    output_files = []
+    for uri in data_product_uris:
+        data_product = client.research.get_data_product(uri)
+        path = data_product_file_path(data_product)
+        if path and client.storage.file_exists(path):
+            resp = client.storage.download_file(path)
+            output_file = io.BytesIO(resp.content)
+            output_file.name = resp.name or os.path.basename(path)
+            output_files.append(output_file)
+    return output_files

--- a/airavata-python-sdk/tests/helpers/test_compute_resources.py
+++ b/airavata-python-sdk/tests/helpers/test_compute_resources.py
@@ -1,0 +1,882 @@
+"""Unit tests for airavata_sdk.helpers.compute_resources.
+
+The gateway-resource-profile family is proto-direct: ``get_gateway_resource_profile``
+returns a ``WithAccess[GatewayResourceProfile]`` (the raw proto wrapped with the
+caller's access flags), so its tests assert the wrapper carries the proto
+verbatim plus ``is_owner`` / ``user_has_write_access``.  The standalone
+gateway-storage-preference family is proto-direct too, but BARE: it has no
+ownership / sharing fields, so ``get`` returns one ``StoragePreference`` proto
+and ``list`` returns ``list[proto]`` (no envelope).  The still-legacy families
+(the compute-resource / group-resource-profile / job-submission ``_x_dict``
+transforms) keep their proto → neutral-dict tests.
+
+Orchestration functions (``get_gateway_resource_profile``,
+``update_gateway_resource_profile``) are tested via a lightweight stub client
+that records the calls made.
+"""
+
+from airavata_sdk.helpers._envelope import WithAccess
+from airavata_sdk.helpers.compute_resources import (
+    _data_movement_protocol_int,
+    _job_submission_protocol_int,
+    build_gateway_resource_profile,
+    build_group_resource_profile,
+    create_gateway_storage_preference,
+    create_group_resource_profile,
+    delete_gateway_storage_preference,
+    delete_group_resource_profile,
+    get_cloud_job_submission,
+    get_compute_resource,
+    get_gateway_resource_profile,
+    get_gateway_storage_preference,
+    get_group_resource_profile,
+    get_local_job_submission,
+    get_ssh_job_submission,
+    get_unicore_job_submission,
+    list_compute_resource_names,
+    list_gateway_storage_preferences,
+    list_group_resource_profiles,
+    update_gateway_resource_profile,
+    update_gateway_storage_preference,
+    update_group_resource_profile,
+)
+
+
+def _gp_pb2():
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.gatewayprofile import (  # noqa: E501
+        gateway_profile_pb2,
+    )
+    return gateway_profile_pb2
+
+
+def _make_storage_preference(**kwargs):
+    return _gp_pb2().StoragePreference(**kwargs)
+
+
+def _make_compute_preference(**kwargs):
+    return _gp_pb2().ComputeResourcePreference(**kwargs)
+
+
+def _make_profile(**kwargs):
+    return _gp_pb2().GatewayResourceProfile(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Protocol enum bridges
+# ---------------------------------------------------------------------------
+
+class TestProtocolEnumBridges:
+    def test_job_submission_protocol_proto_to_thrift(self):
+        # proto: 0 UNKNOWN, 1 LOCAL, 2 SSH, 3 GLOBUS, 4 UNICORE, 5 JSP_CLOUD,
+        # 6 SSH_FORK, 7 LOCAL_FORK
+        assert _job_submission_protocol_int(0) is None
+        assert _job_submission_protocol_int(1) == 0   # LOCAL
+        assert _job_submission_protocol_int(2) == 1   # SSH
+        assert _job_submission_protocol_int(3) == 2   # GLOBUS
+        assert _job_submission_protocol_int(4) == 3   # UNICORE
+        assert _job_submission_protocol_int(5) == 4   # JSP_CLOUD -> CLOUD
+        assert _job_submission_protocol_int(6) == 5   # SSH_FORK
+        assert _job_submission_protocol_int(7) == 6   # LOCAL_FORK
+
+    def test_data_movement_protocol_proto_to_thrift(self):
+        # proto: 0 UNKNOWN, 1 LOCAL, 2 SCP, 3 SFTP, 4 GRID_FTP, 5 UNICORE_SS
+        assert _data_movement_protocol_int(0) is None
+        assert _data_movement_protocol_int(1) == 0    # LOCAL
+        assert _data_movement_protocol_int(2) == 1    # SCP
+        assert _data_movement_protocol_int(3) == 2    # SFTP
+        assert _data_movement_protocol_int(4) is None  # GRID_FTP (proto-only)
+        assert _data_movement_protocol_int(5) == 4    # UNICORE_STORAGE_SERVICE
+
+
+# ---------------------------------------------------------------------------
+# build_gateway_resource_profile (write path)
+# ---------------------------------------------------------------------------
+
+class TestBuildGatewayResourceProfile:
+    def test_scalar_fields(self):
+        pb = build_gateway_resource_profile({
+            "gateway_id": "default",
+            "credential_store_token": "cred",
+            "identity_server_tenant": "tenant",
+            "identity_server_pwd_cred_token": "pwd",
+        })
+        assert pb.gateway_id == "default"
+        assert pb.credential_store_token == "cred"
+        assert pb.identity_server_tenant == "tenant"
+        assert pb.identity_server_pwd_cred_token == "pwd"
+
+    def test_protocol_thrift_int_round_trip(self):
+        # Thrift SSH=1 -> proto SSH=2; Thrift SFTP=2 -> proto SFTP=3
+        pb = build_gateway_resource_profile({
+            "compute_resource_preferences": [{
+                "compute_resource_id": "cr-1",
+                "preferred_job_submission_protocol": 1,
+                "preferred_data_movement_protocol": 2,
+            }],
+        })
+        c = pb.compute_resource_preferences[0]
+        assert c.preferred_job_submission_protocol == 2   # proto SSH
+        assert c.preferred_data_movement_protocol == 3    # proto SFTP
+
+    def test_nested_storage_preference(self):
+        pb = build_gateway_resource_profile({
+            "storage_preferences": [{
+                "storage_resource_id": "store-1",
+                "login_user_name": "alice",
+            }],
+        })
+        assert pb.storage_preferences[0].storage_resource_id == "store-1"
+        assert pb.storage_preferences[0].login_user_name == "alice"
+
+    def test_empty_lists(self):
+        pb = build_gateway_resource_profile({"gateway_id": "default"})
+        assert list(pb.compute_resource_preferences) == []
+        assert list(pb.storage_preferences) == []
+
+
+# ---------------------------------------------------------------------------
+# Orchestration — stub client
+# ---------------------------------------------------------------------------
+
+class _FakeCompute:
+    def __init__(self, profile):
+        self._profile = profile
+        self.updated_gateway_id = None
+        self.updated_profile = None
+
+    def get_gateway_resource_profile(self, gateway_id):
+        return self._profile
+
+    def update_gateway_resource_profile(self, gateway_id, profile):
+        self.updated_gateway_id = gateway_id
+        self.updated_profile = profile
+
+
+class _FakeClient:
+    def __init__(self, profile, gateway_id="default", username="alice"):
+        self.compute = _FakeCompute(profile)
+        self.gateway_id = gateway_id
+        self.username = username
+
+
+class TestGetGatewayResourceProfile:
+    """``get_gateway_resource_profile`` is proto-direct: it returns a
+    ``WithAccess[GatewayResourceProfile]`` carrying the raw proto verbatim plus
+    the gateway-catalog access flags (``is_owner`` always ``False``;
+    ``user_has_write_access`` is the supplied gateway-admin flag)."""
+
+    def _profile(self):
+        return _make_profile(
+            gateway_id="default", credential_store_token="cred",
+            compute_resource_preferences=[
+                _make_compute_preference(
+                    compute_resource_id="cr-1",
+                    preferred_job_submission_protocol=2)],
+            storage_preferences=[
+                _make_storage_preference(storage_resource_id="store-1")])
+
+    def test_returns_withaccess_carrying_the_proto(self):
+        profile = self._profile()
+        client = _FakeClient(profile)
+        result = get_gateway_resource_profile(client, "default", has_write=True)
+        assert isinstance(result, WithAccess)
+        # the proto flows through wholesale — no field copied out
+        assert result.message is profile
+        assert result.message.gateway_id == "default"
+        assert result.message.credential_store_token == "cred"
+        assert (result.message.compute_resource_preferences[0]
+                .compute_resource_id == "cr-1")
+        assert (result.message.storage_preferences[0].storage_resource_id
+                == "store-1")
+
+    def test_is_owner_always_false(self):
+        client = _FakeClient(self._profile())
+        result = get_gateway_resource_profile(client, "default", has_write=True)
+        assert result.is_owner is False
+
+    def test_has_write_forwarded(self):
+        client = _FakeClient(self._profile())
+        assert get_gateway_resource_profile(
+            client, "default", has_write=True).user_has_write_access is True
+        assert get_gateway_resource_profile(
+            client, "default", has_write=False).user_has_write_access is False
+
+
+class TestUpdateGatewayResourceProfile:
+    """``update_gateway_resource_profile`` builds the proto from the snake_case
+    write dict, persists it via the facade, then re-fetches via
+    ``get_gateway_resource_profile`` so the return is a
+    ``WithAccess[GatewayResourceProfile]`` matching the read path."""
+
+    def _profile(self):
+        return _make_profile(
+            gateway_id="default", credential_store_token="cred")
+
+    def test_persists_and_refetches(self):
+        client = _FakeClient(self._profile())
+        result = update_gateway_resource_profile(
+            client, "default",
+            {"gateway_id": "default", "credential_store_token": "cred"},
+            has_write=True)
+        assert client.compute.updated_gateway_id == "default"
+        assert client.compute.updated_profile is not None
+        assert isinstance(result, WithAccess)
+        assert result.message.gateway_id == "default"
+        assert result.user_has_write_access is True
+
+    def test_builds_proto_from_data(self):
+        client = _FakeClient(self._profile())
+        update_gateway_resource_profile(
+            client, "default",
+            {"gateway_id": "default", "identity_server_tenant": "t"},
+            has_write=True)
+        assert client.compute.updated_profile.identity_server_tenant == "t"
+
+
+# ---------------------------------------------------------------------------
+# Gateway storage-preference orchestration (standalone family)
+# ---------------------------------------------------------------------------
+
+class _FakeStoragePrefCompute:
+    """Stub ``compute`` facade for the standalone storage-preference family."""
+
+    def __init__(self, prefs):
+        # prefs: dict storage_resource_id -> StoragePreference proto
+        self._prefs = dict(prefs)
+        self.added = []
+        self.updated = []
+        self.deleted = []
+
+    def get_all_gateway_storage_preferences(self, gateway_id):
+        self.last_list_gateway = gateway_id
+        return list(self._prefs.values())
+
+    def get_gateway_storage_preference(self, gateway_id, storage_resource_id):
+        return self._prefs[storage_resource_id]
+
+    def add_gateway_storage_preference(self, gateway_id, storage_resource_id, pref):
+        self.added.append((gateway_id, storage_resource_id, pref))
+        self._prefs[storage_resource_id] = pref
+
+    def update_gateway_storage_preference(self, gateway_id, storage_resource_id, pref):
+        self.updated.append((gateway_id, storage_resource_id, pref))
+        self._prefs[storage_resource_id] = pref
+
+    def delete_gateway_storage_preference(self, gateway_id, storage_resource_id):
+        self.deleted.append((gateway_id, storage_resource_id))
+        self._prefs.pop(storage_resource_id, None)
+
+
+class _FakeStoragePrefClient:
+    def __init__(self, prefs, gateway_id="default", username="alice"):
+        self.compute = _FakeStoragePrefCompute(prefs)
+        self.gateway_id = gateway_id
+        self.username = username
+
+
+class TestListGatewayStoragePreferences:
+    """Proto-direct: ``list`` returns a ``list[StoragePreference]`` (bare protos,
+    no envelope, no dict transform)."""
+
+    def test_returns_protos(self):
+        client = _FakeStoragePrefClient({
+            "store-1": _make_storage_preference(
+                storage_resource_id="store-1", login_user_name="alice"),
+            "store-2": _make_storage_preference(
+                storage_resource_id="store-2", login_user_name="bob"),
+        })
+        out = list_gateway_storage_preferences(client, "default")
+        assert client.compute.last_list_gateway == "default"
+        assert all(
+            isinstance(p, _gp_pb2().StoragePreference) for p in out)
+        assert {p.storage_resource_id for p in out} == {"store-1", "store-2"}
+
+    def test_empty(self):
+        client = _FakeStoragePrefClient({})
+        assert list_gateway_storage_preferences(client, "default") == []
+
+
+class TestGetGatewayStoragePreference:
+    """Proto-direct: ``get`` returns the raw ``StoragePreference`` proto."""
+
+    def test_returns_proto(self):
+        pref = _make_storage_preference(
+            storage_resource_id="store-1", file_system_root_location="/data")
+        client = _FakeStoragePrefClient({"store-1": pref})
+        out = get_gateway_storage_preference(client, "default", "store-1")
+        # the proto flows through wholesale — no field copied out
+        assert out is pref
+        assert out.storage_resource_id == "store-1"
+        assert out.file_system_root_location == "/data"
+
+    def test_empty_token_stays_empty_string(self):
+        # proto-direct drops the legacy empty-token -> None coercion; the proto's
+        # empty string flows through verbatim.
+        client = _FakeStoragePrefClient({
+            "store-1": _make_storage_preference(
+                storage_resource_id="store-1",
+                resource_specific_credential_store_token=""),
+        })
+        out = get_gateway_storage_preference(client, "default", "store-1")
+        assert out.resource_specific_credential_store_token == ""
+
+
+class TestCreateGatewayStoragePreference:
+    def test_persists_and_refetches(self):
+        client = _FakeStoragePrefClient({})
+        out = create_gateway_storage_preference(client, "default", {
+            "storage_resource_id": "store-new",
+            "login_user_name": "alice",
+            "file_system_root_location": "/data",
+        })
+        assert len(client.compute.added) == 1
+        gw, srid, pref = client.compute.added[0]
+        assert gw == "default"
+        assert srid == "store-new"
+        assert pref.login_user_name == "alice"
+        assert isinstance(out, _gp_pb2().StoragePreference)
+        assert out.storage_resource_id == "store-new"
+        assert out.login_user_name == "alice"
+
+
+class TestUpdateGatewayStoragePreference:
+    def test_path_id_authoritative(self):
+        client = _FakeStoragePrefClient({
+            "store-1": _make_storage_preference(storage_resource_id="store-1"),
+        })
+        out = update_gateway_storage_preference(client, "default", "store-1", {
+            # a divergent id in the body must be ignored in favour of the path
+            "storage_resource_id": "WRONG",
+            "login_user_name": "carol",
+        })
+        assert len(client.compute.updated) == 1
+        gw, srid, pref = client.compute.updated[0]
+        assert srid == "store-1"
+        assert pref.storage_resource_id == "store-1"
+        assert pref.login_user_name == "carol"
+        assert isinstance(out, _gp_pb2().StoragePreference)
+        assert out.storage_resource_id == "store-1"
+
+
+class TestDeleteGatewayStoragePreference:
+    def test_delegates_to_facade(self):
+        client = _FakeStoragePrefClient({
+            "store-1": _make_storage_preference(storage_resource_id="store-1"),
+        })
+        result = delete_gateway_storage_preference(client, "default", "store-1")
+        assert result is None
+        assert client.compute.deleted == [("default", "store-1")]
+
+
+# ---------------------------------------------------------------------------
+# ComputeResourceDescription family (proto-direct)
+# ---------------------------------------------------------------------------
+#
+# ``get_compute_resource`` is proto-direct: it returns the raw
+# ``ComputeResourceDescription`` proto verbatim (this family carries no
+# ownership / sharing fields, so there is no ``WithAccess`` envelope and no dict
+# transform).  ``list_compute_resource_names`` passes the raw id->name map
+# straight through.  The proto -> snake_case JSON serialization (enums as NAMES,
+# verbatim file-system map keys) is pinned by the portal contract-snapshot test.
+
+def _cr_pb2():
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.computeresource import (  # noqa: E501
+        compute_resource_pb2,
+    )
+    return compute_resource_pb2
+
+
+def _dm_pb2():
+    from airavata_sdk.generated.org.apache.airavata.model.data.movement import (
+        data_movement_pb2,
+    )
+    return data_movement_pb2
+
+
+def _make_compute_resource(**kwargs):
+    return _cr_pb2().ComputeResourceDescription(**kwargs)
+
+
+class _FakeComputeCR:
+    def __init__(self, cr, names):
+        self._cr = cr
+        self._names = names
+
+    def get_compute_resource(self, compute_resource_id):
+        return self._cr
+
+    def get_all_compute_resource_names(self):
+        return dict(self._names)
+
+
+class _FakeCRClient:
+    def __init__(self, cr, names, gateway_id="default", username="alice"):
+        self.compute = _FakeComputeCR(cr, names)
+        self.gateway_id = gateway_id
+        self.username = username
+
+
+class TestGetComputeResource:
+    """Proto-direct: ``get`` returns the raw ``ComputeResourceDescription``
+    proto (no envelope, no dict transform)."""
+
+    def test_returns_proto_verbatim(self):
+        cr = _make_compute_resource(
+            compute_resource_id="cr-1", host_name="host",
+            batch_queues=[_cr_pb2().BatchQueue(queue_name="normal")])
+        client = _FakeCRClient(cr, {})
+        out = get_compute_resource(client, "cr-1")
+        # the proto flows through wholesale — no field copied out
+        assert out is cr
+        assert isinstance(out, _cr_pb2().ComputeResourceDescription)
+        assert out.compute_resource_id == "cr-1"
+        assert out.host_name == "host"
+        assert out.batch_queues[0].queue_name == "normal"
+
+
+class TestListComputeResourceNames:
+    def test_passthrough_map(self):
+        client = _FakeCRClient(None, {"cr-1": "host-1", "cr-2": "host-2"})
+        out = list_compute_resource_names(client)
+        assert out == {"cr-1": "host-1", "cr-2": "host-2"}
+
+
+# ===========================================================================
+# GroupResourceProfile
+# ===========================================================================
+
+def _grp():
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.groupresourceprofile import (  # noqa: E501
+        group_resource_profile_pb2,
+    )
+    return group_resource_profile_pb2
+
+
+def _make_slurm_pref(**kwargs):
+    g = _grp()
+    slurm = g.SlurmComputeResourcePreference(
+        allocation_project_number="alloc-1",
+        preferred_batch_queue="normal",
+        ssh_account_provisioner="prov",
+        group_ssh_account_provisioner_configs=[
+            g.GroupAccountSSHProvisionerConfig(
+                resource_id="r1", config_name="cn", config_value="cv")],
+        reservations=[
+            g.ComputeResourceReservation(
+                reservation_id="rid", queue_names=["q1"],
+                start_time=1705320000000, end_time=0)],
+    )
+    base = dict(
+        compute_resource_id="cr-slurm",
+        override_by_airavata=True,
+        preferred_job_submission_protocol=2,   # proto SSH -> Thrift 1
+        preferred_data_movement_protocol=3,    # proto SFTP -> Thrift 2
+        resource_type=g.ResourceType.SLURM,
+        specific_preferences=g.EnvironmentSpecificPreferences(slurm=slurm),
+    )
+    base.update(kwargs)
+    return g.GroupComputeResourcePreference(**base)
+
+
+def _make_aws_pref(**kwargs):
+    g = _grp()
+    base = dict(
+        compute_resource_id="cr-aws",
+        group_resource_profile_id="grp-1",
+        resource_type=g.ResourceType.AWS,
+        specific_preferences=g.EnvironmentSpecificPreferences(
+            aws=g.AwsComputeResourcePreference(
+                region="us-east-1", preferred_ami_id="ami-1",
+                preferred_instance_type="t2.micro")),
+    )
+    base.update(kwargs)
+    return g.GroupComputeResourcePreference(**base)
+
+
+def _make_group_profile(**kwargs):
+    g = _grp()
+    base = dict(
+        gateway_id="default",
+        group_resource_profile_id="grp-1",
+        group_resource_profile_name="Test GRP",
+        compute_preferences=[_make_slurm_pref(), _make_aws_pref()],
+        compute_resource_policies=[
+            g.ComputeResourcePolicy(
+                resource_policy_id="rp-1", compute_resource_id="cr-slurm",
+                allowed_batch_queues=["normal", "long"])],
+        batch_queue_resource_policies=[
+            g.BatchQueueResourcePolicy(
+                resource_policy_id="bq-1", compute_resource_id="cr-slurm",
+                queuename="normal", max_allowed_nodes=10,
+                max_allowed_cores=100, max_allowed_walltime=60)],
+        creation_time=1705320000000,
+        updated_time=1705323600000,
+        default_credential_store_token="def-tok",
+    )
+    base.update(kwargs)
+    return g.GroupResourceProfile(**base)
+
+
+class TestBuildGroupResourceProfile:
+    def test_forces_gateway_id_and_builds_tree(self):
+        client = _FakeGroupClient(_make_group_profile())
+        proto = build_group_resource_profile(client, {
+            "gateway_id": "ignored",
+            "group_resource_profile_name": "New",
+            "compute_preferences": [{
+                "compute_resource_id": "cr-1",
+                "overrideby_airavata": True,
+                "resource_type": 0,  # Thrift SLURM
+                "allocation_project_number": "ap",
+                "specific_preferences": {"slurm": {
+                    "preferred_batch_queue": "q"}},
+            }],
+            "compute_resource_policies": [{
+                "resource_policy_id": "rp", "allowed_batch_queues": ["a"]}],
+            "batch_queue_resource_policies": [{
+                "resource_policy_id": "bq", "queuename": "q",
+                "max_allowed_nodes": 5}],
+            "default_credential_store_token": "t",
+        })
+        assert proto.gateway_id == "default"  # forced from client
+        assert proto.group_resource_profile_name == "New"
+        cp = proto.compute_preferences[0]
+        assert cp.override_by_airavata is True
+        assert cp.resource_type == _grp().ResourceType.SLURM  # Thrift 0 -> proto
+        assert cp.specific_preferences.WhichOneof("preferences") == "slurm"
+        assert cp.specific_preferences.slurm.preferred_batch_queue == "q"
+        # flattened allocation_project_number folded into the slurm member
+        assert (cp.specific_preferences.slurm.allocation_project_number
+                == "ap")
+        assert proto.compute_resource_policies[0].resource_policy_id == "rp"
+        assert proto.batch_queue_resource_policies[0].max_allowed_nodes == 5
+
+
+# ---------------------------------------------------------------------------
+# GroupResourceProfile orchestration (fake-client)
+# ---------------------------------------------------------------------------
+
+class _FakeGroupCompute:
+    def __init__(self, profile):
+        self._profile = profile
+        self.created = None
+        self.updated = None
+        self.removed_prefs = []
+        self.removed_compute_policies = []
+        self.removed_bq_policies = []
+        self.removed_profile = None
+
+    def get_group_resource_list(self):
+        return [self._profile]
+
+    def get_group_resource_profile(self, grp_id):
+        return self._profile
+
+    def create_group_resource_profile(self, profile):
+        self.created = profile
+        # server assigns id + creation_time
+        profile.group_resource_profile_id = "grp-new"
+        profile.creation_time = 1705320000000
+        return profile
+
+    def update_group_resource_profile(self, grp_id, profile):
+        self.updated = (grp_id, profile)
+
+    def remove_group_compute_prefs(self, grp_id, compute_resource_id):
+        self.removed_prefs.append((grp_id, compute_resource_id))
+
+    def remove_group_compute_resource_policy(self, policy_id):
+        self.removed_compute_policies.append(policy_id)
+
+    def remove_group_batch_queue_resource_policy(self, policy_id):
+        self.removed_bq_policies.append(policy_id)
+
+    def remove_group_resource_profile(self, grp_id):
+        self.removed_profile = grp_id
+
+
+class _FakeGroupClient:
+    def __init__(self, profile, gateway_id="default", username="alice"):
+        self.compute = _FakeGroupCompute(profile)
+        self.gateway_id = gateway_id
+        self.username = username
+
+
+class TestGroupResourceProfileOrchestration:
+    def test_list_returns_withaccess_carrying_the_proto(self):
+        profile = _make_group_profile()
+        client = _FakeGroupClient(profile)
+        out = list_group_resource_profiles(
+            client, has_write_by_id={"grp-1": True})
+        assert len(out) == 1
+        assert isinstance(out[0], WithAccess)
+        # the proto flows through wholesale — no field copied out.
+        assert out[0].message is profile
+        assert out[0].is_owner is False
+        assert out[0].user_has_write_access is True
+
+    def test_list_default_false(self):
+        client = _FakeGroupClient(_make_group_profile())
+        out = list_group_resource_profiles(client)
+        assert out[0].user_has_write_access is False
+
+    def test_get_returns_withaccess_carrying_the_proto(self):
+        profile = _make_group_profile()
+        client = _FakeGroupClient(profile)
+        r = get_group_resource_profile(client, "grp-1", has_write=False)
+        assert isinstance(r, WithAccess)
+        assert r.message is profile
+        assert r.message.group_resource_profile_id == "grp-1"
+        assert r.is_owner is False
+        assert r.user_has_write_access is False
+
+    def test_get_forwards_has_write_true(self):
+        client = _FakeGroupClient(_make_group_profile())
+        r = get_group_resource_profile(client, "grp-1", has_write=True)
+        assert r.user_has_write_access is True
+
+    def test_create_persists_and_wraps(self):
+        client = _FakeGroupClient(_make_group_profile())
+        r = create_group_resource_profile(
+            client, {"group_resource_profile_name": "New"})
+        assert client.compute.created is not None
+        assert client.compute.created.gateway_id == "default"
+        assert isinstance(r, WithAccess)
+        # the server-assigned id is on the wrapped proto.
+        assert r.message.group_resource_profile_id == "grp-new"
+        assert r.is_owner is False
+        # newly created profile is owned by the caller -> has_write defaults True
+        assert r.user_has_write_access is True
+
+    def test_update_removes_orphans(self):
+        # original has cr-slurm + cr-aws prefs, rp-1 + bq-1 policies
+        original = _make_group_profile()
+        client = _FakeGroupClient(original)
+        # new payload keeps only cr-slurm; drops cr-aws, rp-1, bq-1
+        update_group_resource_profile(client, "grp-1", {
+            "group_resource_profile_name": "Test GRP",
+            "compute_preferences": [{
+                "compute_resource_id": "cr-slurm", "resource_type": 0}],
+            "compute_resource_policies": [],
+            "batch_queue_resource_policies": [],
+        })
+        # cr-aws pref removed
+        assert ("grp-1", "cr-aws") in client.compute.removed_prefs
+        assert ("grp-1", "cr-slurm") not in client.compute.removed_prefs
+        assert "rp-1" in client.compute.removed_compute_policies
+        assert "bq-1" in client.compute.removed_bq_policies
+        assert client.compute.updated[0] == "grp-1"
+
+    def test_delete(self):
+        client = _FakeGroupClient(_make_group_profile())
+        delete_group_resource_profile(client, "grp-1")
+        assert client.compute.removed_profile == "grp-1"
+
+
+# ===========================================================================
+# Per-protocol job submission (Local / SSH / Unicore / Cloud)
+# ===========================================================================
+#
+# Proto-direct: each ``get_{local,ssh,unicore,cloud}_job_submission`` returns the
+# bare facade proto VERBATIM (no envelope, no dict transform).  These resources
+# carry no cross-service fields, so there is nothing to union in.  The portal's
+# ``to_jsonable`` serializes the proto to snake_case JSON (enums as member NAMES);
+# that serialization is exercised by the portal contract snapshot, not here.
+
+def _sec_proto(name):
+    return _dm_pb2().SecurityProtocol.Value(name)
+
+
+class _FakeJobSubCompute:
+    def __init__(self, local=None, ssh=None, unicore=None, cloud=None):
+        self._local = local
+        self._ssh = ssh
+        self._unicore = unicore
+        self._cloud = cloud
+        self.calls = []
+
+    def get_local_job_submission(self, sid):
+        self.calls.append(("local", sid))
+        return self._local
+
+    def get_ssh_job_submission(self, sid):
+        self.calls.append(("ssh", sid))
+        return self._ssh
+
+    def get_unicore_job_submission(self, sid):
+        self.calls.append(("unicore", sid))
+        return self._unicore
+
+    def get_cloud_job_submission(self, sid):
+        self.calls.append(("cloud", sid))
+        return self._cloud
+
+
+class _FakeJobSubClient:
+    def __init__(self, **kwargs):
+        self.compute = _FakeJobSubCompute(**kwargs)
+
+
+class TestJobSubmissionOrchestration:
+    """Each helper returns the facade proto VERBATIM (identity), no transform."""
+
+    def test_get_local_returns_proto_verbatim(self):
+        c = _cr_pb2()
+        proto = c.LOCALSubmission(
+            job_submission_interface_id="ls-1",
+            security_protocol=_sec_proto("LOCAL"))
+        client = _FakeJobSubClient(local=proto)
+        result = get_local_job_submission(client, "ls-1")
+        assert result is proto
+        assert client.compute.calls == [("local", "ls-1")]
+
+    def test_get_ssh_returns_proto_verbatim(self):
+        c = _cr_pb2()
+        proto = c.SSHJobSubmission(
+            job_submission_interface_id="ssh-1",
+            security_protocol=_sec_proto("SSH_KEYS"),
+            monitor_mode=c.MonitorMode.MONITOR_FORK)
+        client = _FakeJobSubClient(ssh=proto)
+        result = get_ssh_job_submission(client, "ssh-1")
+        assert result is proto
+        assert client.compute.calls == [("ssh", "ssh-1")]
+
+    def test_get_unicore_returns_proto_verbatim(self):
+        c = _cr_pb2()
+        proto = c.UnicoreJobSubmission(
+            job_submission_interface_id="u-1",
+            security_protocol=_sec_proto("GSI"),
+            unicore_end_point_url="https://u")
+        client = _FakeJobSubClient(unicore=proto)
+        result = get_unicore_job_submission(client, "u-1")
+        assert result is proto
+        assert client.compute.calls == [("unicore", "u-1")]
+
+    def test_get_cloud_returns_proto_verbatim(self):
+        c = _cr_pb2()
+        proto = c.CloudJobSubmission(
+            job_submission_interface_id="cl-1",
+            security_protocol=_sec_proto("OAUTH"),
+            provider_name=c.ProviderName.AWSEC2)
+        client = _FakeJobSubClient(cloud=proto)
+        result = get_cloud_job_submission(client, "cl-1")
+        assert result is proto
+        assert client.compute.calls == [("cloud", "cl-1")]
+
+
+# ---------------------------------------------------------------------------
+# Workspace defaults (edge-workspace-prefs)
+# ---------------------------------------------------------------------------
+
+from types import SimpleNamespace  # noqa: E402
+
+from airavata_sdk.helpers.compute_resources import (  # noqa: E402
+    accessible_group_resource_profile_ids,
+    most_recent_writeable_project_id,
+    resolve_workspace_defaults,
+    user_can_write,
+)
+
+
+class _FakeResearch:
+    def __init__(self, projects):
+        self._projects = projects
+        self.user_projects_calls = []
+
+    def get_user_projects(self, gateway_id, user_name, limit=-1, offset=0):
+        self.user_projects_calls.append((gateway_id, user_name, limit, offset))
+        return self._projects
+
+
+class _FakeComputeGrp:
+    def __init__(self, grp_ids):
+        self._grp_ids = grp_ids
+        self.group_resource_list_calls = 0
+
+    def get_group_resource_list(self):
+        self.group_resource_list_calls += 1
+        return [
+            SimpleNamespace(group_resource_profile_id=i) for i in self._grp_ids
+        ]
+
+
+class _FakeSharing:
+    def __init__(self, writeable_ids):
+        self._writeable = set(writeable_ids)
+        self.calls = []
+
+    def user_has_access(self, resource_id, user_id, permission_type):
+        self.calls.append((resource_id, user_id, permission_type))
+        return resource_id in self._writeable
+
+
+class _FakeWorkspaceClient:
+    def __init__(self, *, project_ids=(), writeable_ids=(), grp_ids=(),
+                 gateway_id="default", username="alice"):
+        self.research = _FakeResearch(
+            [SimpleNamespace(project_id=p) for p in project_ids])
+        self.compute = _FakeComputeGrp(list(grp_ids))
+        self.sharing = _FakeSharing(writeable_ids)
+        self.gateway_id = gateway_id
+        self.username = username
+
+
+class TestWorkspaceDefaults:
+    def test_user_can_write_true(self):
+        client = _FakeWorkspaceClient(writeable_ids=["proj-1"])
+        assert user_can_write(client, "proj-1") is True
+        assert client.sharing.calls == [("proj-1", "alice", "WRITE")]
+
+    def test_user_can_write_false(self):
+        client = _FakeWorkspaceClient(writeable_ids=["proj-1"])
+        assert user_can_write(client, "proj-2") is False
+
+    def test_most_recent_writeable_project_picks_first_writeable(self):
+        # proj-1 not writeable, proj-2 writeable -> returns proj-2.
+        client = _FakeWorkspaceClient(
+            project_ids=["proj-1", "proj-2", "proj-3"],
+            writeable_ids=["proj-2", "proj-3"])
+        assert most_recent_writeable_project_id(client) == "proj-2"
+        # gateway / user come from the client context.
+        assert client.research.user_projects_calls == [
+            ("default", "alice", -1, 0)]
+
+    def test_most_recent_writeable_project_none_when_no_writeable(self):
+        client = _FakeWorkspaceClient(
+            project_ids=["proj-1"], writeable_ids=[])
+        assert most_recent_writeable_project_id(client) is None
+
+    def test_most_recent_writeable_project_none_when_no_projects(self):
+        client = _FakeWorkspaceClient(project_ids=[], writeable_ids=[])
+        assert most_recent_writeable_project_id(client) is None
+
+    def test_accessible_grp_ids(self):
+        client = _FakeWorkspaceClient(grp_ids=["grp-1", "grp-2"])
+        assert accessible_group_resource_profile_ids(client) == [
+            "grp-1", "grp-2"]
+
+    def test_accessible_grp_ids_empty(self):
+        client = _FakeWorkspaceClient(grp_ids=[])
+        assert accessible_group_resource_profile_ids(client) == []
+
+    def test_resolve_defaults_full(self):
+        client = _FakeWorkspaceClient(
+            project_ids=["proj-1", "proj-2"],
+            writeable_ids=["proj-2"],
+            grp_ids=["grp-1", "grp-2"])
+        defaults = resolve_workspace_defaults(client)
+        assert defaults == {
+            "most_recent_project_id": "proj-2",
+            "group_resource_profile_ids": ["grp-1", "grp-2"],
+            "most_recent_group_resource_profile_id": "grp-1",
+        }
+
+    def test_resolve_defaults_empty(self):
+        client = _FakeWorkspaceClient(
+            project_ids=[], writeable_ids=[], grp_ids=[])
+        defaults = resolve_workspace_defaults(client)
+        assert defaults == {
+            "most_recent_project_id": None,
+            "group_resource_profile_ids": [],
+            "most_recent_group_resource_profile_id": None,
+        }

--- a/airavata-python-sdk/tests/helpers/test_credential_resources.py
+++ b/airavata-python-sdk/tests/helpers/test_credential_resources.py
@@ -1,0 +1,238 @@
+"""Unit tests for airavata_sdk.helpers.credential_resources (proto-direct).
+
+The credential helpers return OBJECTS, not dicts: a
+:class:`airavata_sdk.helpers._envelope.WithAccess` wrapping the raw
+``credential_store_pb2.CredentialSummary`` proto plus the caller's access
+flags.  ``is_owner`` is always ``False`` (a credential has no owner);
+``user_has_write_access`` is the CHAINED ``sharing.user_has_access`` WRITE
+lookup keyed on the credential ``token``.
+
+These tests assert:
+
+* the return is a ``WithAccess`` whose ``.message`` is the raw proto (no field
+  copied out, ``type`` left as the proto enum, not a string);
+* ``is_owner`` is ``False`` and ``user_has_write_access`` reflects the chained
+  sharing call;
+* the chained ``sharing.user_has_access`` call is keyed on the ``token`` with
+  ``permission_type="WRITE"``;
+* the create/delete orchestration still drives the raw facade correctly.
+
+Snake_case JSON rendering (enum NAMES, ``persisted_time`` epoch-millis string)
+is the portal renderer's responsibility and is pinned by the portal contract
+snapshot test, not here.
+"""
+
+from airavata_sdk.generated.org.apache.airavata.model.credential.store import (
+    credential_store_pb2 as pb2,
+)
+from airavata_sdk.helpers._envelope import WithAccess
+from airavata_sdk.helpers.credential_resources import (
+    create_password_credential,
+    create_ssh_credential,
+    delete_credential_summary,
+    get_all_credential_summaries,
+    get_credential_summary,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers / stubs
+# ---------------------------------------------------------------------------
+
+def _make_summary(**kwargs):
+    return pb2.CredentialSummary(**kwargs)
+
+
+class _FakeCredential:
+    def __init__(self, summary):
+        self._summary = summary
+        self.generated = None
+        self.registered = None
+        self.deleted_ssh = None
+        self.deleted_pwd = None
+        self.list_calls = []
+
+    def get_credential_summary(self, token_id, gateway_id):
+        return self._summary
+
+    def get_all_credential_summaries(self, gateway_id, type):
+        self.list_calls.append((gateway_id, type))
+        return [self._summary]
+
+    def generate_and_register_ssh_keys(self, gateway_id, username, description):
+        self.generated = (gateway_id, username, description)
+        return "new-ssh-token"
+
+    def register_pwd_credential(self, gateway_id, password_credential):
+        self.registered = (gateway_id, password_credential)
+        return "new-pwd-token"
+
+    def delete_ssh_pub_key(self, token, gateway_id):
+        self.deleted_ssh = (token, gateway_id)
+
+    def delete_pwd_credential(self, token, gateway_id):
+        self.deleted_pwd = (token, gateway_id)
+
+
+class _FakeSharing:
+    def __init__(self, has_access=True):
+        self._has_access = has_access
+        self.calls = []
+
+    def user_has_access(self, resource_id, user_id, permission_type):
+        self.calls.append((resource_id, user_id, permission_type))
+        return self._has_access
+
+
+class _FakeClient:
+    def __init__(self, summary, gateway_id="gw1", username="alice",
+                 sharing_has_access=True):
+        self.credential = _FakeCredential(summary)
+        self.sharing = _FakeSharing(sharing_has_access)
+        self.gateway_id = gateway_id
+        self.username = username
+
+
+def _summary(type=pb2.SummaryType.SSH, token="tok-1"):
+    return _make_summary(
+        type=type, gateway_id="gw1", username="alice",
+        persisted_time=1705320000000, token=token, description="d")
+
+
+# ---------------------------------------------------------------------------
+# get_credential_summary — WithAccess[CredentialSummary]
+# ---------------------------------------------------------------------------
+
+class TestGetCredentialSummary:
+    def test_returns_with_access(self):
+        client = _FakeClient(_summary())
+        result = get_credential_summary(client, "tok-1")
+        assert isinstance(result, WithAccess)
+
+    def test_message_is_the_raw_proto(self):
+        summary = _summary(token="tok-1")
+        client = _FakeClient(summary)
+        result = get_credential_summary(client, "tok-1")
+        assert result.message is summary
+        # The proto flows through wholesale — type stays the proto enum, not a
+        # rendered string.
+        assert result.message.type == pb2.SummaryType.SSH
+        assert result.message.token == "tok-1"
+
+    def test_is_owner_always_false(self):
+        client = _FakeClient(_summary())
+        result = get_credential_summary(client, "tok-1")
+        assert result.is_owner is False
+
+    def test_has_write_keyed_on_token(self):
+        client = _FakeClient(_summary(token="tok-xyz"))
+        get_credential_summary(client, "tok-xyz")
+        assert client.sharing.calls == [("tok-xyz", "alice", "WRITE")]
+
+    def test_user_has_write_access_true(self):
+        client = _FakeClient(_summary(), sharing_has_access=True)
+        result = get_credential_summary(client, "tok-1")
+        assert result.user_has_write_access is True
+
+    def test_user_has_write_access_false(self):
+        client = _FakeClient(_summary(), sharing_has_access=False)
+        result = get_credential_summary(client, "tok-1")
+        assert result.user_has_write_access is False
+
+
+# ---------------------------------------------------------------------------
+# get_all_credential_summaries — list[WithAccess]
+# ---------------------------------------------------------------------------
+
+class TestGetAllCredentialSummaries:
+    def test_concatenates_ssh_and_passwd_when_no_type(self):
+        client = _FakeClient(_summary())
+        get_all_credential_summaries(client)
+        types = [t for (_, t) in client.credential.list_calls]
+        assert pb2.SummaryType.SSH in types
+        assert pb2.SummaryType.PASSWD in types
+
+    def test_single_type_when_specified(self):
+        client = _FakeClient(_summary())
+        get_all_credential_summaries(
+            client, summary_type=pb2.SummaryType.SSH)
+        assert client.credential.list_calls == [("gw1", pb2.SummaryType.SSH)]
+
+    def test_returns_list_of_with_access(self):
+        client = _FakeClient(_summary())
+        result = get_all_credential_summaries(
+            client, summary_type=pb2.SummaryType.SSH)
+        assert isinstance(result, list)
+        assert isinstance(result[0], WithAccess)
+        assert result[0].message.token == "tok-1"
+        assert result[0].message.type == pb2.SummaryType.SSH
+        assert result[0].is_owner is False
+
+    def test_per_summary_write_lookup_keyed_on_token(self):
+        client = _FakeClient(_summary(token="tok-keyed"))
+        get_all_credential_summaries(
+            client, summary_type=pb2.SummaryType.SSH)
+        assert client.sharing.calls == [("tok-keyed", "alice", "WRITE")]
+
+    def test_user_has_write_access_reflects_sharing(self):
+        client = _FakeClient(_summary(), sharing_has_access=False)
+        result = get_all_credential_summaries(
+            client, summary_type=pb2.SummaryType.SSH)
+        assert result[0].user_has_write_access is False
+
+
+class TestCreateSshCredential:
+    def test_generates_with_context_and_description(self):
+        client = _FakeClient(_summary(token="new-ssh-token"))
+        create_ssh_credential(client, {"description": "key desc"})
+        assert client.credential.generated == ("gw1", "alice", "key desc")
+
+    def test_returns_with_access_for_new_token(self):
+        client = _FakeClient(_summary(token="new-ssh-token"))
+        result = create_ssh_credential(client, {"description": "key desc"})
+        assert isinstance(result, WithAccess)
+        assert result.message.token == "new-ssh-token"
+        assert result.is_owner is False
+
+
+class TestCreatePasswordCredential:
+    def test_builds_password_credential_proto(self):
+        client = _FakeClient(_summary(type=pb2.SummaryType.PASSWD,
+                                      token="new-pwd-token"))
+        create_password_credential(client, {
+            "username": "loginuser",
+            "password": "secret",
+            "description": "pw desc",
+        })
+        gw, pc = client.credential.registered
+        assert gw == "gw1"
+        assert pc.gateway_id == "gw1"
+        assert pc.portal_user_name == "alice"
+        assert pc.login_user_name == "loginuser"
+        assert pc.password == "secret"
+        assert pc.description == "pw desc"
+
+    def test_returns_with_access_for_new_token(self):
+        client = _FakeClient(_summary(type=pb2.SummaryType.PASSWD,
+                                      token="new-pwd-token"))
+        result = create_password_credential(client, {
+            "username": "u", "password": "p", "description": "d"})
+        assert isinstance(result, WithAccess)
+        assert result.message.token == "new-pwd-token"
+        assert result.message.type == pb2.SummaryType.PASSWD
+
+
+class TestDeleteCredentialSummary:
+    def test_ssh_dispatches_to_delete_ssh_pub_key(self):
+        summary = _summary(type=pb2.SummaryType.SSH, token="ssh-tok")
+        client = _FakeClient(summary)
+        delete_credential_summary(client, summary)
+        assert client.credential.deleted_ssh == ("ssh-tok", "gw1")
+        assert client.credential.deleted_pwd is None
+
+    def test_passwd_dispatches_to_delete_pwd_credential(self):
+        summary = _summary(type=pb2.SummaryType.PASSWD, token="pwd-tok")
+        client = _FakeClient(summary)
+        delete_credential_summary(client, summary)
+        assert client.credential.deleted_pwd == ("pwd-tok", "gw1")
+        assert client.credential.deleted_ssh is None

--- a/airavata-python-sdk/tests/helpers/test_iam_resources.py
+++ b/airavata-python-sdk/tests/helpers/test_iam_resources.py
@@ -1,0 +1,309 @@
+"""Unit tests for airavata_sdk.helpers.iam_resources.
+
+The user-profiles family is **proto-direct**: ``get_user_profile`` returns the
+raw ``UserProfile`` proto and ``get_all_user_profiles_in_gateway`` returns a
+``list[UserProfile]`` — the family computes nothing cross-service, so there is
+no dict transform and no envelope.  The tests assert the protos flow through
+the raw facade unchanged (identity, not value re-mapping).
+
+The IAM-user family is **proto-direct (composed)**: ``get_iam_user`` returns a
+pydantic ``IAMUser`` and ``get_unverified_email_user`` an ``UnverifiedEmailUser``
+— the proto-derived scalars unioned with the cross-service / request-scoped /
+ORM parts the ViewSet supplies.  ``list_iam_users`` is a raw pass-through of the
+IAM-admin ``UserProfile`` protos.
+
+Orchestration functions are tested via lightweight stub clients that record the
+calls made.
+"""
+
+from airavata_sdk.generated.org.apache.airavata.model.user import (
+    user_profile_pb2 as pb2,
+)
+from airavata_sdk.helpers.iam_resources import (
+    IAMUser,
+    UnverifiedEmailUser,
+    get_all_user_profiles_in_gateway,
+    get_iam_user,
+    get_unverified_email_user,
+    get_user_profile,
+    list_iam_users,
+)
+
+
+# ---------------------------------------------------------------------------
+# Representative proto
+# ---------------------------------------------------------------------------
+
+def _full_profile():
+    return pb2.UserProfile(
+        user_model_version="1.0",
+        airavata_internal_user_id="internal-1",
+        user_id="alice@gw",
+        gateway_id="default",
+        emails=["a@x.com", "b@x.com"],
+        first_name="Alice",
+        last_name="Liddell",
+        middle_name="M",
+        name_prefix="Dr",
+        name_suffix="Jr",
+        orcid_id="0000-0001",
+        phones=["555-1234"],
+        country="US",
+        nationality=["American"],
+        home_organization="GT",
+        origination_affiliation="ARTISAN",
+        creation_time=1705320000000,
+        last_access_time=1705320005000,
+        valid_until=1705320009000,
+        state=pb2.Status.ACTIVE,
+        comments="hello",
+        labeled_uri=["http://a", "http://b"],
+        gpg_key="gpg123",
+        time_zone="UTC",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestration functions — stub client (proto-direct returns)
+# ---------------------------------------------------------------------------
+
+class _FakeIam:
+    def __init__(self, profile, profiles=None):
+        self._profile = profile
+        self._profiles = profiles if profiles is not None else [profile]
+        self.by_id_calls = []
+        self.list_calls = []
+
+    def get_user_profile_by_id(self, user_id, gateway_id):
+        self.by_id_calls.append((user_id, gateway_id))
+        return self._profile
+
+    def get_all_user_profiles_in_gateway(self, gateway_id, offset, limit):
+        self.list_calls.append((gateway_id, offset, limit))
+        return self._profiles
+
+
+class _FakeClient:
+    def __init__(self, profile, profiles=None, gateway_id="gw1",
+                 username="alice"):
+        self.iam = _FakeIam(profile, profiles)
+        self.gateway_id = gateway_id
+        self.username = username
+
+
+class TestGetUserProfile:
+    def test_returns_the_raw_proto(self):
+        """Proto-direct: the facade's ``UserProfile`` flows through unchanged
+        (no transform, no envelope) — the same object identity is returned."""
+        profile = _full_profile()
+        client = _FakeClient(profile)
+        result = get_user_profile(client, "alice@gw")
+        assert result is profile
+        assert isinstance(result, pb2.UserProfile)
+        # Proto fields are preserved verbatim; no '' -> None remapping, no
+        # field renames, the enum stays the proto enum value.
+        assert result.user_id == "alice@gw"
+        assert result.state == pb2.Status.ACTIVE
+        assert result.origination_affiliation == "ARTISAN"
+
+    def test_lookup_uses_client_gateway(self):
+        client = _FakeClient(_full_profile())
+        get_user_profile(client, "alice@gw")
+        assert client.iam.by_id_calls == [("alice@gw", "gw1")]
+
+
+class TestGetAllUserProfilesInGateway:
+    def test_returns_list_of_protos(self):
+        p1 = _full_profile()
+        p2 = pb2.UserProfile(user_id="bob@gw")
+        client = _FakeClient(p1, profiles=[p1, p2])
+        result = get_all_user_profiles_in_gateway(client)
+        assert all(isinstance(u, pb2.UserProfile) for u in result)
+        assert [u.user_id for u in result] == ["alice@gw", "bob@gw"]
+        # The protos themselves flow through (identity), only re-listed.
+        assert result[0] is p1
+        assert result[1] is p2
+
+    def test_default_offset_and_limit(self):
+        client = _FakeClient(_full_profile())
+        get_all_user_profiles_in_gateway(client)
+        assert client.iam.list_calls == [("gw1", 0, -1)]
+
+    def test_custom_offset_and_limit(self):
+        client = _FakeClient(_full_profile())
+        get_all_user_profiles_in_gateway(client, offset=5, limit=10)
+        assert client.iam.list_calls == [("gw1", 5, 10)]
+
+
+# ===========================================================================
+# IAM-user family (composed pydantic: IAMUser / UnverifiedEmailUser)
+# ===========================================================================
+
+def _iam_profile(state=pb2.Status.ACTIVE, **overrides):
+    base = dict(
+        airavata_internal_user_id="alice@gw_internal",
+        user_id="alice@gw",
+        gateway_id="default",
+        emails=["alice@x.com", "alt@x.com"],
+        first_name="Alice",
+        last_name="Liddell",
+        creation_time=1705320000000,
+        state=state,
+    )
+    base.update(overrides)
+    return pb2.UserProfile(**base)
+
+
+class _FakeIamUsers:
+    def __init__(self, users):
+        self._users = users
+        self.list_calls = []
+
+    def get_iam_users(self, offset, limit, search):
+        self.list_calls.append((offset, limit, search))
+        return list(self._users)
+
+
+class _FakeIamUserClient:
+    def __init__(self, users, gateway_id="gw1", username="alice"):
+        self.iam = _FakeIamUsers(users)
+        self.gateway_id = gateway_id
+        self.username = username
+
+
+def _call_get_iam_user(profile, **overrides):
+    kwargs = dict(
+        airavata_user_profile_exists=True,
+        user_has_write_access=True,
+        groups=[{"id": "g1", "name": "Group One"}],
+        external_idp_user_info={"idp_alias": "cilogon"},
+        user_profile_invalid_fields=["phone"],
+    )
+    kwargs.update(overrides)
+    return get_iam_user(_FakeIamUserClient([]), profile, **kwargs)
+
+
+class TestGetIamUser:
+
+    def test_returns_iam_user_model(self):
+        u = _call_get_iam_user(_iam_profile())
+        assert isinstance(u, IAMUser)
+
+    def test_scalar_and_derived_fields(self):
+        u = _call_get_iam_user(_iam_profile())
+        assert u.airavata_internal_user_id == "alice@gw_internal"
+        assert u.user_id == "alice@gw"
+        assert u.gateway_id == "default"
+        # email is the FIRST element of the repeated emails field
+        assert u.email == "alice@x.com"
+        assert u.first_name == "Alice"
+        assert u.last_name == "Liddell"
+        assert u.airavata_user_profile_exists is True
+
+    def test_composed_fields_passed_through(self):
+        u = _call_get_iam_user(_iam_profile())
+        assert u.user_has_write_access is True
+        assert u.groups == [{"id": "g1", "name": "Group One"}]
+        assert u.external_idp_user_info == {"idp_alias": "cilogon"}
+        assert u.user_profile_invalid_fields == ["phone"]
+
+    def test_composed_fields_default_empty(self):
+        u = get_iam_user(
+            _FakeIamUserClient([]), _iam_profile(),
+            airavata_user_profile_exists=False,
+            user_has_write_access=False)
+        assert u.groups == []
+        assert u.external_idp_user_info == {}
+        assert u.user_profile_invalid_fields == []
+
+    def test_enabled_and_email_verified_active(self):
+        u = _call_get_iam_user(_iam_profile(state=pb2.Status.ACTIVE))
+        assert u.enabled is True
+        assert u.email_verified is True
+
+    def test_email_verified_confirmed_but_not_enabled(self):
+        u = _call_get_iam_user(_iam_profile(state=pb2.Status.CONFIRMED))
+        assert u.enabled is False
+        assert u.email_verified is True
+
+    def test_neither_enabled_nor_verified_for_other_state(self):
+        u = _call_get_iam_user(_iam_profile(state=pb2.Status.PENDING))
+        assert u.enabled is False
+        assert u.email_verified is False
+
+    def test_creation_time_is_epoch_millis_string(self):
+        u = _call_get_iam_user(_iam_profile())
+        assert u.creation_time == "1705320000000"
+
+    def test_creation_time_zero_is_string_zero(self):
+        """proto-direct int64 contract: 0 -> "0", never None / never epoch ISO."""
+        u = _call_get_iam_user(_iam_profile(creation_time=0))
+        assert u.creation_time == "0"
+
+    def test_no_emails_renders_empty_email(self):
+        prof = pb2.UserProfile(user_id="bob@gw", state=pb2.Status.ACTIVE)
+        u = _call_get_iam_user(prof)
+        assert u.email == ""
+
+    def test_no_url_field(self):
+        """The hyperlink is dropped; the frontend builds it from user_id."""
+        u = _call_get_iam_user(_iam_profile())
+        assert not hasattr(u, "url")
+
+    def test_expected_field_set(self):
+        u = _call_get_iam_user(_iam_profile())
+        assert set(u.model_dump().keys()) == {
+            "airavata_internal_user_id", "user_id", "gateway_id", "email",
+            "first_name", "last_name", "enabled", "email_verified",
+            "creation_time", "airavata_user_profile_exists",
+            "user_has_write_access", "groups", "external_idp_user_info",
+            "user_profile_invalid_fields",
+        }
+
+
+class TestGetUnverifiedEmailUser:
+
+    def test_returns_unverified_model(self):
+        u = get_unverified_email_user(
+            _FakeIamUserClient([]), _iam_profile(state=pb2.Status.CONFIRMED),
+            user_has_write_access=False)
+        assert isinstance(u, UnverifiedEmailUser)
+
+    def test_subset_field_set(self):
+        u = get_unverified_email_user(
+            _FakeIamUserClient([]), _iam_profile(state=pb2.Status.CONFIRMED),
+            user_has_write_access=True)
+        assert set(u.model_dump().keys()) == {
+            "user_id", "gateway_id", "email", "first_name", "last_name",
+            "enabled", "email_verified", "creation_time",
+            "user_has_write_access",
+        }
+
+    def test_derived_flags(self):
+        u = get_unverified_email_user(
+            _FakeIamUserClient([]), _iam_profile(state=pb2.Status.CONFIRMED),
+            user_has_write_access=False)
+        assert u.enabled is False
+        assert u.email_verified is True
+        assert u.email == "alice@x.com"
+        assert u.user_has_write_access is False
+
+    def test_creation_time_is_epoch_millis_string(self):
+        u = get_unverified_email_user(
+            _FakeIamUserClient([]), _iam_profile(),
+            user_has_write_access=False)
+        assert u.creation_time == "1705320000000"
+
+
+class TestListIamUsers:
+    def test_passes_through_protos(self):
+        p = _iam_profile()
+        client = _FakeIamUserClient([p])
+        result = list_iam_users(client, offset=2, limit=5, search="ali")
+        assert result == [p]
+        assert client.iam.list_calls == [(2, 5, "ali")]
+
+    def test_defaults(self):
+        client = _FakeIamUserClient([])
+        list_iam_users(client)
+        assert client.iam.list_calls == [(0, -1, "")]

--- a/airavata-python-sdk/tests/helpers/test_research_resources.py
+++ b/airavata-python-sdk/tests/helpers/test_research_resources.py
@@ -1,0 +1,2357 @@
+"""Unit tests for airavata_sdk.helpers.research_resources.
+
+PROJECT FAMILY (proto-direct reference)
+---------------------------------------
+The project family follows the proto-direct architecture: the helpers return
+the raw ``workspace_pb2.Project`` proto unioned with the caller's sharing-access
+flags in a :class:`~airavata_sdk.helpers._envelope.WithAccess` container.  The
+tests below assert that ``get_project`` / ``list_projects`` / ``create_project``
+/ ``update_project`` return a ``WithAccess`` carrying the proto message plus the
+two bools (``is_owner`` / ``user_has_write_access``), and that the chained
+``sharing.user_has_access`` call is made with the right arguments.  There is no
+dict transform to test — the portal's generic renderer flattens the proto.
+
+Other families still use the legacy dict path and are tested via a lightweight
+stub client that records the calls made.
+"""
+
+from airavata_sdk.helpers._envelope import WithAccess
+from airavata_sdk.helpers.research_resources import (
+    create_application_module,
+    create_notification,
+    create_project,
+    delete_notification,
+    get_application_module,
+    get_experiment_statistics,
+    get_notification,
+    get_project,
+    list_application_modules,
+    list_notifications,
+    list_projects,
+    search_experiments,
+    update_application_module,
+    update_notification,
+    update_project,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_project(**kwargs):
+    from airavata_sdk.generated.org.apache.airavata.model.workspace import workspace_pb2
+    return workspace_pb2.Project(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Project family — proto-direct + WithAccess (stub client)
+# ---------------------------------------------------------------------------
+
+class _FakeResearch:
+    def __init__(self, project):
+        self._project = project
+        self.created_project = None
+        self.updated_project = None
+        self.created_gateway_id = None
+
+    def get_project(self, project_id):
+        return self._project
+
+    def get_user_projects(self, gateway_id, user_name, limit=-1, offset=0):
+        return [self._project]
+
+    def create_project(self, gateway_id, project):
+        self.created_project = project
+        self.created_gateway_id = gateway_id
+        return "new-proj-id"
+
+    def update_project(self, project_id, project):
+        self.updated_project = project
+
+
+class _FakeSharing:
+    def __init__(self, has_access=True):
+        self._has_access = has_access
+        self.calls = []
+
+    def user_has_access(self, resource_id, user_id, permission_type):
+        self.calls.append((resource_id, user_id, permission_type))
+        return self._has_access
+
+
+class _FakeClient:
+    def __init__(self, project, gateway_id="gw1", username="alice",
+                 sharing_has_access=True):
+        self.research = _FakeResearch(project)
+        self.sharing = _FakeSharing(sharing_has_access)
+        self.gateway_id = gateway_id
+        self.username = username
+
+
+class TestGetProject:
+    """``get_project`` returns ``WithAccess[Project]`` — the raw proto plus the
+    two sharing-access bools.  No dict transform; the proto flows through."""
+
+    def _project(self):
+        return _make_project(
+            project_id="proj-1", owner="alice", gateway_id="gw1",
+            name="Test", creation_time=1705320000000,
+        )
+
+    def test_returns_with_access_container(self):
+        client = _FakeClient(self._project())
+        result = get_project(client, "proj-1")
+        assert isinstance(result, WithAccess)
+
+    def test_message_is_the_proto(self):
+        p = self._project()
+        client = _FakeClient(p)
+        result = get_project(client, "proj-1")
+        # The exact proto object flows through wholesale — not copied.
+        assert result.message is p
+        assert result.message.project_id == "proj-1"
+        assert result.message.owner == "alice"
+
+    def test_is_owner_true_when_username_matches(self):
+        client = _FakeClient(self._project(), username="alice")
+        result = get_project(client, "proj-1")
+        assert result.is_owner is True
+
+    def test_is_owner_false_when_username_differs(self):
+        client = _FakeClient(self._project(), username="bob")
+        result = get_project(client, "proj-1")
+        assert result.is_owner is False
+
+    def test_user_has_write_access_forwarded_from_sharing(self):
+        client = _FakeClient(self._project(), sharing_has_access=False)
+        result = get_project(client, "proj-1")
+        assert result.user_has_write_access is False
+
+    def test_user_has_write_access_true_from_sharing(self):
+        client = _FakeClient(self._project(), sharing_has_access=True)
+        result = get_project(client, "proj-1")
+        assert result.user_has_write_access is True
+
+    def test_sharing_called_with_correct_args(self):
+        client = _FakeClient(self._project(), username="alice")
+        get_project(client, "proj-1")
+        assert len(client.sharing.calls) == 1
+        resource_id, user_id, perm = client.sharing.calls[0]
+        assert resource_id == "proj-1"
+        assert user_id == "alice"
+        assert perm == "WRITE"
+
+
+class TestListProjects:
+    def _project(self):
+        return _make_project(
+            project_id="proj-2", owner="alice", gateway_id="gw1",
+            name="Listed Project", creation_time=1705320000000,
+        )
+
+    def test_returns_list_of_with_access(self):
+        client = _FakeClient(self._project())
+        results = list_projects(client)
+        assert len(results) == 1
+        assert isinstance(results[0], WithAccess)
+
+    def test_message_carries_proto_and_flags(self):
+        client = _FakeClient(self._project())
+        result = list_projects(client)[0]
+        assert result.message.project_id == "proj-2"
+        assert result.is_owner is True
+        assert result.user_has_write_access is True
+
+    def test_passes_limit_and_offset(self):
+        p = self._project()
+        client = _FakeClient(p)
+        # Overwrite get_user_projects to capture args
+        calls = []
+        original = client.research.get_user_projects
+
+        def capturing(gateway_id, user_name, limit=-1, offset=0):
+            calls.append((gateway_id, user_name, limit, offset))
+            return original(gateway_id, user_name, limit, offset)
+
+        client.research.get_user_projects = capturing
+        list_projects(client, limit=10, offset=5)
+        assert calls[0][2] == 10
+        assert calls[0][3] == 5
+
+
+class TestCreateProject:
+    def test_returns_with_access_after_create(self):
+        p = _make_project(project_id="new-proj-id", owner="alice",
+                          gateway_id="gw1", name="New Project")
+        client = _FakeClient(p)
+        result = create_project(
+            client, {"name": "New Project", "description": "Desc"})
+        assert isinstance(result, WithAccess)
+        assert result.message.project_id == "new-proj-id"
+
+    def test_sets_owner_from_client(self):
+        p = _make_project(project_id="new-proj-id", owner="alice",
+                          gateway_id="gw1", name="New Project")
+        client = _FakeClient(p, username="alice")
+        create_project(client, {"name": "New Project"})
+        assert client.research.created_project.owner == "alice"
+
+    def test_sets_gateway_id_from_client(self):
+        p = _make_project(project_id="new-proj-id", owner="alice",
+                          gateway_id="gw1", name="New Project")
+        client = _FakeClient(p, gateway_id="gw1")
+        create_project(client, {"name": "New Project"})
+        assert client.research.created_gateway_id == "gw1"
+
+
+class TestUpdateProject:
+    def _base_project(self):
+        return _make_project(
+            project_id="proj-3", owner="alice", gateway_id="gw1",
+            name="Old Name", description="Old Desc",
+        )
+
+    def test_updates_name(self):
+        client = _FakeClient(self._base_project())
+        update_project(client, "proj-3", {"name": "New Name"})
+        assert client.research.updated_project.name == "New Name"
+
+    def test_updates_description(self):
+        client = _FakeClient(self._base_project())
+        update_project(client, "proj-3", {"description": "New Desc"})
+        assert client.research.updated_project.description == "New Desc"
+
+    def test_returns_with_access(self):
+        p = self._base_project()
+        client = _FakeClient(p)
+        result = update_project(client, "proj-3", {"name": "Updated"})
+        assert isinstance(result, WithAccess)
+        assert result.message.project_id == "proj-3"
+
+
+# ===========================================================================
+# ApplicationModule
+# ===========================================================================
+
+def _make_app_module(**kwargs):
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.appdeployment import (  # noqa: E501
+        app_deployment_pb2,
+    )
+    return app_deployment_pb2.ApplicationModule(**kwargs)
+
+
+# The application-module family follows the proto-direct architecture
+# (gateway-catalog variant): the helpers return the raw
+# ``app_deployment_pb2.ApplicationModule`` proto wrapped in a ``WithAccess``
+# container.  Unlike the project family there is no ownership concept — the
+# proto has no ``owner`` field — so ``is_owner`` is always ``False`` and
+# ``user_has_write_access`` is the gateway-admin flag the ViewSet passes in as
+# ``has_write`` (NOT a chained ``sharing.user_has_access`` call).  There is no
+# dict transform to test; the portal's generic renderer flattens the proto.
+
+
+class _FakeAppResearch:
+    def __init__(self, module):
+        self._module = module
+        self.registered_module = None
+        self.registered_gateway_id = None
+        self.updated_module = None
+        self.updated_id = None
+
+    def get_application_module(self, app_module_id):
+        return self._module
+
+    def get_accessible_app_modules(self, gateway_id):
+        return [self._module]
+
+    def get_all_app_modules(self, gateway_id):
+        return [self._module]
+
+    def register_application_module(self, gateway_id, application_module):
+        self.registered_module = application_module
+        self.registered_gateway_id = gateway_id
+        return "new-mod-id"
+
+    def update_application_module(self, app_module_id, application_module):
+        self.updated_id = app_module_id
+        self.updated_module = application_module
+
+
+class _FakeAppClient:
+    def __init__(self, module, gateway_id="gw1", username="alice"):
+        self.research = _FakeAppResearch(module)
+        self.gateway_id = gateway_id
+        self.username = username
+
+
+class TestGetApplicationModule:
+    """``get_application_module`` returns ``WithAccess[ApplicationModule]`` — the
+    raw proto plus the gateway-catalog access flags (``is_owner`` always
+    ``False``; ``user_has_write_access`` forwarded from ``has_write``)."""
+
+    def _module(self):
+        return _make_app_module(
+            app_module_id="mod-1", app_module_name="App",
+            app_module_version="1.0", app_module_description="d",
+        )
+
+    def test_returns_with_access_container(self):
+        client = _FakeAppClient(self._module())
+        result = get_application_module(client, "mod-1", has_write=True)
+        assert isinstance(result, WithAccess)
+
+    def test_message_is_the_proto(self):
+        m = self._module()
+        client = _FakeAppClient(m)
+        result = get_application_module(client, "mod-1", has_write=True)
+        # The exact proto object flows through wholesale — not copied.
+        assert result.message is m
+        assert result.message.app_module_id == "mod-1"
+
+    def test_is_owner_always_false(self):
+        client = _FakeAppClient(self._module())
+        result = get_application_module(client, "mod-1", has_write=True)
+        assert result.is_owner is False
+
+    def test_has_write_forwarded_true(self):
+        client = _FakeAppClient(self._module())
+        result = get_application_module(client, "mod-1", has_write=True)
+        assert result.user_has_write_access is True
+
+    def test_has_write_forwarded_false(self):
+        client = _FakeAppClient(self._module())
+        result = get_application_module(client, "mod-1", has_write=False)
+        assert result.user_has_write_access is False
+
+
+class TestListApplicationModules:
+    def _module(self):
+        return _make_app_module(
+            app_module_id="mod-2", app_module_name="Listed",
+        )
+
+    def test_accessible_only_uses_accessible_facade(self):
+        client = _FakeAppClient(self._module())
+        calls = []
+        client.research.get_accessible_app_modules = lambda gateway_id: (
+            calls.append(("accessible", gateway_id)) or [self._module()])
+        client.research.get_all_app_modules = lambda gateway_id: (
+            calls.append(("all", gateway_id)) or [self._module()])
+        list_application_modules(client, has_write=True, accessible_only=True)
+        assert calls[0][0] == "accessible"
+
+    def test_all_uses_all_facade(self):
+        client = _FakeAppClient(self._module())
+        calls = []
+        client.research.get_accessible_app_modules = lambda gateway_id: (
+            calls.append(("accessible", gateway_id)) or [self._module()])
+        client.research.get_all_app_modules = lambda gateway_id: (
+            calls.append(("all", gateway_id)) or [self._module()])
+        list_application_modules(client, has_write=True, accessible_only=False)
+        assert calls[0][0] == "all"
+
+    def test_returns_list_of_with_access(self):
+        client = _FakeAppClient(self._module())
+        results = list_application_modules(client, has_write=True)
+        assert len(results) == 1
+        assert isinstance(results[0], WithAccess)
+
+    def test_message_carries_proto_and_flags(self):
+        client = _FakeAppClient(self._module())
+        result = list_application_modules(client, has_write=True)[0]
+        assert result.message.app_module_id == "mod-2"
+        assert result.is_owner is False
+        assert result.user_has_write_access is True
+
+
+class TestCreateApplicationModule:
+    def test_returns_with_access_after_create(self):
+        m = _make_app_module(
+            app_module_id="new-mod-id", app_module_name="New")
+        client = _FakeAppClient(m)
+        result = create_application_module(
+            client, {"app_module_name": "New", "app_module_version": "1"},
+            has_write=True)
+        assert isinstance(result, WithAccess)
+        assert result.message.app_module_id == "new-mod-id"
+
+    def test_sets_fields_on_proto(self):
+        m = _make_app_module(app_module_id="new-mod-id", app_module_name="New")
+        client = _FakeAppClient(m)
+        create_application_module(
+            client,
+            {"app_module_name": "New", "app_module_version": "2",
+             "app_module_description": "desc"},
+            has_write=True)
+        reg = client.research.registered_module
+        assert reg.app_module_name == "New"
+        assert reg.app_module_version == "2"
+        assert reg.app_module_description == "desc"
+
+    def test_uses_client_gateway_id(self):
+        m = _make_app_module(app_module_id="new-mod-id", app_module_name="New")
+        client = _FakeAppClient(m, gateway_id="gw1")
+        create_application_module(
+            client, {"app_module_name": "New"}, has_write=True)
+        assert client.research.registered_gateway_id == "gw1"
+
+
+class TestUpdateApplicationModule:
+    def _base_module(self):
+        return _make_app_module(
+            app_module_id="mod-3", app_module_name="Old",
+            app_module_version="1", app_module_description="old",
+        )
+
+    def test_updates_name(self):
+        client = _FakeAppClient(self._base_module())
+        update_application_module(
+            client, "mod-3", {"app_module_name": "New"}, has_write=True)
+        assert client.research.updated_module.app_module_name == "New"
+
+    def test_updates_version_and_description(self):
+        client = _FakeAppClient(self._base_module())
+        update_application_module(
+            client, "mod-3",
+            {"app_module_version": "2", "app_module_description": "new"},
+            has_write=True)
+        assert client.research.updated_module.app_module_version == "2"
+        assert client.research.updated_module.app_module_description == "new"
+
+    def test_returns_with_access(self):
+        client = _FakeAppClient(self._base_module())
+        result = update_application_module(
+            client, "mod-3", {"app_module_name": "Updated"}, has_write=True)
+        assert isinstance(result, WithAccess)
+        assert result.message.app_module_id == "mod-3"
+
+
+# ===========================================================================
+# ExperimentSummary (experiment-search)
+# ===========================================================================
+
+def _make_experiment_summary(**kwargs):
+    from airavata_sdk.generated.org.apache.airavata.model.experiment import (
+        experiment_pb2,
+    )
+    return experiment_pb2.ExperimentSummaryModel(**kwargs)
+
+
+class _FakeExpResearch:
+    def __init__(self, summaries):
+        self._summaries = summaries
+        self.search_args = None
+
+    def search_experiments(self, gateway_id, user_name, filters=None,
+                           limit=-1, offset=0):
+        self.search_args = (gateway_id, user_name, filters, limit, offset)
+        return list(self._summaries)
+
+
+class _FakeExpClient:
+    def __init__(self, summaries, gateway_id="gw1", username="alice",
+                 sharing_has_access=True):
+        self.research = _FakeExpResearch(summaries)
+        self.sharing = _FakeSharing(sharing_has_access)
+        self.gateway_id = gateway_id
+        self.username = username
+
+
+class TestSearchExperiments:
+    """``search_experiments`` returns ``list[WithAccess[ExperimentSummaryModel]]``
+    — each raw proto unioned with the two sharing-access bools.  No dict
+    transform; the proto flows through wholesale.  ``is_owner`` is always
+    ``False`` (the summary proto has no ``owner`` field) and
+    ``user_has_write_access`` is a per-experiment chained sharing WRITE lookup."""
+
+    def _summary(self):
+        return _make_experiment_summary(
+            experiment_id="exp-1", project_id="proj-1", gateway_id="gw1",
+            name="Searched", creation_time=1705320000000,
+            experiment_status="EXECUTING",
+        )
+
+    def test_returns_list_of_with_access(self):
+        client = _FakeExpClient([self._summary()])
+        results = search_experiments(client)
+        assert len(results) == 1
+        assert isinstance(results[0], WithAccess)
+
+    def test_message_is_the_proto(self):
+        s = self._summary()
+        client = _FakeExpClient([s])
+        result = search_experiments(client)[0]
+        # The exact proto object flows through wholesale — not copied.
+        assert result.message is s
+        assert result.message.experiment_id == "exp-1"
+        assert result.message.experiment_status == "EXECUTING"
+
+    def test_is_owner_always_false(self):
+        """ExperimentSummaryModel has no owner field; is_owner is trivially
+        False (matching the legacy serializer, which had no isOwner flag)."""
+        client = _FakeExpClient([self._summary()], username="alice")
+        result = search_experiments(client)[0]
+        assert result.is_owner is False
+
+    def test_user_has_write_access_true_from_sharing(self):
+        client = _FakeExpClient([self._summary()], sharing_has_access=True)
+        result = search_experiments(client)[0]
+        assert result.user_has_write_access is True
+
+    def test_write_access_forwarded_false(self):
+        client = _FakeExpClient([self._summary()], sharing_has_access=False)
+        result = search_experiments(client)[0]
+        assert result.user_has_write_access is False
+
+    def test_passes_gateway_and_username_and_filters(self):
+        client = _FakeExpClient([self._summary()], gateway_id="gw1",
+                                username="alice")
+        search_experiments(
+            client, filters={"USER_NAME": "alice"}, limit=10, offset=5)
+        gw, user, filters, limit, offset = client.research.search_args
+        assert gw == "gw1"
+        assert user == "alice"
+        assert filters == {"USER_NAME": "alice"}
+        assert limit == 10
+        assert offset == 5
+
+    def test_none_filters_becomes_empty_dict(self):
+        client = _FakeExpClient([self._summary()])
+        search_experiments(client)
+        _, _, filters, _, _ = client.research.search_args
+        assert filters == {}
+
+    def test_sharing_keyed_on_experiment_id(self):
+        client = _FakeExpClient([self._summary()], username="alice")
+        search_experiments(client)
+        assert len(client.sharing.calls) == 1
+        resource_id, user_id, perm = client.sharing.calls[0]
+        assert resource_id == "exp-1"
+        assert user_id == "alice"
+        assert perm == "WRITE"
+
+
+# ===========================================================================
+# ExperimentStatistics (experiment-statistics — proto-direct)
+# ===========================================================================
+#
+# Proto-direct: ``get_experiment_statistics`` returns the
+# ``experiment_pb2.ExperimentStatistics`` proto WHOLESALE.  The proto already
+# carries the full shape (six per-state counts + six per-state summary lists of
+# ExperimentSummaryModel) and nothing cross-service is computed, so there is no
+# dict transform and no WithAccess/pydantic wrapper to test — only that the proto
+# is returned as-is and the facade is called with the right arguments.
+
+def _make_experiment_statistics(**kwargs):
+    from airavata_sdk.generated.org.apache.airavata.model.experiment import (
+        experiment_pb2,
+    )
+    return experiment_pb2.ExperimentStatistics(**kwargs)
+
+
+class _FakeStatsResearch:
+    def __init__(self, stats):
+        self._stats = stats
+        self.call_args = None
+
+    def get_experiment_statistics(self, gateway_id, from_time, to_time,
+                                  user_name="", application_name="",
+                                  resource_host_name="", limit=0, offset=0):
+        self.call_args = dict(
+            gateway_id=gateway_id, from_time=from_time, to_time=to_time,
+            user_name=user_name, application_name=application_name,
+            resource_host_name=resource_host_name, limit=limit, offset=offset)
+        return self._stats
+
+
+class _FakeStatsClient:
+    def __init__(self, stats, gateway_id="gw1", username="alice"):
+        self.research = _FakeStatsResearch(stats)
+        self.gateway_id = gateway_id
+        self.username = username
+
+
+class TestGetExperimentStatistics:
+    def _summary(self, **kwargs):
+        base = dict(
+            experiment_id="exp-1", project_id="proj-1", gateway_id="gw1",
+            name="E", creation_time=1705320000000,
+            experiment_status="COMPLETED",
+        )
+        base.update(kwargs)
+        return _make_experiment_summary(**base)
+
+    def _full_stats(self):
+        return _make_experiment_statistics(
+            all_experiment_count=10,
+            completed_experiment_count=4,
+            cancelled_experiment_count=1,
+            failed_experiment_count=2,
+            created_experiment_count=2,
+            running_experiment_count=1,
+            all_experiments=[self._summary(experiment_id="all-1")],
+            completed_experiments=[self._summary(experiment_id="comp-1")],
+            failed_experiments=[self._summary(experiment_id="fail-1")],
+            cancelled_experiments=[self._summary(experiment_id="canc-1")],
+            created_experiments=[self._summary(experiment_id="crea-1")],
+            running_experiments=[self._summary(experiment_id="run-1")],
+        )
+
+    def _stats(self):
+        return _make_experiment_statistics(all_experiment_count=3)
+
+    def test_returns_the_proto_directly(self):
+        """No dict transform, no wrapper — the proto flows through wholesale."""
+        from airavata_sdk.generated.org.apache.airavata.model.experiment import (
+            experiment_pb2,
+        )
+        stats = self._stats()
+        client = _FakeStatsClient(stats)
+        result = get_experiment_statistics(client, from_time=1000, to_time=2000)
+        assert isinstance(result, experiment_pb2.ExperimentStatistics)
+        assert result is stats
+
+    def test_proto_carries_counts_and_summary_lists(self):
+        client = _FakeStatsClient(self._full_stats())
+        result = get_experiment_statistics(client, from_time=1, to_time=2)
+        assert result.all_experiment_count == 10
+        assert result.completed_experiment_count == 4
+        assert result.cancelled_experiment_count == 1
+        assert result.failed_experiment_count == 2
+        assert result.created_experiment_count == 2
+        assert result.running_experiment_count == 1
+        assert result.all_experiments[0].experiment_id == "all-1"
+        assert result.completed_experiments[0].experiment_id == "comp-1"
+        assert result.failed_experiments[0].experiment_id == "fail-1"
+        assert result.cancelled_experiments[0].experiment_id == "canc-1"
+        assert result.created_experiments[0].experiment_id == "crea-1"
+        assert result.running_experiments[0].experiment_id == "run-1"
+
+    def test_passes_bounds_and_gateway(self):
+        client = _FakeStatsClient(self._stats(), gateway_id="gw1")
+        get_experiment_statistics(
+            client, from_time=1000, to_time=2000, limit=25, offset=5)
+        args = client.research.call_args
+        assert args["gateway_id"] == "gw1"
+        assert args["from_time"] == 1000
+        assert args["to_time"] == 2000
+        assert args["limit"] == 25
+        assert args["offset"] == 5
+
+    def test_none_filters_normalised_to_empty_string(self):
+        client = _FakeStatsClient(self._stats())
+        get_experiment_statistics(
+            client, from_time=1000, to_time=2000,
+            user_name=None, application_name=None, resource_host_name=None)
+        args = client.research.call_args
+        assert args["user_name"] == ""
+        assert args["application_name"] == ""
+        assert args["resource_host_name"] == ""
+
+    def test_filters_forwarded(self):
+        client = _FakeStatsClient(self._stats())
+        get_experiment_statistics(
+            client, from_time=1000, to_time=2000,
+            user_name="bob", application_name="Gaussian",
+            resource_host_name="host-x")
+        args = client.research.call_args
+        assert args["user_name"] == "bob"
+        assert args["application_name"] == "Gaussian"
+        assert args["resource_host_name"] == "host-x"
+
+
+# ===========================================================================
+# Notification — proto-direct + WithAccess (gateway-catalog variant)
+# ===========================================================================
+#
+# Like the application-module family, the notification helpers return the raw
+# ``workspace_pb2.Notification`` proto wrapped in a ``WithAccess`` container.
+# There is no ownership concept (the proto has no ``owner`` field), so
+# ``is_owner`` is always ``False`` and ``user_has_write_access`` is the
+# gateway-admin flag the ViewSet passes in as ``has_write``.  There is no dict
+# transform to test — the portal's generic renderer flattens the proto (enums as
+# NAMES, int64 timestamps as STRINGS); that JSON shape is pinned by the portal's
+# ``test_notifications_contract.py`` snapshot.  The create/update wire-decoders
+# (``_to_epoch_ms`` / ``_to_priority_int``) remain on the write path and are
+# tested by ``TestNotificationWireDecoders``.
+
+def _make_notification(**kwargs):
+    from airavata_sdk.generated.org.apache.airavata.model.workspace import (
+        workspace_pb2,
+    )
+    return workspace_pb2.Notification(**kwargs)
+
+
+def _priority(name):
+    from airavata_sdk.generated.org.apache.airavata.model.workspace import (
+        workspace_pb2,
+    )
+    return getattr(workspace_pb2.NotificationPriority, name)
+
+
+class _FakeNotifResearch:
+    def __init__(self, notification, listing=None):
+        self._notification = notification
+        self._listing = listing if listing is not None else [notification]
+        self.created = None
+        self.updated = None
+        self.deleted = None
+
+    def get_notification(self, gateway_id, notification_id):
+        return self._notification
+
+    def get_all_notifications(self, gateway_id):
+        return list(self._listing)
+
+    def create_notification(self, notification):
+        self.created = notification
+        return "new-notif-id"
+
+    def update_notification(self, notification):
+        self.updated = notification
+
+    def delete_notification(self, gateway_id, notification_id):
+        self.deleted = (gateway_id, notification_id)
+
+
+class _FakeNotifClient:
+    def __init__(self, notification, listing=None, gateway_id="gw1",
+                 username="admin"):
+        self.research = _FakeNotifResearch(notification, listing)
+        self.gateway_id = gateway_id
+        self.username = username
+
+
+class TestGetNotification:
+    """``get_notification`` returns ``WithAccess[Notification]`` — the raw proto
+    plus the gateway-catalog access flags (``is_owner`` always ``False``;
+    ``user_has_write_access`` forwarded from ``has_write``)."""
+
+    def _n(self):
+        return _make_notification(
+            notification_id="notif-1", gateway_id="gw1", title="T",
+            creation_time=1705320000000, priority=_priority("NORMAL"))
+
+    def test_returns_with_access_container(self):
+        client = _FakeNotifClient(self._n())
+        result = get_notification(client, "notif-1", has_write=True)
+        assert isinstance(result, WithAccess)
+
+    def test_message_is_the_proto(self):
+        n = self._n()
+        client = _FakeNotifClient(n)
+        result = get_notification(client, "notif-1", has_write=True)
+        # The exact proto object flows through wholesale — not copied.
+        assert result.message is n
+        assert result.message.notification_id == "notif-1"
+        assert result.message.priority == _priority("NORMAL")
+
+    def test_is_owner_always_false(self):
+        client = _FakeNotifClient(self._n())
+        result = get_notification(client, "notif-1", has_write=True)
+        assert result.is_owner is False
+
+    def test_has_write_forwarded_true(self):
+        client = _FakeNotifClient(self._n())
+        result = get_notification(client, "notif-1", has_write=True)
+        assert result.user_has_write_access is True
+
+    def test_has_write_forwarded_false(self):
+        client = _FakeNotifClient(self._n())
+        result = get_notification(client, "notif-1", has_write=False)
+        assert result.user_has_write_access is False
+
+
+class TestListNotifications:
+    def _n(self, nid="notif-1"):
+        return _make_notification(
+            notification_id=nid, gateway_id="gw1", title="T",
+            priority=_priority("LOW"))
+
+    def test_returns_list_of_with_access(self):
+        client = _FakeNotifClient(
+            self._n(), listing=[self._n("a"), self._n("b")])
+        results = list_notifications(client, has_write=False)
+        assert len(results) == 2
+        assert all(isinstance(r, WithAccess) for r in results)
+
+    def test_messages_carry_protos_and_flags(self):
+        client = _FakeNotifClient(
+            self._n(), listing=[self._n("a"), self._n("b")])
+        results = list_notifications(client, has_write=False)
+        assert {r.message.notification_id for r in results} == {"a", "b"}
+        assert all(r.is_owner is False for r in results)
+        assert all(r.user_has_write_access is False for r in results)
+
+    def test_has_write_forwarded_to_every_item(self):
+        client = _FakeNotifClient(
+            self._n(), listing=[self._n("a"), self._n("b")])
+        results = list_notifications(client, has_write=True)
+        assert all(r.user_has_write_access is True for r in results)
+
+
+class TestCreateNotification:
+    def _n(self):
+        return _make_notification(notification_id="x", gateway_id="gw1")
+
+    def test_returns_with_access_with_new_id(self):
+        client = _FakeNotifClient(self._n())
+        result = create_notification(
+            client, {"title": "Hi", "notification_message": "msg",
+                     "priority": _priority("HIGH")},
+            has_write=True)
+        assert isinstance(result, WithAccess)
+        assert result.message.notification_id == "new-notif-id"
+        assert result.message.title == "Hi"
+        assert result.message.priority == _priority("HIGH")
+        assert result.is_owner is False
+        assert result.user_has_write_access is True
+
+    def test_forces_gateway_id_from_client(self):
+        client = _FakeNotifClient(self._n(), gateway_id="gw1")
+        create_notification(client, {"title": "Hi"}, has_write=True)
+        assert client.research.created.gateway_id == "gw1"
+
+    def test_has_write_forwarded(self):
+        client = _FakeNotifClient(self._n())
+        result = create_notification(
+            client, {"title": "Hi"}, has_write=False)
+        assert result.user_has_write_access is False
+
+
+class TestUpdateNotification:
+    def _base(self):
+        return _make_notification(
+            notification_id="notif-9", gateway_id="gw1", title="Old",
+            notification_message="oldmsg", priority=_priority("LOW"))
+
+    def test_updates_title(self):
+        client = _FakeNotifClient(self._base())
+        update_notification(
+            client, "notif-9", {"title": "New"}, has_write=True)
+        assert client.research.updated.title == "New"
+        # untouched field preserved from base
+        assert client.research.updated.notification_message == "oldmsg"
+
+    def test_preserves_notification_id(self):
+        client = _FakeNotifClient(self._base())
+        update_notification(
+            client, "notif-9", {"title": "New"}, has_write=True)
+        assert client.research.updated.notification_id == "notif-9"
+
+    def test_returns_with_access(self):
+        client = _FakeNotifClient(self._base())
+        result = update_notification(
+            client, "notif-9", {"title": "New"}, has_write=False)
+        assert isinstance(result, WithAccess)
+        assert result.message.notification_id == "notif-9"
+        assert result.message.title == "New"
+        assert result.is_owner is False
+        assert result.user_has_write_access is False
+
+
+class TestDeleteNotification:
+    def test_calls_facade_with_gateway_and_id(self):
+        n = _make_notification(notification_id="notif-1", gateway_id="gw1")
+        client = _FakeNotifClient(n, gateway_id="gw1")
+        delete_notification(client, "notif-1")
+        assert client.research.deleted == ("gw1", "notif-1")
+
+
+class TestNotificationWireDecoders:
+    """The create/update path accepts the portal wire format (ISO timestamps,
+    priority NAME strings) as well as already-decoded proto values."""
+
+    def test_create_accepts_iso_timestamps(self):
+        from airavata_sdk.helpers.research_resources import _to_epoch_ms
+        # JS Date toJSON form (millisecond precision, trailing Z)
+        assert _to_epoch_ms("2024-01-15T12:00:00.000Z") == 1705320000000
+        # microsecond + Z (DRF output form)
+        assert _to_epoch_ms("2024-01-15T12:00:00.000000Z") == 1705320000000
+
+    def test_epoch_ms_passthrough_and_falsy(self):
+        from airavata_sdk.helpers.research_resources import _to_epoch_ms
+        assert _to_epoch_ms(1705320000000) == 1705320000000
+        assert _to_epoch_ms(0) == 0
+        assert _to_epoch_ms(None) == 0
+        assert _to_epoch_ms("") == 0
+
+    def test_priority_name_decode(self):
+        from airavata_sdk.helpers.research_resources import _to_priority_int
+        assert _to_priority_int("LOW") == _priority("LOW")
+        assert _to_priority_int("NORMAL") == _priority("NORMAL")
+        assert _to_priority_int("HIGH") == _priority("HIGH")
+
+    def test_priority_int_passthrough_and_unknown(self):
+        from airavata_sdk.helpers.research_resources import _to_priority_int
+        assert _to_priority_int(_priority("HIGH")) == _priority("HIGH")
+        assert _to_priority_int(None) == 0
+        assert _to_priority_int("") == 0
+        assert _to_priority_int("BOGUS") == 0
+
+    def test_create_with_wire_format_decodes_to_proto(self):
+        client = _FakeNotifClient(
+            _make_notification(notification_id="x", gateway_id="gw1"))
+        result = create_notification(
+            client,
+            {"title": "Hi", "published_time": "2024-01-15T12:10:00.000Z",
+             "priority": "NORMAL"},
+            has_write=True)
+        # facade received the decoded proto (epoch-millis int + enum int)
+        assert client.research.created.published_time == 1705320600000
+        assert client.research.created.priority == _priority("NORMAL")
+        # the returned WithAccess carries that same proto wholesale
+        assert result.message.published_time == 1705320600000
+        assert result.message.priority == _priority("NORMAL")
+
+
+# ===========================================================================
+# Parser
+# ===========================================================================
+
+def _make_parser(**kwargs):
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.parser import (  # noqa: E501
+        parser_pb2,
+    )
+    return parser_pb2.Parser(**kwargs)
+
+
+def _make_parser_input(**kwargs):
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.parser import (  # noqa: E501
+        parser_pb2,
+    )
+    return parser_pb2.ParserInput(**kwargs)
+
+
+def _make_parser_output(**kwargs):
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.parser import (  # noqa: E501
+        parser_pb2,
+    )
+    return parser_pb2.ParserOutput(**kwargs)
+
+
+def _io_type(name):
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.parser import (  # noqa: E501
+        parser_pb2,
+    )
+    return getattr(parser_pb2.IOType, name)
+
+
+class TestIoTypeValueCoercion:
+    """``_io_type_value`` accepts the proto member NAME or the proto integer."""
+
+    def test_name_string_to_proto_int(self):
+        from airavata_sdk.helpers.research_resources import _io_type_value
+        assert _io_type_value("FILE") == _io_type("FILE")
+        assert _io_type_value("PROPERTY") == _io_type("PROPERTY")
+
+    def test_prefixed_name_accepted(self):
+        from airavata_sdk.helpers.research_resources import _io_type_value
+        assert _io_type_value("IO_TYPE_UNKNOWN") == 0
+        assert _io_type_value("UNKNOWN") == 0
+
+    def test_proto_int_passthrough(self):
+        from airavata_sdk.helpers.research_resources import _io_type_value
+        assert _io_type_value(_io_type("FILE")) == _io_type("FILE")
+        assert _io_type_value(_io_type("PROPERTY")) == _io_type("PROPERTY")
+
+    def test_none_and_unknown_to_zero(self):
+        from airavata_sdk.helpers.research_resources import _io_type_value
+        assert _io_type_value(None) == 0
+        assert _io_type_value("") == 0
+        assert _io_type_value("BOGUS") == 0
+        assert _io_type_value(99) == 0
+        assert _io_type_value(True) == 0
+
+
+class _FakeParserResearch:
+    def __init__(self, parser, listing=None):
+        self._parser = parser
+        self._listing = listing if listing is not None else [parser]
+        # The most recently saved proto, re-fetched by create/update.
+        self._saved_for_fetch = parser
+        self.saved = None
+        self.removed = None
+
+    def get_parser(self, parser_id, gateway_id):
+        # Mirror the server: return the saved proto with the requested id.
+        from airavata_sdk.generated.org.apache.airavata.model.appcatalog.parser import (  # noqa: E501
+            parser_pb2,
+        )
+        p = parser_pb2.Parser()
+        p.CopyFrom(self._saved_for_fetch)
+        p.id = parser_id
+        return p
+
+    def list_all_parsers(self, gateway_id):
+        return list(self._listing)
+
+    def save_parser(self, parser):
+        self.saved = parser
+        self._saved_for_fetch = parser
+        return "new-parser-id"
+
+    def remove_parser(self, parser_id, gateway_id):
+        self.removed = (parser_id, gateway_id)
+
+
+class _FakeParserClient:
+    def __init__(self, parser, listing=None, gateway_id="gw1",
+                 username="alice"):
+        self.research = _FakeParserResearch(parser, listing)
+        self.gateway_id = gateway_id
+        self.username = username
+
+
+class TestGetParser:
+    def _p(self):
+        return _make_parser(
+            id="parser-1", gateway_id="gw1", image_name="img",
+            input_files=[
+                _make_parser_input(
+                    id="in-1", name="infile", required_input=True,
+                    parser_id="parser-1", type=_io_type("FILE")),
+            ],
+            output_files=[
+                _make_parser_output(
+                    id="out-1", name="outfile", required_output=False,
+                    parser_id="parser-1", type=_io_type("PROPERTY")),
+            ],
+        )
+
+    def test_returns_the_proto_directly(self):
+        from airavata_sdk.generated.org.apache.airavata.model.appcatalog.parser import (  # noqa: E501
+            parser_pb2,
+        )
+        from airavata_sdk.helpers.research_resources import get_parser
+        client = _FakeParserClient(self._p())
+        result = get_parser(client, "parser-1")
+        # proto-direct: the facade proto is returned as-is, not a dict / envelope
+        assert isinstance(result, parser_pb2.Parser)
+        assert result.id == "parser-1"
+        assert result.image_name == "img"
+
+    def test_nested_files_and_enum_carried_on_proto(self):
+        from airavata_sdk.helpers.research_resources import get_parser
+        client = _FakeParserClient(self._p())
+        result = get_parser(client, "parser-1")
+        assert result.input_files[0].name == "infile"
+        assert result.input_files[0].type == _io_type("FILE")
+        assert result.output_files[0].type == _io_type("PROPERTY")
+
+
+class TestListParsers:
+    def _p(self, pid="parser-1"):
+        return _make_parser(id=pid, gateway_id="gw1")
+
+    def test_returns_list_of_protos(self):
+        from airavata_sdk.generated.org.apache.airavata.model.appcatalog.parser import (  # noqa: E501
+            parser_pb2,
+        )
+        from airavata_sdk.helpers.research_resources import list_parsers
+        client = _FakeParserClient(
+            self._p(), listing=[self._p("a"), self._p("b")])
+        results = list_parsers(client)
+        assert all(isinstance(r, parser_pb2.Parser) for r in results)
+        assert {r.id for r in results} == {"a", "b"}
+
+
+class TestCreateParser:
+    def _p(self):
+        return _make_parser(id="x", gateway_id="gw1")
+
+    def test_returns_proto_with_new_id(self):
+        from airavata_sdk.generated.org.apache.airavata.model.appcatalog.parser import (  # noqa: E501
+            parser_pb2,
+        )
+        from airavata_sdk.helpers.research_resources import create_parser
+        client = _FakeParserClient(self._p())
+        result = create_parser(
+            client,
+            {"image_name": "img", "execution_command": "run",
+             "input_files": [
+                 {"name": "f", "required_input": True, "type": "FILE"}]})
+        # proto-direct: the re-fetched proto carries the server-assigned id
+        assert isinstance(result, parser_pb2.Parser)
+        assert result.id == "new-parser-id"
+        assert result.image_name == "img"
+        assert result.input_files[0].type == _io_type("FILE")
+
+    def test_forces_gateway_id_from_client(self):
+        from airavata_sdk.helpers.research_resources import create_parser
+        client = _FakeParserClient(self._p(), gateway_id="gw1")
+        create_parser(client, {"image_name": "img"})
+        assert client.research.saved.gateway_id == "gw1"
+
+    def test_input_type_name_decoded_to_proto(self):
+        from airavata_sdk.helpers.research_resources import create_parser
+        client = _FakeParserClient(self._p())
+        create_parser(
+            client,
+            {"input_files": [{"name": "f", "type": "PROPERTY"}],
+             "output_files": [{"name": "g", "type": "FILE"}]})
+        saved = client.research.saved
+        assert saved.input_files[0].type == _io_type("PROPERTY")
+        assert saved.output_files[0].type == _io_type("FILE")
+
+
+class TestUpdateParser:
+    def _p(self):
+        return _make_parser(id="parser-9", gateway_id="gw1", image_name="old")
+
+    def test_preserves_parser_id_on_save(self):
+        from airavata_sdk.helpers.research_resources import update_parser
+        client = _FakeParserClient(self._p())
+        update_parser(client, "parser-9", {"image_name": "new"})
+        assert client.research.saved.id == "parser-9"
+
+    def test_returns_proto(self):
+        from airavata_sdk.generated.org.apache.airavata.model.appcatalog.parser import (  # noqa: E501
+            parser_pb2,
+        )
+        from airavata_sdk.helpers.research_resources import update_parser
+        client = _FakeParserClient(self._p())
+        result = update_parser(client, "parser-9", {"image_name": "new"})
+        assert isinstance(result, parser_pb2.Parser)
+        assert result.id == "parser-9"
+        assert result.image_name == "new"
+
+
+class TestDeleteParser:
+    def test_calls_facade_with_id_and_gateway(self):
+        from airavata_sdk.helpers.research_resources import delete_parser
+        client = _FakeParserClient(
+            _make_parser(id="parser-1", gateway_id="gw1"), gateway_id="gw1")
+        delete_parser(client, "parser-1")
+        assert client.research.removed == ("parser-1", "gw1")
+
+
+# ===========================================================================
+# DataProduct
+# ===========================================================================
+
+def _rc():
+    from airavata_sdk.generated.org.apache.airavata.model.data.replica import (  # noqa: E501
+        replica_catalog_pb2,
+    )
+    return replica_catalog_pb2
+
+
+def _make_replica(**kwargs):
+    return _rc().DataReplicaLocationModel(**kwargs)
+
+
+def _make_data_product(**kwargs):
+    return _rc().DataProductModel(**kwargs)
+
+
+
+
+class _FakeDataProductResearch:
+    def __init__(self, data_product):
+        self._data_product = data_product
+        self.registered = None
+
+    def get_data_product(self, product_uri):
+        return self._data_product
+
+    def register_data_product(self, data_product):
+        self.registered = data_product
+        return "airavata-dp://new-uri"
+
+
+class _FakeDataProductClient:
+    def __init__(self, data_product, gateway_id="gw1", username="alice"):
+        self.research = _FakeDataProductResearch(data_product)
+        self.gateway_id = gateway_id
+        self.username = username
+
+
+class TestGetDataProduct:
+    """Proto-direct read path: ``get_data_product`` returns a
+    ``WithAccess[DataProductModel]`` — the raw proto unioned with the caller's
+    ``is_owner`` (SDK-trivial ``owner_name == username``) and
+    ``user_has_write_access`` (the request-bound *has_write* flag the ViewSet
+    passes in)."""
+
+    def _dp(self, owner_name="alice"):
+        rc = _rc()
+        return _make_data_product(
+            product_uri="airavata-dp://1", gateway_id="gw1",
+            product_name="f.dat", owner_name=owner_name,
+            data_product_type=rc.DataProductType.FILE,
+            creation_time=1705320000000)
+
+    def test_returns_with_access_carrying_the_proto(self):
+        from airavata_sdk.helpers._envelope import WithAccess
+        from airavata_sdk.helpers.research_resources import get_data_product
+        dp = self._dp()
+        client = _FakeDataProductClient(dp)
+        result = get_data_product(
+            client, "airavata-dp://1", has_write=True)
+        assert isinstance(result, WithAccess)
+        # The proto flows through wholesale — no field copied out.
+        assert result.message is dp
+        assert result.message.product_uri == "airavata-dp://1"
+
+    def test_is_owner_true_when_owner_matches_username(self):
+        from airavata_sdk.helpers.research_resources import get_data_product
+        client = _FakeDataProductClient(
+            self._dp(owner_name="alice"), username="alice")
+        result = get_data_product(client, "airavata-dp://1", has_write=True)
+        assert result.is_owner is True
+
+    def test_is_owner_false_when_owner_differs(self):
+        from airavata_sdk.helpers.research_resources import get_data_product
+        client = _FakeDataProductClient(
+            self._dp(owner_name="alice"), username="bob")
+        result = get_data_product(client, "airavata-dp://1", has_write=True)
+        assert result.is_owner is False
+
+    def test_is_owner_false_when_owner_empty(self):
+        from airavata_sdk.helpers.research_resources import get_data_product
+        client = _FakeDataProductClient(
+            self._dp(owner_name=""), username="")
+        result = get_data_product(client, "airavata-dp://1", has_write=True)
+        # An empty owner_name never makes the (possibly empty) caller the owner.
+        assert result.is_owner is False
+
+    def test_user_has_write_access_reflects_has_write(self):
+        from airavata_sdk.helpers.research_resources import get_data_product
+        client = _FakeDataProductClient(self._dp())
+        assert get_data_product(
+            client, "airavata-dp://1", has_write=True).user_has_write_access
+        assert not get_data_product(
+            client, "airavata-dp://1", has_write=False).user_has_write_access
+
+
+class TestDataProductForUpload:
+    def test_builds_proto_with_single_replica(self):
+        from airavata_sdk.helpers.research_resources import (
+            data_product_for_upload,
+        )
+        dp = data_product_for_upload(
+            gateway_id="gw1", owner_name="alice", product_name="f.dat",
+            file_path="/data/tmp/f.dat", storage_resource_id="storage-1",
+            content_type="text/plain", product_size=10)
+        rc = _rc()
+        assert dp.gateway_id == "gw1"
+        assert dp.owner_name == "alice"
+        assert dp.product_name == "f.dat"
+        assert dp.data_product_type == rc.DataProductType.FILE
+        assert dp.product_size == 10
+        assert dp.product_metadata["mime-type"] == "text/plain"
+        assert len(dp.replica_locations) == 1
+        r = dp.replica_locations[0]
+        assert r.file_path == "/data/tmp/f.dat"
+        assert r.storage_resource_id == "storage-1"
+        assert (r.replica_location_category
+                == rc.ReplicaLocationCategory.GATEWAY_DATA_STORE)
+        assert (r.replica_persistent_type
+                == rc.ReplicaPersistentType.TRANSIENT)
+
+    def test_no_content_type_means_empty_metadata(self):
+        from airavata_sdk.helpers.research_resources import (
+            data_product_for_upload,
+        )
+        dp = data_product_for_upload(
+            gateway_id="gw1", owner_name="alice", product_name="f.dat",
+            file_path="/p", storage_resource_id="s")
+        assert dict(dp.product_metadata) == {}
+
+
+class TestRegisterDataProduct:
+    def test_returns_uri_and_passes_proto(self):
+        from airavata_sdk.helpers.research_resources import (
+            data_product_for_upload, register_data_product,
+        )
+        client = _FakeDataProductClient(_make_data_product(product_uri="x"))
+        dp = data_product_for_upload(
+            gateway_id="gw1", owner_name="alice", product_name="f",
+            file_path="/p", storage_resource_id="s")
+        uri = register_data_product(client, dp)
+        assert uri == "airavata-dp://new-uri"
+        assert client.research.registered is dp
+
+
+# ===========================================================================
+# ApplicationInterface
+# ===========================================================================
+
+def _io_pb2():
+    from airavata_sdk.generated.org.apache.airavata.model.application.io import (
+        application_io_pb2,
+    )
+    return application_io_pb2
+
+
+def _ai_pb2():
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.appinterface import (  # noqa: E501
+        app_interface_pb2,
+    )
+    return app_interface_pb2
+
+
+def _make_input(**kwargs):
+    io = _io_pb2()
+    defaults = dict(
+        name="in1", value="v", type=io.DataType.STRING,
+        application_argument="-i", standard_input=False,
+        user_friendly_description="ufd", meta_data='{"a": 1}',
+        input_order=2, is_required=True,
+        required_to_added_to_command_line=True, data_staged=False,
+        storage_resource_id="sr1", is_read_only=False, override_filename="of")
+    defaults.update(kwargs)
+    return io.InputDataObjectType(**defaults)
+
+
+def _make_output(**kwargs):
+    io = _io_pb2()
+    defaults = dict(
+        name="out1", value="ov", type=io.DataType.URI,
+        application_argument="-o", is_required=True,
+        required_to_added_to_command_line=False, data_movement=True,
+        location="loc", search_query="sq", output_streaming=False,
+        storage_resource_id="sr2", meta_data="")
+    defaults.update(kwargs)
+    return io.OutputDataObjectType(**defaults)
+
+
+def _make_interface(**kwargs):
+    ai = _ai_pb2()
+    defaults = dict(
+        application_interface_id="echo_abc", application_name="Echo",
+        application_description="desc", application_modules=["mod1"],
+        archive_working_directory=True, has_optional_file_inputs=True,
+        application_inputs=[_make_input()],
+        application_outputs=[_make_output()])
+    defaults.update(kwargs)
+    return ai.ApplicationInterfaceDescription(**defaults)
+
+
+
+
+class _FakeAppInterfaceResearch:
+    def __init__(self, interface):
+        self._interface = interface
+        self.registered = None
+        self.updated = None
+        self.deleted = None
+
+    def get_application_interface(self, app_interface_id):
+        return self._interface
+
+    def get_all_application_interfaces(self, gateway_id):
+        return [self._interface]
+
+    def register_application_interface(self, gateway_id, application_interface):
+        self.registered = (gateway_id, application_interface)
+        return "new-iface-id"
+
+    def update_application_interface(self, app_interface_id,
+                                     application_interface):
+        self.updated = (app_interface_id, application_interface)
+
+    def delete_application_interface(self, app_interface_id):
+        self.deleted = app_interface_id
+
+
+class _FakeAppInterfaceClient:
+    def __init__(self, interface, gateway_id="gw1", username="alice"):
+        self.research = _FakeAppInterfaceResearch(interface)
+        self.gateway_id = gateway_id
+        self.username = username
+
+
+class TestApplicationInterfaceOrchestration:
+    def test_get_returns_with_access(self):
+        from airavata_sdk.helpers._envelope import WithAccess
+        from airavata_sdk.helpers.research_resources import (
+            get_application_interface,
+        )
+        client = _FakeAppInterfaceClient(_make_interface())
+        result = get_application_interface(client, "echo_abc", has_write=True)
+        # Gateway-catalog WithAccess: the raw proto under .message, no owner,
+        # write access forwarded from the gateway-admin flag.
+        assert isinstance(result, WithAccess)
+        assert result.message is client.research._interface
+        assert result.message.application_interface_id == "echo_abc"
+        assert result.is_owner is False
+        assert result.user_has_write_access is True
+
+    def test_get_forwards_has_write_false(self):
+        from airavata_sdk.helpers.research_resources import (
+            get_application_interface,
+        )
+        client = _FakeAppInterfaceClient(_make_interface())
+        result = get_application_interface(client, "echo_abc", has_write=False)
+        assert result.user_has_write_access is False
+
+    def test_list_returns_with_access(self):
+        from airavata_sdk.helpers._envelope import WithAccess
+        from airavata_sdk.helpers.research_resources import (
+            list_application_interfaces,
+        )
+        client = _FakeAppInterfaceClient(_make_interface())
+        items = list_application_interfaces(client, has_write=False)
+        assert len(items) == 1
+        assert isinstance(items[0], WithAccess)
+        assert items[0].message is client.research._interface
+        assert items[0].is_owner is False
+        assert items[0].user_has_write_access is False
+
+    def test_create_builds_proto_and_refetches(self):
+        from airavata_sdk.helpers.research_resources import (
+            create_application_interface,
+        )
+        client = _FakeAppInterfaceClient(_make_interface())
+        data = {
+            "application_name": "NewApp",
+            "application_description": "nd",
+            "application_modules": ["m1"],
+            "archive_working_directory": True,
+            "application_inputs": [{
+                "name": "i", "type": "URI", "meta_data": {"x": 1}}],
+            "application_outputs": [{"name": "o", "type": "STDOUT"}],
+        }
+        create_application_interface(client, data, has_write=True)
+        gw, proto = client.research.registered
+        assert gw == "gw1"
+        assert proto.application_name == "NewApp"
+        assert proto.application_modules == ["m1"]
+        io = _io_pb2()
+        assert proto.application_inputs[0].type == io.DataType.URI
+        assert proto.application_inputs[0].meta_data == '{"x": 1}'
+        assert proto.application_outputs[0].type == io.DataType.STDOUT
+
+    def test_update_merges_and_forces_id(self):
+        from airavata_sdk.helpers.research_resources import (
+            update_application_interface,
+        )
+        client = _FakeAppInterfaceClient(_make_interface())
+        update_application_interface(
+            client, "echo_abc", {"application_name": "Renamed"},
+            has_write=True)
+        iface_id, proto = client.research.updated
+        assert iface_id == "echo_abc"
+        assert proto.application_interface_id == "echo_abc"
+        assert proto.application_name == "Renamed"
+        # Untouched fields retained from the base proto.
+        assert proto.application_description == "desc"
+
+    def test_delete(self):
+        from airavata_sdk.helpers.research_resources import (
+            delete_application_interface,
+        )
+        client = _FakeAppInterfaceClient(_make_interface())
+        delete_application_interface(client, "echo_abc")
+        assert client.research.deleted == "echo_abc"
+
+
+class TestDataTypeIntCoercion:
+    def test_name_to_int(self):
+        from airavata_sdk.helpers.research_resources import _data_type_int
+        io = _io_pb2()
+        assert _data_type_int("STRING") == io.DataType.STRING
+        assert _data_type_int("URI") == io.DataType.URI
+
+    def test_int_passthrough(self):
+        from airavata_sdk.helpers.research_resources import _data_type_int
+        io = _io_pb2()
+        assert _data_type_int(io.DataType.FLOAT) == io.DataType.FLOAT
+
+    def test_none_and_unknown(self):
+        from airavata_sdk.helpers.research_resources import _data_type_int
+        assert _data_type_int(None) == 0
+        assert _data_type_int("") == 0
+        assert _data_type_int("NOPE") == 0
+
+
+class TestMetaDataStr:
+    def test_none_to_empty(self):
+        from airavata_sdk.helpers.research_resources import _meta_data_str
+        assert _meta_data_str(None) == ""
+
+    def test_string_passthrough(self):
+        from airavata_sdk.helpers.research_resources import _meta_data_str
+        assert _meta_data_str('{"a": 1}') == '{"a": 1}'
+
+    def test_dict_dumps(self):
+        from airavata_sdk.helpers.research_resources import _meta_data_str
+        import json
+        assert json.loads(_meta_data_str({"a": 1})) == {"a": 1}
+
+
+# ===========================================================================
+# ApplicationDeployment  (proto-direct + WithAccess envelope)
+# ===========================================================================
+#
+# The application-deployment family follows the proto-direct architecture
+# (sharing-controlled gateway-catalog variant): the read helpers return the raw
+# ``app_deployment_pb2.ApplicationDeploymentDescription`` proto wrapped in a
+# ``WithAccess`` container.  The deployment proto has no ``owner`` field, so
+# ``is_owner`` is always ``False``; ``user_has_write_access`` is a CHAINED
+# ``sharing.user_has_access`` WRITE lookup keyed on ``app_deployment_id`` (the
+# legacy ``user_has_access(request, app_deployment_id)``).  There is no dict
+# transform, no Thrift-int parallelism mapping, and no order-sorting to test —
+# the portal's generic renderer flattens the proto (enums as NAMES, nested lists
+# in proto order).
+
+
+def _ad_pb2():
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.appdeployment import (  # noqa: E501
+        app_deployment_pb2,
+    )
+    return app_deployment_pb2
+
+
+def _par_pb2():
+    from airavata_sdk.generated.org.apache.airavata.model.parallelism import (
+        parallelism_pb2,
+    )
+    return parallelism_pb2
+
+
+def _make_deployment(**kwargs):
+    ad = _ad_pb2()
+    return ad.ApplicationDeploymentDescription(**kwargs)
+
+
+class _FakeDeploymentSharing:
+    def __init__(self, has_access=True):
+        self._has_access = has_access
+        self.calls = []
+
+    def user_has_access(self, resource_id, user_id, permission_type):
+        self.calls.append((resource_id, user_id, permission_type))
+        if isinstance(self._has_access, dict):
+            return bool(self._has_access.get(resource_id, False))
+        return self._has_access
+
+
+class _FakeDeploymentResearch:
+    def __init__(self, deployment=None, deployments=None):
+        self._deployment = deployment
+        self._deployments = deployments or []
+        self.registered = None
+        self.updated = None
+        self.deleted = None
+
+    def get_application_deployment(self, app_deployment_id):
+        return self._deployment
+
+    def get_accessible_application_deployments(self, gateway_id):
+        return list(self._deployments)
+
+    def get_application_deployments_for_app_module_and_group_resource_profile(
+            self, app_module_id, group_resource_profile_id):
+        self.module_profile_args = (app_module_id, group_resource_profile_id)
+        return list(self._deployments)
+
+    def register_application_deployment(self, gateway_id, application_deployment):
+        self.registered = application_deployment
+        self.registered_gateway_id = gateway_id
+        return "dep-new"
+
+    def update_application_deployment(self, app_deployment_id, application_deployment):
+        self.updated = (app_deployment_id, application_deployment)
+
+    def delete_application_deployment(self, app_deployment_id):
+        self.deleted = app_deployment_id
+
+
+class _FakeDeploymentClient:
+    def __init__(self, research, sharing_has_access=True,
+                 username="alice", gateway_id="default"):
+        self.research = research
+        self.sharing = _FakeDeploymentSharing(sharing_has_access)
+        self.username = username
+        self.gateway_id = gateway_id
+
+
+class TestParallelismInputToProtoInt:
+    def test_name_string_accepted(self):
+        from airavata_sdk.helpers.research_resources import (
+            _parallelism_input_to_proto_int,
+        )
+        par = _par_pb2()
+        assert _parallelism_input_to_proto_int("MPI") == \
+            par.ApplicationParallelismType.MPI
+        assert _parallelism_input_to_proto_int(
+            "APPLICATION_PARALLELISM_TYPE_OPENMP") == \
+            par.ApplicationParallelismType.OPENMP
+
+    def test_proto_int_passthrough(self):
+        from airavata_sdk.helpers.research_resources import (
+            _parallelism_input_to_proto_int,
+        )
+        par = _par_pb2()
+        assert _parallelism_input_to_proto_int(
+            par.ApplicationParallelismType.CRAY_MPI) == \
+            par.ApplicationParallelismType.CRAY_MPI
+
+    def test_none_and_unknown_to_zero(self):
+        from airavata_sdk.helpers.research_resources import (
+            _parallelism_input_to_proto_int,
+        )
+        assert _parallelism_input_to_proto_int(None) == 0
+        assert _parallelism_input_to_proto_int("") == 0
+        assert _parallelism_input_to_proto_int("NOPE") == 0
+
+
+class TestBuildApplicationDeployment:
+    def test_build_from_snake_case(self):
+        from airavata_sdk.helpers.research_resources import (
+            _build_application_deployment,
+        )
+        client = _FakeDeploymentClient(_FakeDeploymentResearch())
+        data = {
+            "app_module_id": "mod-1",
+            "compute_host_id": "host-1",
+            "executable_path": "/bin/run",
+            "parallelism": "MPI",  # proto member NAME (wire format)
+            "module_load_cmds": [{"command": "x", "command_order": 0}],
+            "set_environment": [{"name": "N", "value": "V", "env_path_order": 0}],
+            "default_node_count": 3,
+            "editable_by_user": True,
+        }
+        pb = _build_application_deployment(client, data)
+        par = _par_pb2()
+        assert pb.app_module_id == "mod-1"
+        assert pb.parallelism == par.ApplicationParallelismType.MPI
+        assert pb.module_load_cmds[0].command == "x"
+        assert pb.set_environment[0].name == "N"
+        assert pb.default_node_count == 3
+        assert pb.editable_by_user is True
+
+
+class TestGetApplicationDeployment:
+    """``get_application_deployment`` returns ``WithAccess[...Deployment]`` — the
+    raw proto plus ``is_owner`` (always ``False``) and the chained sharing WRITE
+    flag keyed on ``app_deployment_id``."""
+
+    def _deployment(self):
+        par = _par_pb2()
+        return _make_deployment(
+            app_deployment_id="dep-1", app_module_id="m",
+            parallelism=par.ApplicationParallelismType.MPI)
+
+    def test_returns_with_access_container(self):
+        from airavata_sdk.helpers.research_resources import (
+            get_application_deployment,
+        )
+        client = _FakeDeploymentClient(
+            _FakeDeploymentResearch(deployment=self._deployment()))
+        result = get_application_deployment(client, "dep-1")
+        assert isinstance(result, WithAccess)
+
+    def test_message_is_the_proto(self):
+        from airavata_sdk.helpers.research_resources import (
+            get_application_deployment,
+        )
+        dep = self._deployment()
+        client = _FakeDeploymentClient(
+            _FakeDeploymentResearch(deployment=dep))
+        result = get_application_deployment(client, "dep-1")
+        # The exact proto object flows through wholesale — not copied.
+        assert result.message is dep
+        assert result.message.app_deployment_id == "dep-1"
+
+    def test_is_owner_always_false(self):
+        from airavata_sdk.helpers.research_resources import (
+            get_application_deployment,
+        )
+        client = _FakeDeploymentClient(
+            _FakeDeploymentResearch(deployment=self._deployment()))
+        result = get_application_deployment(client, "dep-1")
+        assert result.is_owner is False
+
+    def test_write_access_reflects_sharing(self):
+        from airavata_sdk.helpers.research_resources import (
+            get_application_deployment,
+        )
+        client = _FakeDeploymentClient(
+            _FakeDeploymentResearch(deployment=self._deployment()),
+            sharing_has_access=True)
+        assert get_application_deployment(
+            client, "dep-1").user_has_write_access is True
+        client = _FakeDeploymentClient(
+            _FakeDeploymentResearch(deployment=self._deployment()),
+            sharing_has_access=False)
+        assert get_application_deployment(
+            client, "dep-1").user_has_write_access is False
+
+    def test_chained_sharing_call_arguments(self):
+        from airavata_sdk.helpers.research_resources import (
+            get_application_deployment,
+        )
+        client = _FakeDeploymentClient(
+            _FakeDeploymentResearch(deployment=self._deployment()),
+            username="alice")
+        get_application_deployment(client, "dep-1")
+        assert len(client.sharing.calls) == 1
+        resource_id, user_id, perm = client.sharing.calls[0]
+        assert resource_id == "dep-1"
+        assert user_id == "alice"
+        assert perm == "WRITE"
+
+
+class TestListApplicationDeployments:
+    def test_per_deployment_chained_write_lookup(self):
+        from airavata_sdk.helpers.research_resources import (
+            list_application_deployments,
+        )
+        d1 = _make_deployment(app_deployment_id="a")
+        d2 = _make_deployment(app_deployment_id="b")
+        client = _FakeDeploymentClient(
+            _FakeDeploymentResearch(deployments=[d1, d2]),
+            sharing_has_access={"a": True, "b": False})
+        out = list_application_deployments(client)
+        assert all(isinstance(x, WithAccess) for x in out)
+        by_id = {x.message.app_deployment_id: x for x in out}
+        assert by_id["a"].user_has_write_access is True
+        assert by_id["b"].user_has_write_access is False
+        assert by_id["a"].is_owner is False
+        # One chained WRITE lookup per deployment, keyed on app_deployment_id.
+        keyed = {c[0]: c[2] for c in client.sharing.calls}
+        assert keyed == {"a": "WRITE", "b": "WRITE"}
+
+
+class TestListApplicationDeploymentsForModuleAndProfile:
+    def test_uses_module_profile_facade_and_wraps(self):
+        from airavata_sdk.helpers.research_resources import (
+            list_application_deployments_for_module_and_profile,
+        )
+        d1 = _make_deployment(app_deployment_id="a")
+        research = _FakeDeploymentResearch(deployments=[d1])
+        client = _FakeDeploymentClient(research, sharing_has_access=True)
+        out = list_application_deployments_for_module_and_profile(
+            client, "mod-1", "grp-1")
+        assert research.module_profile_args == ("mod-1", "grp-1")
+        assert isinstance(out[0], WithAccess)
+        assert out[0].message.app_deployment_id == "a"
+        assert out[0].user_has_write_access is True
+
+
+class TestCreateUpdateDeleteApplicationDeployment:
+    def test_create_registers_and_refetches_with_access(self):
+        from airavata_sdk.helpers.research_resources import (
+            create_application_deployment,
+        )
+        created = _make_deployment(app_deployment_id="dep-new", app_module_id="m")
+        research = _FakeDeploymentResearch(deployment=created)
+        client = _FakeDeploymentClient(research)
+        out = create_application_deployment(
+            client, {"app_module_id": "m"}, has_write=True)
+        assert research.registered is not None
+        assert isinstance(out, WithAccess)
+        assert out.message.app_deployment_id == "dep-new"
+        assert out.is_owner is False
+        # has_write is forwarded, not chained, for the freshly created record.
+        assert out.user_has_write_access is True
+        assert client.sharing.calls == []
+
+    def test_update_forces_id_and_returns_with_access(self):
+        from airavata_sdk.helpers.research_resources import (
+            update_application_deployment,
+        )
+        existing = _make_deployment(app_deployment_id="dep-1", app_module_id="m")
+        research = _FakeDeploymentResearch(deployment=existing)
+        client = _FakeDeploymentClient(research)
+        out = update_application_deployment(
+            client, "dep-1", {"app_module_id": "m2"}, has_write=False)
+        sent_id, sent_pb = research.updated
+        assert sent_id == "dep-1"
+        assert sent_pb.app_deployment_id == "dep-1"
+        assert isinstance(out, WithAccess)
+        assert out.user_has_write_access is False
+
+    def test_delete_calls_facade(self):
+        from airavata_sdk.helpers.research_resources import (
+            delete_application_deployment,
+        )
+        research = _FakeDeploymentResearch()
+        client = _FakeDeploymentClient(research)
+        delete_application_deployment(client, "dep-x")
+        assert research.deleted == "dep-x"
+
+
+# ===========================================================================
+# Experiment (experiments-core)
+# ===========================================================================
+
+def _make_experiment(**kwargs):
+    from airavata_sdk.generated.org.apache.airavata.model.experiment import (
+        experiment_pb2,
+    )
+    return experiment_pb2.ExperimentModel(**kwargs)
+
+
+def _make_job(**kwargs):
+    from airavata_sdk.generated.org.apache.airavata.model.job import job_pb2
+    return job_pb2.JobModel(**kwargs)
+
+
+class _FakeExpCoreResearch:
+    def __init__(self, experiment=None, jobs=None, experiments=None):
+        self._experiment = experiment
+        self._jobs = jobs or []
+        self._experiments = experiments or []
+        self.created = None
+        self.created_gateway_id = None
+        self.updated = None
+
+    def get_experiment(self, experiment_id):
+        return self._experiment
+
+    def get_experiments_in_project(self, project_id, limit=-1, offset=0):
+        self.in_project_args = (project_id, limit, offset)
+        return self._experiments
+
+    def get_job_details(self, experiment_id):
+        return self._jobs
+
+    def create_experiment(self, gateway_id, experiment):
+        self.created = experiment
+        self.created_gateway_id = gateway_id
+        return "new-exp-id"
+
+    def update_experiment(self, experiment_id, experiment):
+        self.updated = (experiment_id, experiment)
+
+
+class _FakeExpCoreSharing:
+    def __init__(self, has_access=True):
+        self._has_access = has_access
+        self.calls = []
+
+    def user_has_access(self, resource_id, user_id, permission_type):
+        self.calls.append((resource_id, user_id, permission_type))
+        return self._has_access
+
+
+class _FakeExpCoreClient:
+    def __init__(self, research, gateway_id="gw1", username="alice",
+                 sharing_has_access=True):
+        self.research = research
+        self.sharing = _FakeExpCoreSharing(sharing_has_access)
+        self.gateway_id = gateway_id
+        self.username = username
+
+
+
+
+class TestGetExperiment:
+    """``get_experiment`` returns ``WithAccess[ExperimentModel]``: the raw proto
+    (the whole tree flows through wholesale for the renderer to serialize), with
+    ``is_owner`` trivially ``False`` and ``user_has_write_access`` a chained
+    sharing WRITE lookup keyed on ``experiment_id``."""
+
+    def _client(self, sharing_has_access=True):
+        e = _make_experiment(experiment_id="exp-1", experiment_name="E")
+        return _FakeExpCoreClient(
+            _FakeExpCoreResearch(experiment=e),
+            sharing_has_access=sharing_has_access)
+
+    def test_returns_with_access_container(self):
+        from airavata_sdk.helpers.research_resources import get_experiment
+        result = get_experiment(self._client(), "exp-1")
+        assert isinstance(result, WithAccess)
+
+    def test_message_is_the_proto(self):
+        from airavata_sdk.generated.org.apache.airavata.model.experiment import (
+            experiment_pb2,
+        )
+        from airavata_sdk.helpers.research_resources import get_experiment
+        result = get_experiment(self._client(), "exp-1")
+        assert isinstance(result.message, experiment_pb2.ExperimentModel)
+        assert result.message.experiment_id == "exp-1"
+        assert result.message.experiment_name == "E"
+
+    def test_is_owner_always_false(self):
+        from airavata_sdk.helpers.research_resources import get_experiment
+        result = get_experiment(self._client(), "exp-1")
+        assert result.is_owner is False
+
+    def test_user_has_write_access_true_from_sharing(self):
+        from airavata_sdk.helpers.research_resources import get_experiment
+        result = get_experiment(
+            self._client(sharing_has_access=True), "exp-1")
+        assert result.user_has_write_access is True
+
+    def test_user_has_write_access_false_from_sharing(self):
+        from airavata_sdk.helpers.research_resources import get_experiment
+        result = get_experiment(
+            self._client(sharing_has_access=False), "exp-1")
+        assert result.user_has_write_access is False
+
+    def test_sharing_keyed_on_experiment_id(self):
+        from airavata_sdk.helpers.research_resources import get_experiment
+        client = self._client()
+        get_experiment(client, "exp-1")
+        assert client.sharing.calls == [("exp-1", "alice", "WRITE")]
+
+
+class TestGetExperimentProto:
+    def test_returns_raw_proto(self):
+        from airavata_sdk.helpers.research_resources import get_experiment_proto
+        e = _make_experiment(experiment_id="exp-1", experiment_name="E")
+        client = _FakeExpCoreClient(_FakeExpCoreResearch(experiment=e))
+        result = get_experiment_proto(client, "exp-1")
+        # The proto message itself is returned, not a WithAccess wrapper.
+        assert result is e
+        assert result.experiment_id == "exp-1"
+        assert result.experiment_name == "E"
+
+
+class TestListExperimentJobs:
+    def test_returns_raw_job_protos(self):
+        from airavata_sdk.generated.org.apache.airavata.model.job import job_pb2
+        from airavata_sdk.helpers.research_resources import list_experiment_jobs
+        jobs = [_make_job(job_id="j1"), _make_job(job_id="j2")]
+        client = _FakeExpCoreClient(_FakeExpCoreResearch(jobs=jobs))
+        result = list_experiment_jobs(client, "exp-1")
+        # Proto-direct: each element is the raw JobModel proto (no transform, no
+        # sharing wrapper — a job has no ownership concept).
+        assert all(isinstance(j, job_pb2.JobModel) for j in result)
+        assert [j.job_id for j in result] == ["j1", "j2"]
+
+
+class TestGetExperimentsInProject:
+    def test_returns_with_access_with_per_experiment_sharing(self):
+        from airavata_sdk.helpers.research_resources import (
+            get_experiments_in_project,
+        )
+        exps = [_make_experiment(experiment_id="a"),
+                _make_experiment(experiment_id="b")]
+        # has_access False only for "b": the fake returns a single value, so use
+        # a per-id discriminating sharing stub.
+        client = _FakeExpCoreClient(_FakeExpCoreResearch(experiments=exps))
+
+        class _PerIdSharing:
+            calls = []
+
+            def user_has_access(self, resource_id, user_id, permission_type):
+                self.calls.append((resource_id, user_id, permission_type))
+                return resource_id == "a"
+
+        client.sharing = _PerIdSharing()
+        result = get_experiments_in_project(client, "proj-1")
+        assert all(isinstance(r, WithAccess) for r in result)
+        by_id = {
+            r.message.experiment_id: r.user_has_write_access for r in result}
+        assert by_id == {"a": True, "b": False}
+        # Each experiment triggers its own chained WRITE lookup.
+        assert client.sharing.calls == [
+            ("a", "alice", "WRITE"), ("b", "alice", "WRITE")]
+
+    def test_passes_limit_and_offset(self):
+        from airavata_sdk.helpers.research_resources import (
+            get_experiments_in_project,
+        )
+        research = _FakeExpCoreResearch(experiments=[])
+        client = _FakeExpCoreClient(research)
+        get_experiments_in_project(client, "proj-1", limit=5, offset=10)
+        assert research.in_project_args == ("proj-1", 5, 10)
+
+
+class TestCreateExperiment:
+    def test_builds_creates_and_returns_with_access(self):
+        from airavata_sdk.helpers.research_resources import create_experiment
+        # The created experiment is re-fetched via get_experiment, so the fake
+        # research returns it from get_experiment(new-id).
+        refetched = _make_experiment(
+            experiment_id="new-exp-id", experiment_name="New",
+            project_id="proj-1")
+        research = _FakeExpCoreResearch(experiment=refetched)
+        client = _FakeExpCoreClient(research)
+        result = create_experiment(
+            client,
+            {"project_id": "proj-1", "experiment_name": "New",
+             "description": "d"})
+        assert isinstance(result, WithAccess)
+        assert result.message.experiment_id == "new-exp-id"
+        # The proto sent to create_experiment carried the forced context.
+        assert research.created.project_id == "proj-1"
+        assert research.created.gateway_id == "gw1"
+        assert research.created.user_name == "alice"
+        assert research.created_gateway_id == "gw1"
+
+    def test_user_configuration_data_built_when_present(self):
+        from airavata_sdk.helpers.research_resources import create_experiment
+        research = _FakeExpCoreResearch(
+            experiment=_make_experiment(experiment_id="new-exp-id"))
+        client = _FakeExpCoreClient(research)
+        create_experiment(client, {
+            "project_id": "p", "experiment_name": "E",
+            "user_configuration_data": {
+                "airavata_auto_schedule": True,
+                "computational_resource_scheduling": {
+                    "resource_host_id": "h", "total_cpu_count": 4}}})
+        ucd = research.created.user_configuration_data
+        assert ucd.airavata_auto_schedule is True
+        assert ucd.computational_resource_scheduling.total_cpu_count == 4
+
+
+class TestUpdateExperiment:
+    def test_pushes_with_forced_id_and_returns_with_access(self):
+        from airavata_sdk.helpers.research_resources import update_experiment
+        refetched = _make_experiment(
+            experiment_id="exp-9", experiment_name="Updated")
+        research = _FakeExpCoreResearch(experiment=refetched)
+        client = _FakeExpCoreClient(research)
+        result = update_experiment(
+            client, "exp-9", {"experiment_name": "Updated"})
+        sent_id, sent_pb = research.updated
+        assert sent_id == "exp-9"
+        assert sent_pb.experiment_id == "exp-9"
+        assert sent_pb.experiment_name == "Updated"
+        assert isinstance(result, WithAccess)
+        assert result.message.experiment_id == "exp-9"
+
+
+class TestExperimentTypeInt:
+    def test_thrift_int_round_trip(self):
+        from airavata_sdk.helpers.research_resources import _experiment_type_int
+        # Thrift 0 -> proto SINGLE_APPLICATION (1), Thrift 1 -> WORKFLOW (2).
+        assert _experiment_type_int(0) == 1
+        assert _experiment_type_int(1) == 2
+
+    def test_name_string_accepted(self):
+        from airavata_sdk.helpers.research_resources import _experiment_type_int
+        assert _experiment_type_int("SINGLE_APPLICATION") == 1
+        assert _experiment_type_int("WORKFLOW") == 2
+
+    def test_none_maps_to_zero(self):
+        from airavata_sdk.helpers.research_resources import _experiment_type_int
+        assert _experiment_type_int(None) == 0
+        assert _experiment_type_int("") == 0
+
+
+# ---------------------------------------------------------------------------
+# FullExperiment
+# ---------------------------------------------------------------------------
+
+def _make_full_input(**kwargs):
+    from airavata_sdk.generated.org.apache.airavata.model.application.io import (
+        application_io_pb2 as io,
+    )
+    return io.InputDataObjectType(**kwargs)
+
+
+def _make_full_output(**kwargs):
+    from airavata_sdk.generated.org.apache.airavata.model.application.io import (
+        application_io_pb2 as io,
+    )
+    return io.OutputDataObjectType(**kwargs)
+
+
+def _make_full_data_product(**kwargs):
+    from airavata_sdk.generated.org.apache.airavata.model.data.replica import (
+        replica_catalog_pb2,
+    )
+    return replica_catalog_pb2.DataProductModel(**kwargs)
+
+
+def _make_app_interface(**kwargs):
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.appinterface import (  # noqa: E501
+        app_interface_pb2,
+    )
+    return app_interface_pb2.ApplicationInterfaceDescription(**kwargs)
+
+
+def _make_compute_resource(**kwargs):
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.computeresource import (  # noqa: E501
+        compute_resource_pb2,
+    )
+    return compute_resource_pb2.ComputeResourceDescription(**kwargs)
+
+
+def _dp_write(_dp):
+    """Stub per-data-product write resolver (the ViewSet supplies one)."""
+    return True
+
+
+def _output_views(_experiment, _app_interface):
+    return {}
+
+
+class TestCollectDataProductUris:
+    def test_single_uri_types_collected(self):
+        from airavata_sdk.helpers.research_resources import (
+            _collect_data_product_uris,
+        )
+        from airavata_sdk.generated.org.apache.airavata.model.application.io import (  # noqa: E501
+            application_io_pb2 as io,
+        )
+        outs = [
+            _make_full_output(name="o1", value="airavata-dp://1", type=io.DataType.URI),
+            _make_full_output(name="o2", value="airavata-dp://2",
+                         type=io.DataType.STDOUT),
+            # not a dp uri -> skipped
+            _make_full_output(name="o3", value="plain.txt", type=io.DataType.URI),
+        ]
+        assert _collect_data_product_uris(outs) == [
+            "airavata-dp://1", "airavata-dp://2"]
+
+    def test_uri_collection_expanded_after_singles(self):
+        from airavata_sdk.helpers.research_resources import (
+            _collect_data_product_uris,
+        )
+        from airavata_sdk.generated.org.apache.airavata.model.application.io import (  # noqa: E501
+            application_io_pb2 as io,
+        )
+        items = [
+            _make_full_output(name="a", value="airavata-dp://single",
+                         type=io.DataType.URI),
+            _make_full_output(name="b",
+                         value="airavata-dp://x,airavata-dp://y",
+                         type=io.DataType.URI_COLLECTION),
+        ]
+        assert _collect_data_product_uris(items) == [
+            "airavata-dp://single", "airavata-dp://x", "airavata-dp://y"]
+
+
+class _FakeFullResearch:
+    def __init__(self, *, experiment, project=None, app_interface=None,
+                 app_module=None, data_products=None, jobs=None):
+        self._experiment = experiment
+        self._project = project
+        self._app_interface = app_interface
+        self._app_module = app_module
+        self._data_products = data_products or {}
+        self._jobs = jobs or []
+
+    def get_experiment(self, experiment_id):
+        return self._experiment
+
+    def get_data_product(self, uri):
+        return self._data_products[uri]
+
+    def get_application_interface(self, app_interface_id):
+        if self._app_interface is None:
+            raise RuntimeError("no app interface")
+        return self._app_interface
+
+    def get_application_module(self, app_module_id):
+        return self._app_module
+
+    def get_project(self, project_id):
+        return self._project
+
+    def get_job_details(self, experiment_id):
+        return self._jobs
+
+
+class _FakeCompute:
+    def __init__(self, compute_resource=None):
+        self._compute_resource = compute_resource
+
+    def get_compute_resource(self, compute_resource_id):
+        if self._compute_resource is None:
+            raise RuntimeError("no compute resource")
+        return self._compute_resource
+
+
+class _FakeFullClient:
+    def __init__(self, research, compute=None, gateway_id="gw1",
+                 username="alice"):
+        self.research = research
+        self.compute = compute or _FakeCompute()
+        self.gateway_id = gateway_id
+        self.username = username
+        self.sharing = _FakeSharing(True)
+
+
+# ---------------------------------------------------------------------------
+# FullExperiment — proto-direct composed pydantic shape
+# ---------------------------------------------------------------------------
+#
+# ``get_full_experiment`` returns a :class:`FullExperiment` pydantic model whose
+# fields carry the component protos / ``WithAccess`` envelopes WHOLESALE: the
+# experiment is ``WithAccess[ExperimentModel]``, the project (when readable) is
+# ``WithAccess[Project]``, the application module (when resolvable) is
+# ``WithAccess[ApplicationModule]``, the compute resource is the raw
+# ``ComputeResourceDescription`` proto, the input/output data products are
+# ``WithAccess[DataProductModel]`` and the jobs are raw ``JobModel`` protos.  The
+# portal renderer flattens the whole tree; these tests assert on the OBJECTS
+# (no dict literals) — the JSON shape is pinned by the portal contract snapshot.
+
+
+class TestGetFullExperiment:
+    def _wire(self, *, with_refs=True):
+        from airavata_sdk.generated.org.apache.airavata.model.application.io import (  # noqa: E501
+            application_io_pb2 as io,
+        )
+        from airavata_sdk.generated.org.apache.airavata.model.experiment import (
+            experiment_pb2,
+        )
+        from airavata_sdk.generated.org.apache.airavata.model.scheduling import (
+            scheduling_pb2,
+        )
+        ucd = experiment_pb2.UserConfigurationDataModel(
+            computational_resource_scheduling=(
+                scheduling_pb2.ComputationalResourceSchedulingModel(
+                    resource_host_id="comp-1")))
+        e = _make_experiment(
+            experiment_id="exp-1", project_id="proj-1", gateway_id="gw1",
+            user_name="alice", experiment_name="E", execution_id="iface-1",
+            experiment_inputs=[
+                _make_full_input(name="in", value="airavata-dp://i",
+                            type=io.DataType.URI)],
+            experiment_outputs=[
+                _make_full_output(name="out", value="airavata-dp://o",
+                             type=io.DataType.URI)],
+            user_configuration_data=ucd,
+        )
+        ai = _make_app_interface(
+            application_interface_id="iface-1",
+            application_modules=["mod-1"]) if with_refs else None
+        module = _make_app_module(
+            app_module_id="mod-1", app_module_name="mod") if with_refs else None
+        compute = _make_compute_resource(
+            compute_resource_id="comp-1",
+            host_name="hpc") if with_refs else None
+        project = _make_project(project_id="proj-1", owner="alice")
+        jobs = [_make_job(job_id="j1")]
+        data_products = {
+            "airavata-dp://i": _make_full_data_product(
+                product_uri="airavata-dp://i", owner_name="alice"),
+            "airavata-dp://o": _make_full_data_product(
+                product_uri="airavata-dp://o", owner_name="bob"),
+        }
+        research = _FakeFullResearch(
+            experiment=e, project=project, app_interface=ai, app_module=module,
+            data_products=data_products, jobs=jobs)
+        client = _FakeFullClient(research, compute=_FakeCompute(compute))
+        return client
+
+    def _call(self, client, **overrides):
+        from airavata_sdk.helpers.research_resources import get_full_experiment
+        kwargs = dict(
+            project_has_read=True,
+            module_has_write=True,
+            data_product_write_fn=_dp_write,
+            output_views_fn=_output_views,
+        )
+        kwargs.update(overrides)
+        return get_full_experiment(client, "exp-1", **kwargs)
+
+    # ------------------------------------------------------------------
+    # Composed pydantic shape
+    # ------------------------------------------------------------------
+
+    def test_returns_full_experiment_model(self):
+        from airavata_sdk.helpers.research_resources import FullExperiment
+        fe = self._call(self._wire(with_refs=True))
+        assert isinstance(fe, FullExperiment)
+        assert fe.experiment_id == "exp-1"
+
+    def test_experiment_is_with_access_carrying_proto(self):
+        from airavata_sdk.generated.org.apache.airavata.model.experiment import (
+            experiment_pb2,
+        )
+        fe = self._call(self._wire(with_refs=True))
+        assert isinstance(fe.experiment, WithAccess)
+        assert isinstance(fe.experiment.message, experiment_pb2.ExperimentModel)
+        assert fe.experiment.message.experiment_id == "exp-1"
+        # WRITE comes from the chained sharing call (stub returns True).
+        assert fe.experiment.user_has_write_access is True
+
+    def test_project_is_with_access_carrying_proto(self):
+        from airavata_sdk.generated.org.apache.airavata.model.workspace import (
+            workspace_pb2,
+        )
+        fe = self._call(self._wire(with_refs=True))
+        assert isinstance(fe.project, WithAccess)
+        assert isinstance(fe.project.message, workspace_pb2.Project)
+        assert fe.project.message.project_id == "proj-1"
+        # is_owner SDK-trivial: project.owner == client.username ("alice").
+        assert fe.project.is_owner is True
+        assert fe.project.user_has_write_access is True
+
+    def test_application_module_is_with_access_carrying_proto(self):
+        from airavata_sdk.generated.org.apache.airavata.model.appcatalog.appdeployment import (  # noqa: E501
+            app_deployment_pb2,
+        )
+        fe = self._call(self._wire(with_refs=True))
+        assert isinstance(fe.application_module, WithAccess)
+        assert isinstance(
+            fe.application_module.message,
+            app_deployment_pb2.ApplicationModule)
+        assert fe.application_module.message.app_module_id == "mod-1"
+        # gateway-catalog: no ownership, write flag is module_has_write.
+        assert fe.application_module.is_owner is False
+        assert fe.application_module.user_has_write_access is True
+
+    def test_compute_resource_is_raw_proto(self):
+        from airavata_sdk.generated.org.apache.airavata.model.appcatalog.computeresource import (  # noqa: E501
+            compute_resource_pb2,
+        )
+        fe = self._call(self._wire(with_refs=True))
+        assert isinstance(
+            fe.compute_resource,
+            compute_resource_pb2.ComputeResourceDescription)
+        assert fe.compute_resource.compute_resource_id == "comp-1"
+
+    def test_data_products_are_with_access_carrying_protos(self):
+        from airavata_sdk.generated.org.apache.airavata.model.data.replica import (
+            replica_catalog_pb2,
+        )
+        fe = self._call(self._wire(with_refs=True))
+        assert [w.message.product_uri for w in fe.input_data_products] == [
+            "airavata-dp://i"]
+        assert [w.message.product_uri for w in fe.output_data_products] == [
+            "airavata-dp://o"]
+        for w in fe.input_data_products + fe.output_data_products:
+            assert isinstance(w, WithAccess)
+            assert isinstance(w.message, replica_catalog_pb2.DataProductModel)
+            # write flag is the resolver result (stub returns True).
+            assert w.user_has_write_access is True
+        # is_owner SDK-trivial: owner_name == client.username ("alice").
+        assert fe.input_data_products[0].is_owner is True   # owner_name="alice"
+        assert fe.output_data_products[0].is_owner is False  # owner_name="bob"
+
+    def test_jobs_are_raw_protos(self):
+        from airavata_sdk.generated.org.apache.airavata.model.job import job_pb2
+        fe = self._call(self._wire(with_refs=True))
+        assert [j.job_id for j in fe.job_details] == ["j1"]
+        assert all(isinstance(j, job_pb2.JobModel) for j in fe.job_details)
+
+    def test_output_views_passed_through(self):
+        def _views(_e, _ai):
+            return {"out": ["plugin-a"]}
+        fe = self._call(self._wire(with_refs=True), output_views_fn=_views)
+        assert fe.output_views == {"out": ["plugin-a"]}
+
+    # ------------------------------------------------------------------
+    # Optional references
+    # ------------------------------------------------------------------
+
+    def test_project_omitted_without_read(self):
+        fe = self._call(self._wire(with_refs=True), project_has_read=False)
+        assert fe.project is None
+
+    def test_unresolvable_references_become_none(self):
+        # No app interface (raises) and no compute resource (raises) -> both None,
+        # swallowed exactly like the old view's broad try/except.
+        fe = self._call(self._wire(with_refs=False), module_has_write=False)
+        assert fe.application_module is None
+        assert fe.compute_resource is None
+        # Data products + jobs still resolve.
+        assert len(fe.input_data_products) == 1
+        assert len(fe.output_data_products) == 1
+
+    def test_data_product_write_resolver_invoked_per_product(self):
+        seen = []
+
+        def _write(dp):
+            seen.append(dp.product_uri)
+            return dp.product_uri.endswith("o")
+
+        fe = self._call(self._wire(with_refs=True), data_product_write_fn=_write)
+        # Both products resolved (outputs first, then inputs).
+        assert set(seen) == {"airavata-dp://i", "airavata-dp://o"}
+        assert fe.input_data_products[0].user_has_write_access is False
+        assert fe.output_data_products[0].user_has_write_access is True

--- a/airavata-python-sdk/tests/helpers/test_sharing_resources.py
+++ b/airavata-python-sdk/tests/helpers/test_sharing_resources.py
@@ -1,0 +1,573 @@
+"""Unit tests for airavata_sdk.helpers.sharing_resources.
+
+The **groups** family is proto-direct: ``get_group`` / ``list_groups`` /
+``create_group`` / ``update_group`` return the raw ``GroupModel`` proto wrapped
+in a :class:`WithGroupAccess` envelope (proto under ``.message`` + the six
+computed access booleans).  Tests assert the proto flows through untouched and
+the chained flag-computing calls are made with the right arguments.
+
+The **shared-entities** family is also proto-direct: ``get_shared_entity`` /
+``get_all_shared_entity`` return a composed pydantic :class:`SharedEntity` that
+carries the underlying ``UserProfile`` protos and per-group
+:class:`WithGroupAccess` envelopes WHOLESALE, with ``permission_type`` as the
+permission member NAME string.  Tests assert the protos / envelopes flow through
+untouched and the orchestration fires the right chained calls.
+
+Orchestration functions are tested via lightweight stub clients that record the
+calls made.
+"""
+
+from airavata_sdk.generated.org.apache.airavata.model.group import (
+    group_manager_pb2 as gm_pb2,
+)
+from airavata_sdk.generated.org.apache.airavata.model.user import (
+    user_profile_pb2 as up_pb2,
+)
+from airavata_sdk.helpers._envelope import WithGroupAccess
+from airavata_sdk.helpers.sharing_resources import (
+    GroupPermission,
+    SharedEntity,
+    UserPermission,
+    _build_group,
+    _compute_revokes_and_grants,
+    _group_flags,
+    _member_admin_diff,
+    _user_at_gateway,
+    _username_from_internal_id,
+    apply_sharing_update,
+    compute_sharing_deltas,
+    create_group,
+    delete_group,
+    get_all_shared_entity,
+    get_group,
+    get_shared_entity,
+    list_groups,
+    update_group,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test data
+# ---------------------------------------------------------------------------
+
+def _group(
+    id="g1",
+    name="Group One",
+    owner_id="alice@default",
+    description="A test group",
+    members=None,
+    admins=None,
+):
+    return gm_pb2.GroupModel(
+        id=id,
+        name=name,
+        owner_id=owner_id,
+        description=description,
+        members=members if members is not None else ["alice@default"],
+        admins=admins if admins is not None else ["alice@default"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stub client
+# ---------------------------------------------------------------------------
+
+class _GatewayGroups:
+    def __init__(self):
+        self.admins_group_id = "admins-grp"
+        self.read_only_admins_group_id = "ro-admins-grp"
+        self.default_gateway_users_group_id = "default-users-grp"
+
+
+class _FakeSharing:
+    def __init__(self, groups=None, admin_access=True):
+        self._groups = groups or []
+        self._admin_access = admin_access
+        self.calls = []
+
+    def gm_get_groups(self):
+        self.calls.append(("gm_get_groups",))
+        return list(self._groups)
+
+    def gm_get_group(self, group_id):
+        self.calls.append(("gm_get_group", group_id))
+        for g in self._groups:
+            if g.id == group_id:
+                return g
+        return self._groups[0] if self._groups else _group(id=group_id)
+
+    def gm_has_admin_access(self, group_id, admin_id):
+        self.calls.append(("gm_has_admin_access", group_id, admin_id))
+        return self._admin_access
+
+    def gm_create_group(self, group):
+        self.calls.append(("gm_create_group", group))
+        return "new-group-id"
+
+    def gm_update_group(self, group):
+        self.calls.append(("gm_update_group", group))
+
+    def gm_delete_group(self, group_id, owner_id):
+        self.calls.append(("gm_delete_group", group_id, owner_id))
+
+    def gm_add_users_to_group(self, user_ids, group_id):
+        self.calls.append(("gm_add_users_to_group", list(user_ids), group_id))
+
+    def gm_remove_users_from_group(self, user_ids, group_id):
+        self.calls.append(
+            ("gm_remove_users_from_group", list(user_ids), group_id))
+
+    def gm_add_group_admins(self, group_id, admin_ids):
+        self.calls.append(("gm_add_group_admins", group_id, list(admin_ids)))
+
+    def gm_remove_group_admins(self, group_id, admin_ids):
+        self.calls.append(("gm_remove_group_admins", group_id, list(admin_ids)))
+
+
+class _FakeCompute:
+    def __init__(self):
+        self.calls = 0
+
+    def get_gateway_groups(self):
+        self.calls += 1
+        return _GatewayGroups()
+
+
+class _FakeClient:
+    def __init__(self, groups=None, admin_access=True,
+                 username="alice", gateway_id="default"):
+        self.sharing = _FakeSharing(groups, admin_access)
+        self.compute = _FakeCompute()
+        self.username = username
+        self.gateway_id = gateway_id
+
+
+# ---------------------------------------------------------------------------
+# Context helpers
+# ---------------------------------------------------------------------------
+
+class TestContextHelpers:
+    def test_user_at_gateway(self):
+        c = _FakeClient(username="bob", gateway_id="gw1")
+        assert _user_at_gateway(c) == "bob@gw1"
+
+    def test_group_flags_owner_member_admin(self):
+        c = _FakeClient(groups=[_group()])
+        g = _group(owner_id="alice@default", members=["alice@default"])
+        flags = _group_flags(c, g)
+        assert flags["is_admin"] is True
+        assert flags["is_owner"] is True
+        assert flags["is_member"] is True
+        assert flags["is_gateway_admins_group"] is False
+
+    def test_group_flags_gateway_admins_group(self):
+        c = _FakeClient(admin_access=False)
+        g = _group(id="admins-grp", owner_id="someoneelse@default", members=[])
+        flags = _group_flags(c, g)
+        assert flags["is_admin"] is False
+        assert flags["is_owner"] is False
+        assert flags["is_member"] is False
+        assert flags["is_gateway_admins_group"] is True
+
+    def test_group_flags_reuses_passed_gateway_groups(self):
+        c = _FakeClient()
+        gg = {
+            "admins_group_id": "x",
+            "read_only_admins_group_id": "y",
+            "default_gateway_users_group_id": "z",
+        }
+        _group_flags(c, _group(), gateway_groups=gg)
+        # No GetGatewayGroups RPC when caller supplies the map.
+        assert c.compute.calls == 0
+
+
+# ---------------------------------------------------------------------------
+# Read orchestration
+# ---------------------------------------------------------------------------
+
+class TestGetGroup:
+    def test_returns_with_group_access(self):
+        g = _group(id="g1")
+        result = get_group(_FakeClient(groups=[g]), "g1")
+        # proto-direct: the raw GroupModel flows through under .message
+        assert isinstance(result, WithGroupAccess)
+        assert result.message is g
+        assert result.message.id == "g1"
+        # the six computed flags are carried alongside the proto
+        assert result.is_owner is True
+        assert result.is_member is True
+        assert result.is_admin is True
+        assert result.is_gateway_admins_group is False
+        assert result.is_read_only_gateway_admins_group is False
+        assert result.is_default_gateway_users_group is False
+
+
+class TestListGroups:
+    def test_returns_list_of_with_group_access(self):
+        g1 = _group(id="g1")
+        g2 = _group(id="g2")
+        result = list_groups(_FakeClient(groups=[g1, g2]))
+        assert all(isinstance(r, WithGroupAccess) for r in result)
+        assert [r.message.id for r in result] == ["g1", "g2"]
+        # the protos are passed through wholesale, not copied
+        assert result[0].message is g1
+        assert result[1].message is g2
+
+    def test_offset_limit_slicing(self):
+        groups = [_group(id=f"g{i}") for i in range(5)]
+        result = list_groups(_FakeClient(groups=groups), limit=2, offset=1)
+        assert [r.message.id for r in result] == ["g1", "g2"]
+
+    def test_gateway_groups_fetched_once(self):
+        groups = [_group(id=f"g{i}") for i in range(3)]
+        c = _FakeClient(groups=groups)
+        list_groups(c)
+        assert c.compute.calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Write orchestration
+# ---------------------------------------------------------------------------
+
+class TestBuildGroup:
+    def test_forces_owner_from_client(self):
+        c = _FakeClient(username="bob", gateway_id="gw1")
+        g = _build_group(c, {"name": "N", "description": "D",
+                             "members": ["x@gw1"], "admins": ["x@gw1"]})
+        assert g.owner_id == "bob@gw1"
+        assert g.name == "N"
+        assert g.description == "D"
+        assert list(g.members) == ["x@gw1"]
+        assert list(g.admins) == ["x@gw1"]
+
+    def test_defaults(self):
+        c = _FakeClient(username="bob", gateway_id="gw1")
+        g = _build_group(c, {})
+        assert g.name == ""
+        assert g.description == ""
+        assert list(g.members) == []
+        assert list(g.admins) == []
+
+
+class TestCreateGroup:
+    def test_assigns_id_and_returns_tuple(self):
+        c = _FakeClient()
+        result, proto, added = create_group(
+            c, {"name": "N", "members": ["alice@default", "bob@default"]})
+        assert proto.id == "new-group-id"
+        # the read shape is a WithGroupAccess wrapping the same proto
+        assert isinstance(result, WithGroupAccess)
+        assert result.message is proto
+        assert result.message.id == "new-group-id"
+        # added members exclude the owner
+        assert "bob@default" in added
+        assert c.sharing.calls[0][0] == "gm_create_group"
+
+
+class TestMemberAdminDiff:
+    def test_added_and_removed_members(self):
+        existing = _group(members=["a@gw", "b@gw"], admins=[])
+        diff = _member_admin_diff(existing, {"members": ["b@gw", "c@gw"]})
+        assert set(diff["added_members"]) == {"c@gw"}
+        assert set(diff["removed_members"]) == {"a@gw"}
+
+    def test_admin_not_member_added_to_members(self):
+        existing = _group(members=["a@gw"], admins=[])
+        diff = _member_admin_diff(
+            existing, {"members": ["a@gw"], "admins": ["d@gw"]})
+        assert "d@gw" in diff["added_admins"]
+        # admin not in members -> added to members too
+        assert "d@gw" in diff["added_members"]
+        assert "d@gw" in diff["members"]
+
+    def test_absent_keys_keep_existing(self):
+        existing = _group(members=["a@gw"], admins=["a@gw"])
+        diff = _member_admin_diff(existing, {})
+        assert set(diff["members"]) == {"a@gw"}
+        assert set(diff["admins"]) == {"a@gw"}
+        assert diff["added_members"] == []
+        assert diff["removed_members"] == []
+
+
+class TestUpdateGroup:
+    def test_fires_membership_rpcs(self):
+        existing = _group(id="g1", members=["a@gw"], admins=["a@gw"])
+        c = _FakeClient(groups=[existing])
+        result, proto, added = update_group(
+            c, "g1",
+            {"name": "Renamed", "members": ["a@gw", "x@gw"]})
+        names = [call[0] for call in c.sharing.calls]
+        assert "gm_add_users_to_group" in names
+        assert "gm_update_group" in names
+        assert proto.name == "Renamed"
+        assert "x@gw" in added
+
+    def test_name_and_description_patched(self):
+        existing = _group(id="g1", description="old")
+        c = _FakeClient(groups=[existing])
+        result, proto, added = update_group(
+            c, "g1", {"description": "new"})
+        assert proto.description == "new"
+        # the read shape wraps the patched proto (proto-direct)
+        assert isinstance(result, WithGroupAccess)
+        assert result.message is proto
+        assert result.message.description == "new"
+
+
+class TestDeleteGroup:
+    def test_uses_owner_id(self):
+        existing = _group(id="g1", owner_id="alice@default")
+        c = _FakeClient(groups=[existing])
+        delete_group(c, "g1")
+        assert ("gm_delete_group", "g1", "alice@default") in c.sharing.calls
+
+
+# ===========================================================================
+# SharedEntity family
+# ===========================================================================
+
+def _user_profile(user_id="bob@default", first_name="Bob"):
+    return up_pb2.UserProfile(
+        airavata_internal_user_id=user_id,
+        user_id=user_id,
+        gateway_id="default",
+        first_name=first_name,
+    )
+
+
+class TestUsernameFromInternalId:
+    def test_strips_gateway(self):
+        assert _username_from_internal_id("bob@default") == "bob"
+
+    def test_rightmost_at(self):
+        # rindex picks the last @, so an @ in the username is preserved.
+        assert _username_from_internal_id("a@b@default") == "a@b"
+
+
+class TestComputeRevokesAndGrants:
+    def test_grant_read(self):
+        revokes, grants = _compute_revokes_and_grants(None, "READ")
+        assert revokes == set()
+        assert grants == {"READ"}
+
+    def test_grant_write_implies_read(self):
+        revokes, grants = _compute_revokes_and_grants(None, "WRITE")
+        assert grants == {"READ", "WRITE"}
+
+    def test_upgrade_read_to_write(self):
+        revokes, grants = _compute_revokes_and_grants("READ", "WRITE")
+        assert revokes == set()
+        assert grants == {"WRITE"}
+
+    def test_downgrade_manage_to_read(self):
+        revokes, grants = _compute_revokes_and_grants(
+            "MANAGE_SHARING", "READ")
+        assert revokes == {"WRITE", "MANAGE_SHARING"}
+        assert grants == set()
+
+    def test_revoke_all(self):
+        revokes, grants = _compute_revokes_and_grants("WRITE", None)
+        assert revokes == {"READ", "WRITE"}
+        assert grants == set()
+
+
+class TestComputeSharingDeltas:
+    def test_grant_and_revoke_buckets(self):
+        existing = {"bob@default": "READ"}
+        new = {"bob@default": "WRITE", "carol@default": "MANAGE_SHARING"}
+        deltas = compute_sharing_deltas(existing, new)
+        assert "bob@default" in deltas["grant"]["WRITE"]
+        assert "carol@default" in deltas["grant"]["READ"]
+        assert "carol@default" in deltas["grant"]["WRITE"]
+        assert "carol@default" in deltas["grant"]["MANAGE_SHARING"]
+        # bob keeps READ (no revoke for him)
+        assert deltas["revoke"]["READ"] == []
+
+    def test_revoke_when_removed(self):
+        existing = {"bob@default": "WRITE"}
+        new = {}
+        deltas = compute_sharing_deltas(existing, new)
+        assert set(deltas["revoke"]["READ"]) == {"bob@default"}
+        assert set(deltas["revoke"]["WRITE"]) == {"bob@default"}
+
+
+# ---------------------------------------------------------------------------
+# Shared-entity orchestration stubs
+# ---------------------------------------------------------------------------
+
+class _FakeSharingSE:
+    """Sharing facade stub for shared-entity orchestration tests.
+
+    *direct_users* / *direct_groups* (and the ``accessible`` variants) are
+    ``{permission_name -> [id, ...]}`` maps.
+    """
+
+    def __init__(self, direct_users=None, direct_groups=None,
+                 accessible_users=None, accessible_groups=None,
+                 groups=None, manage_sharing=True):
+        self._direct_users = direct_users or {}
+        self._direct_groups = direct_groups or {}
+        self._accessible_users = accessible_users or {}
+        self._accessible_groups = accessible_groups or {}
+        self._groups = {g.id: g for g in (groups or [])}
+        self._manage_sharing = manage_sharing
+        self.calls = []
+
+    def get_all_directly_accessible_users(self, entity_id, name):
+        return list(self._direct_users.get(name, []))
+
+    def get_all_directly_accessible_groups(self, entity_id, name):
+        return list(self._direct_groups.get(name, []))
+
+    def get_all_accessible_users(self, entity_id, name):
+        return list(self._accessible_users.get(name, []))
+
+    def get_all_accessible_groups(self, entity_id, name):
+        return list(self._accessible_groups.get(name, []))
+
+    def gm_get_group(self, group_id):
+        return self._groups.get(group_id, _group(id=group_id))
+
+    def gm_has_admin_access(self, group_id, admin_id):
+        return False
+
+    def user_has_access(self, resource_id, user_id, permission_type):
+        self.calls.append(
+            ("user_has_access", resource_id, user_id, permission_type))
+        return self._manage_sharing
+
+    def share_resource_with_users(self, entity_id, perms):
+        self.calls.append(("share_users", entity_id, perms))
+
+    def share_resource_with_groups(self, entity_id, perms):
+        self.calls.append(("share_groups", entity_id, perms))
+
+    def revoke_sharing_of_resource_from_users(self, entity_id, perms):
+        self.calls.append(("revoke_users", entity_id, perms))
+
+    def revoke_sharing_of_resource_from_groups(self, entity_id, perms):
+        self.calls.append(("revoke_groups", entity_id, perms))
+
+
+class _FakeIam:
+    def __init__(self, profiles=None):
+        # {username -> UserProfile}
+        self._profiles = profiles or {}
+
+    def get_user_profile_by_id(self, user_id, gateway_id):
+        return self._profiles.get(
+            user_id, _user_profile(user_id=f"{user_id}@{gateway_id}"))
+
+
+class _FakeClientSE:
+    def __init__(self, sharing, iam, username="alice", gateway_id="default"):
+        self.sharing = sharing
+        self.iam = iam
+        self.username = username
+        self.gateway_id = gateway_id
+
+
+_GG = {
+    "admins_group_id": "x",
+    "read_only_admins_group_id": "y",
+    "default_gateway_users_group_id": "z",
+}
+
+
+class TestGetSharedEntity:
+    def test_directly_accessible_tree(self):
+        # owner alice; bob has WRITE; group grp1 has READ
+        sharing = _FakeSharingSE(
+            direct_users={
+                "READ": ["bob@default", "alice@default"],
+                "WRITE": ["bob@default"],
+                "MANAGE_SHARING": [],
+                "OWNER": ["alice@default"],
+            },
+            direct_groups={
+                "READ": ["grp1@default"],
+                "WRITE": [],
+                "MANAGE_SHARING": [],
+            },
+            groups=[_group(id="grp1@default", name="G1")],
+            manage_sharing=True,
+        )
+        bob = _user_profile(user_id="bob@default", first_name="Bob")
+        alice = _user_profile(user_id="alice@default", first_name="Alice")
+        iam = _FakeIam(profiles={"alice": alice, "bob": bob})
+        c = _FakeClientSE(sharing, iam, username="alice@default")
+        se = get_shared_entity(c, "ent-1", gateway_groups=_GG)
+
+        # proto-direct composed shape: a pydantic SharedEntity
+        assert isinstance(se, SharedEntity)
+        assert se.entity_id == "ent-1"
+        # owner removed from users list -> only bob remains
+        assert len(se.user_permissions) == 1
+        up = se.user_permissions[0]
+        assert isinstance(up, UserPermission)
+        # the raw UserProfile proto flows through wholesale (not copied)
+        assert up.user is bob
+        assert up.user.user_id == "bob@default"
+        # permission_type is the member NAME string
+        assert up.permission_type == "WRITE"
+        # owner is the raw UserProfile proto, passed through
+        assert se.owner is alice
+        assert se.owner.user_id == "alice@default"
+        # group permission carries a WithGroupAccess envelope + the NAME
+        assert len(se.group_permissions) == 1
+        gp = se.group_permissions[0]
+        assert isinstance(gp, GroupPermission)
+        assert isinstance(gp.group, WithGroupAccess)
+        assert gp.group.message.id == "grp1@default"
+        assert gp.permission_type == "READ"
+        # entity-level flags
+        assert se.is_owner is True            # owner.user_id == client.username
+        assert se.has_sharing_permission is True
+
+    def test_all_uses_accessible_accessor(self):
+        sharing = _FakeSharingSE(
+            accessible_users={
+                "READ": ["alice@default", "bob@default"],
+                "WRITE": [],
+                "MANAGE_SHARING": [],
+                "OWNER": ["alice@default"],
+            },
+            accessible_groups={"READ": [], "WRITE": [], "MANAGE_SHARING": []},
+            manage_sharing=False,
+        )
+        iam = _FakeIam()
+        c = _FakeClientSE(sharing, iam, username="alice@default")
+        se = get_all_shared_entity(c, "ent-2", gateway_groups=_GG)
+        assert len(se.user_permissions) == 1
+        assert se.user_permissions[0].user.user_id == "bob@default"
+        assert se.user_permissions[0].permission_type == "READ"
+        assert se.has_sharing_permission is False
+
+
+class TestApplySharingUpdate:
+    def test_fires_grant_and_revoke_rpcs(self):
+        sharing = _FakeSharingSE()
+        iam = _FakeIam()
+        c = _FakeClientSE(sharing, iam)
+        apply_sharing_update(
+            c, "ent-1",
+            existing_user_permissions={"bob@default": "READ"},
+            new_user_permissions={"bob@default": "WRITE"},   # grant
+            existing_group_permissions={"grp@default": "WRITE"},
+            new_group_permissions={},                        # revoke
+        )
+        names = [call[0] for call in sharing.calls]
+        assert "share_users" in names      # WRITE granted to bob
+        assert "revoke_groups" in names    # group fully revoked
+
+    def test_noop_when_unchanged(self):
+        sharing = _FakeSharingSE()
+        c = _FakeClientSE(sharing, _FakeIam())
+        apply_sharing_update(
+            c, "ent-1",
+            existing_user_permissions={"bob@default": "WRITE"},
+            new_user_permissions={"bob@default": "WRITE"},
+            existing_group_permissions={},
+            new_group_permissions={},
+        )
+        assert sharing.calls == []

--- a/airavata-python-sdk/tests/helpers/test_storage_resources.py
+++ b/airavata-python-sdk/tests/helpers/test_storage_resources.py
@@ -1,0 +1,561 @@
+"""Unit tests for airavata_sdk.helpers.storage_resources.
+
+The **storage-resources** family is proto-direct: ``get_storage_resource``
+returns the raw ``StorageResourceDescription`` proto as-is (no transform, no
+envelope) and ``list_storage_resource_names`` returns the raw name map.  These
+tests assert exactly that — the proto identity / fields and the name map — via a
+lightweight stub client that records the calls made.
+
+The OTHER families in the module (per-protocol data movement, user-storage,
+data-product download) are still on the legacy ``_x_dict`` + camelize path and
+keep their existing transform-level tests below.
+"""
+
+from airavata_sdk.helpers.storage_resources import (
+    get_grid_ftp_data_movement,
+    get_local_data_movement,
+    get_scp_data_movement,
+    get_storage_resource,
+    list_storage_resource_names,
+)
+
+
+def _sr_pb2():
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.storageresource import (  # noqa: E501
+        storage_resource_pb2,
+    )
+    return storage_resource_pb2
+
+
+def _dm_pb2():
+    from airavata_sdk.generated.org.apache.airavata.model.data.movement import (
+        data_movement_pb2,
+    )
+    return data_movement_pb2
+
+
+def _make_dmi(**kwargs):
+    return _dm_pb2().DataMovementInterface(**kwargs)
+
+
+def _make_storage_resource(**kwargs):
+    return _sr_pb2().StorageResourceDescription(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Storage-resources family — proto-direct (returns the proto / name map as-is)
+# ---------------------------------------------------------------------------
+
+class _FakeStorage:
+    def __init__(self, resource=None, names=None):
+        self._resource = resource
+        self._names = names or {}
+        self.requested_id = None
+        self.list_called = False
+
+    def get_storage_resource(self, storage_resource_id):
+        self.requested_id = storage_resource_id
+        return self._resource
+
+    def get_all_storage_resource_names(self):
+        self.list_called = True
+        return dict(self._names)
+
+
+class _FakeClient:
+    def __init__(self, resource=None, names=None,
+                 gateway_id="default", username="alice"):
+        self.storage = _FakeStorage(resource, names)
+        self.gateway_id = gateway_id
+        self.username = username
+
+
+class TestGetStorageResource:
+    def _full(self):
+        return _make_storage_resource(
+            storage_resource_id="store-1",
+            host_name="store.example.com",
+            storage_resource_description="desc",
+            enabled=True,
+            data_movement_interfaces=[
+                _make_dmi(
+                    data_movement_interface_id="dm-1",
+                    data_movement_protocol=_dm_pb2().DataMovementProtocol.SCP,
+                    priority_order=5,
+                    creation_time=1705320000000,
+                    update_time=0,
+                    storage_resource_id="store-1",
+                ),
+            ],
+            creation_time=1705320000000,
+            update_time=0,
+        )
+
+    def test_returns_proto_directly(self):
+        # Proto-direct: the SDK returns the gRPC message itself, NOT a dict.
+        sr = self._full()
+        client = _FakeClient(resource=sr)
+        out = get_storage_resource(client, "store-1")
+        assert client.storage.requested_id == "store-1"
+        assert out is sr
+        assert isinstance(out, _sr_pb2().StorageResourceDescription)
+
+    def test_proto_fields_intact(self):
+        client = _FakeClient(resource=self._full())
+        out = get_storage_resource(client, "store-1")
+        assert out.storage_resource_id == "store-1"
+        assert out.host_name == "store.example.com"
+        assert out.enabled is True
+        # Nested interface + enum stay native proto values (rendered to the
+        # member NAME by the portal's MessageToDict, not a Thrift int here).
+        assert len(out.data_movement_interfaces) == 1
+        dmi = out.data_movement_interfaces[0]
+        assert dmi.data_movement_protocol == _dm_pb2().DataMovementProtocol.SCP
+        assert dmi.creation_time == 1705320000000
+
+
+class TestListStorageResourceNames:
+    def test_returns_name_map(self):
+        client = _FakeClient(names={"store-1": "host1", "store-2": "host2"})
+        out = list_storage_resource_names(client)
+        assert client.storage.list_called is True
+        assert out == {"store-1": "host1", "store-2": "host2"}
+
+    def test_empty(self):
+        client = _FakeClient(names={})
+        assert list_storage_resource_names(client) == {}
+
+
+# ===========================================================================
+# Per-protocol data movement (Local / SCP / GridFTP) — proto-direct
+# ===========================================================================
+#
+# Each ``get_*_data_movement`` helper returns the raw facade proto as-is (no
+# transform, no envelope): the resources carry no hyperlink / ownership /
+# sharing fields, mirroring the per-protocol job-submission family.  The portal's
+# MessageToDict renders ``security_protocol`` to the member NAME, not a Thrift
+# int — that is the portal contract test's concern, not these unit tests.
+
+class _FakeDmStorage:
+    def __init__(self, local=None, scp=None, grid_ftp=None):
+        self._local = local
+        self._scp = scp
+        self._grid_ftp = grid_ftp
+        self.requested_id = None
+
+    def get_local_data_movement(self, data_movement_id):
+        self.requested_id = data_movement_id
+        return self._local
+
+    def get_scp_data_movement(self, data_movement_id):
+        self.requested_id = data_movement_id
+        return self._scp
+
+    def get_grid_ftp_data_movement(self, data_movement_id):
+        self.requested_id = data_movement_id
+        return self._grid_ftp
+
+
+class _FakeDmClient:
+    def __init__(self, **kwargs):
+        self.storage = _FakeDmStorage(**kwargs)
+
+
+class TestDataMovementProtoDirect:
+    def test_get_local_returns_proto_directly(self):
+        # Proto-direct: the SDK returns the gRPC message itself, NOT a dict.
+        local = _dm_pb2().LOCALDataMovement(data_movement_interface_id="l-1")
+        client = _FakeDmClient(local=local)
+        out = get_local_data_movement(client, "l-1")
+        assert client.storage.requested_id == "l-1"
+        assert out is local
+        assert isinstance(out, _dm_pb2().LOCALDataMovement)
+        assert out.data_movement_interface_id == "l-1"
+
+    def test_get_scp_returns_proto_directly(self):
+        scp = _dm_pb2().SCPDataMovement(
+            data_movement_interface_id="scp-1",
+            security_protocol=_dm_pb2().SecurityProtocol.SSH_KEYS,
+            alternative_scp_host_name="alt.host",
+            ssh_port=2222,
+        )
+        client = _FakeDmClient(scp=scp)
+        out = get_scp_data_movement(client, "scp-1")
+        assert client.storage.requested_id == "scp-1"
+        assert out is scp
+        assert isinstance(out, _dm_pb2().SCPDataMovement)
+        assert out.data_movement_interface_id == "scp-1"
+        assert out.alternative_scp_host_name == "alt.host"
+        assert out.ssh_port == 2222
+        # The enum stays a native proto value (rendered to the member NAME by
+        # the portal's MessageToDict, not a Thrift int here).
+        assert out.security_protocol == _dm_pb2().SecurityProtocol.SSH_KEYS
+
+    def test_get_grid_ftp_returns_proto_directly(self):
+        grid_ftp = _dm_pb2().GridFTPDataMovement(
+            data_movement_interface_id="g-1",
+            security_protocol=_dm_pb2().SecurityProtocol.GSI,
+            grid_ftp_end_points=["ep1", "ep2"],
+        )
+        client = _FakeDmClient(grid_ftp=grid_ftp)
+        out = get_grid_ftp_data_movement(client, "g-1")
+        assert client.storage.requested_id == "g-1"
+        assert out is grid_ftp
+        assert isinstance(out, _dm_pb2().GridFTPDataMovement)
+        assert list(out.grid_ftp_end_points) == ["ep1", "ep2"]
+        assert out.security_protocol == _dm_pb2().SecurityProtocol.GSI
+
+
+# ===========================================================================
+# User-storage paths (file/directory listings) — proto-direct
+# ===========================================================================
+#
+# ``get_file_metadata`` returns the raw ``FileMetadataResponse`` proto as-is;
+# ``list_dir`` / ``list_experiment_dir`` return the raw ``ListDirResponse``
+# proto as-is (its ``directories`` / ``files`` are each a
+# ``FileMetadataResponse``).  No ``_x_dict`` transform, no envelope.  The
+# per-entry path-permission flags (``user_has_write_access`` / ``is_shared_dir``)
+# and the experiment-dir relative-path rewrite are portal concerns layered on the
+# rendered proto by the ViewSet — the portal contract test pins that shape.
+
+from airavata_sdk.helpers.storage_resources import (  # noqa: E402
+    create_dir,
+    delete_dir,
+    delete_file,
+    dir_exists,
+    get_file_metadata,
+    list_dir,
+    list_experiment_dir,
+    resolve_user_storage_path,
+)
+
+
+def _fs_pb2():
+    from airavata_sdk.generated.services import file_service_pb2
+    return file_service_pb2
+
+
+def _make_meta(**kwargs):
+    return _fs_pb2().FileMetadataResponse(**kwargs)
+
+
+class _FakeUserStorage:
+    def __init__(self, listing=None, metadata=None, exists=True):
+        self._listing = listing
+        self._metadata = metadata
+        self._exists = exists
+        self.calls = []
+
+    def dir_exists(self, path):
+        self.calls.append(("dir_exists", path))
+        return self._exists
+
+    def create_dir(self, path):
+        self.calls.append(("create_dir", path))
+
+    def delete_file(self, path):
+        self.calls.append(("delete_file", path))
+
+    def delete_dir(self, path):
+        self.calls.append(("delete_dir", path))
+
+    def list_dir(self, path):
+        self.calls.append(("list_dir", path))
+        return self._listing
+
+    def get_file_metadata(self, path):
+        self.calls.append(("get_file_metadata", path))
+        return self._metadata
+
+
+class _FakeResearch:
+    def __init__(self, experiment=None):
+        self._experiment = experiment
+
+    def get_experiment(self, experiment_id):
+        return self._experiment
+
+
+class _FakeUsClient:
+    def __init__(self, storage=None, research=None):
+        self.storage = storage
+        self.research = research
+
+
+class _FakeExperiment:
+    """Minimal proto-like experiment with a data dir."""
+
+    def __init__(self, data_dir, has_ucd=True):
+        self._data_dir = data_dir
+        self._has_ucd = has_ucd
+
+        class _UCD:
+            experiment_data_dir = data_dir
+        self.user_configuration_data = _UCD()
+
+    def HasField(self, name):
+        return self._has_ucd
+
+
+class TestResolveUserStoragePath:
+    def test_bare_relative(self):
+        client = _FakeUsClient()
+        assert resolve_user_storage_path(client, "foo/bar") == "~/foo/bar"
+
+    def test_leading_slash_stripped(self):
+        client = _FakeUsClient()
+        assert resolve_user_storage_path(client, "/foo") == "~/foo"
+
+    def test_already_tilde(self):
+        client = _FakeUsClient()
+        assert resolve_user_storage_path(client, "~/foo") == "~/foo"
+
+    def test_experiment_relative(self):
+        client = _FakeUsClient(
+            research=_FakeResearch(
+                _FakeExperiment("/data/exp-1")))
+        out = resolve_user_storage_path(client, "out.txt", experiment_id="exp-1")
+        assert out == "/data/exp-1/out.txt"
+
+    def test_experiment_empty_path(self):
+        client = _FakeUsClient(
+            research=_FakeResearch(_FakeExperiment("~/data/exp-1")))
+        out = resolve_user_storage_path(client, "", experiment_id="exp-1")
+        assert out == "~/data/exp-1"
+
+
+class TestUserStorageOrchestration:
+    def test_dir_exists_create_delete(self):
+        storage = _FakeUserStorage(exists=True)
+        client = _FakeUsClient(storage=storage)
+        assert dir_exists(client, "~/p") is True
+        create_dir(client, "~/p")
+        delete_file(client, "~/f")
+        delete_dir(client, "~/p")
+        assert ("create_dir", "~/p") in storage.calls
+        assert ("delete_file", "~/f") in storage.calls
+        assert ("delete_dir", "~/p") in storage.calls
+
+
+class TestGetFileMetadataProtoDirect:
+    def test_returns_proto_directly(self):
+        # Proto-direct: the SDK returns the gRPC message itself, NOT a dict.
+        meta = _make_meta(name="a.txt", path="/home/u/a.txt", size=5,
+                          modified_time=1705320000000, content_type="text/plain",
+                          data_product_uri="airavata-dp://x", is_directory=False)
+        storage = _FakeUserStorage(metadata=meta)
+        client = _FakeUsClient(storage=storage)
+        out = get_file_metadata(client, "~/a.txt")
+        assert out is meta
+        assert isinstance(out, _fs_pb2().FileMetadataResponse)
+        assert ("get_file_metadata", "~/a.txt") in storage.calls
+
+    def test_proto_fields_intact(self):
+        meta = _make_meta(name="a.txt", path="/home/u/a.txt", size=5,
+                          modified_time=1705320000000, content_type="text/plain",
+                          data_product_uri="airavata-dp://x")
+        client = _FakeUsClient(storage=_FakeUserStorage(metadata=meta))
+        out = get_file_metadata(client, "~/a.txt")
+        assert out.name == "a.txt"
+        assert out.path == "/home/u/a.txt"
+        assert out.size == 5
+        assert out.modified_time == 1705320000000
+        assert out.content_type == "text/plain"
+        assert out.data_product_uri == "airavata-dp://x"
+        assert out.is_directory is False
+
+
+class TestListDirProtoDirect:
+    def _listing(self):
+        return _fs_pb2().ListDirResponse(
+            directories=[_make_meta(name="d", path="/home/u/d", size=0,
+                                    is_directory=True)],
+            files=[_make_meta(name="f.txt", path="/home/u/f.txt", size=2,
+                              modified_time=1705320000000)],
+        )
+
+    def test_returns_proto_directly(self):
+        # Proto-direct: the SDK returns the ListDirResponse message, NOT a dict.
+        listing = self._listing()
+        storage = _FakeUserStorage(listing=listing)
+        client = _FakeUsClient(storage=storage)
+        out = list_dir(client, "~/")
+        assert out is listing
+        assert isinstance(out, _fs_pb2().ListDirResponse)
+        assert ("list_dir", "~/") in storage.calls
+
+    def test_proto_entries_intact(self):
+        client = _FakeUsClient(storage=_FakeUserStorage(listing=self._listing()))
+        out = list_dir(client, "~/")
+        assert len(out.directories) == 1
+        assert out.directories[0].name == "d"
+        assert out.directories[0].is_directory is True
+        assert len(out.files) == 1
+        assert out.files[0].name == "f.txt"
+        assert out.files[0].size == 2
+
+
+class TestListExperimentDirProtoDirect:
+    def _listing(self):
+        return _fs_pb2().ListDirResponse(
+            directories=[_make_meta(name="sub", path="/data/exp/sub", size=0,
+                                    is_directory=True)],
+            files=[_make_meta(name="o.txt", path="/data/exp/o.txt", size=3,
+                              modified_time=1705320000000)],
+        )
+
+    def test_returns_proto_directly(self):
+        listing = self._listing()
+        storage = _FakeUserStorage(listing=listing)
+        client = _FakeUsClient(storage=storage)
+        out = list_experiment_dir(client, "/data/exp")
+        assert out is listing
+        assert isinstance(out, _fs_pb2().ListDirResponse)
+        assert ("list_dir", "/data/exp") in storage.calls
+
+    def test_proto_entries_intact(self):
+        client = _FakeUsClient(storage=_FakeUserStorage(listing=self._listing()))
+        out = list_experiment_dir(client, "/data/exp")
+        assert out.directories[0].path == "/data/exp/sub"
+        assert out.files[0].name == "o.txt"
+
+
+# ===========================================================================
+# Data-product file download (output-view-provider data generation)
+# ===========================================================================
+
+from airavata_sdk.helpers.storage_resources import (  # noqa: E402
+    data_product_file_path,
+    download_data_product_files,
+    file_exists,
+)
+
+
+def _rc_pb2():
+    from airavata_sdk.generated.org.apache.airavata.model.data.replica import (
+        replica_catalog_pb2,
+    )
+    return replica_catalog_pb2
+
+
+def _make_data_product(*, replica_paths=None, **kwargs):
+    rc = _rc_pb2()
+    replicas = [
+        rc.DataReplicaLocationModel(file_path=p) for p in (replica_paths or [])
+    ]
+    return rc.DataProductModel(replica_locations=replicas, **kwargs)
+
+
+class TestDataProductFilePath:
+    def test_no_replicas_is_none(self):
+        assert data_product_file_path(_make_data_product()) is None
+
+    def test_empty_file_path_is_none(self):
+        assert data_product_file_path(
+            _make_data_product(replica_paths=[""])) is None
+
+    def test_absolute_path_passthrough(self):
+        dp = _make_data_product(replica_paths=["/storage/tmp/out.txt"])
+        assert data_product_file_path(dp) == "/storage/tmp/out.txt"
+
+    def test_tilde_path_passthrough(self):
+        dp = _make_data_product(replica_paths=["~/out.txt"])
+        assert data_product_file_path(dp) == "~/out.txt"
+
+    def test_relative_path_is_tilde_prefixed(self):
+        dp = _make_data_product(replica_paths=["sub/out.txt"])
+        assert data_product_file_path(dp) == "~/sub/out.txt"
+
+    def test_first_replica_used(self):
+        dp = _make_data_product(replica_paths=["/a.txt", "/b.txt"])
+        assert data_product_file_path(dp) == "/a.txt"
+
+
+class _FakeDownloadStorage:
+    def __init__(self, *, existing_paths=None, contents=None, names=None):
+        self._existing = set(existing_paths or [])
+        self._contents = contents or {}
+        self._names = names or {}
+        self.calls = []
+
+    def file_exists(self, path):
+        self.calls.append(("file_exists", path))
+        return path in self._existing
+
+    def download_file(self, path):
+        self.calls.append(("download_file", path))
+        resp = _fs_pb2().DownloadFileResponse(
+            content=self._contents.get(path, b""),
+            name=self._names.get(path, ""),
+        )
+        return resp
+
+
+class _FakeDownloadResearch:
+    def __init__(self, products_by_uri=None):
+        self._products = products_by_uri or {}
+        self.requested = []
+
+    def get_data_product(self, uri):
+        self.requested.append(uri)
+        return self._products[uri]
+
+
+class _FakeDownloadClient:
+    def __init__(self, storage=None, research=None):
+        self.storage = storage
+        self.research = research
+
+
+class TestFileExists:
+    def test_delegates_to_facade(self):
+        storage = _FakeDownloadStorage(existing_paths=["/a.txt"])
+        client = _FakeDownloadClient(storage=storage)
+        assert file_exists(client, "/a.txt") is True
+        assert file_exists(client, "/missing.txt") is False
+        assert ("file_exists", "/a.txt") in storage.calls
+
+
+class TestDownloadDataProductFiles:
+    def test_downloads_existing_files_in_order(self):
+        dp1 = _make_data_product(replica_paths=["/storage/a.txt"])
+        dp2 = _make_data_product(replica_paths=["/storage/b.txt"])
+        research = _FakeDownloadResearch({
+            "airavata-dp://1": dp1,
+            "airavata-dp://2": dp2,
+        })
+        storage = _FakeDownloadStorage(
+            existing_paths=["/storage/a.txt", "/storage/b.txt"],
+            contents={"/storage/a.txt": b"AAA", "/storage/b.txt": b"BBB"},
+            names={"/storage/a.txt": "a.txt"},
+        )
+        client = _FakeDownloadClient(storage=storage, research=research)
+        files = download_data_product_files(
+            client, ["airavata-dp://1", "airavata-dp://2"])
+        assert len(files) == 2
+        assert files[0].read() == b"AAA"
+        assert files[0].name == "a.txt"
+        assert files[1].read() == b"BBB"
+        # Empty download name falls back to the path basename.
+        assert files[1].name == "b.txt"
+
+    def test_skips_products_with_no_replica(self):
+        dp = _make_data_product(replica_paths=[])
+        research = _FakeDownloadResearch({"airavata-dp://x": dp})
+        storage = _FakeDownloadStorage()
+        client = _FakeDownloadClient(storage=storage, research=research)
+        files = download_data_product_files(client, ["airavata-dp://x"])
+        assert files == []
+        # No file_exists / download_file calls for a product without a replica.
+        assert storage.calls == []
+
+    def test_skips_missing_files(self):
+        dp = _make_data_product(replica_paths=["/storage/gone.txt"])
+        research = _FakeDownloadResearch({"airavata-dp://g": dp})
+        storage = _FakeDownloadStorage(existing_paths=[])
+        client = _FakeDownloadClient(storage=storage, research=research)
+        files = download_data_product_files(client, ["airavata-dp://g"])
+        assert files == []
+        assert ("file_exists", "/storage/gone.txt") in storage.calls
+        # download_file is not attempted when the file does not exist.
+        assert ("download_file", "/storage/gone.txt") not in storage.calls

--- a/airavata-python-sdk/tests/test_client_username.py
+++ b/airavata-python-sdk/tests/test_client_username.py
@@ -1,0 +1,29 @@
+"""Tests for the username property on AiravataClient."""
+from airavata_sdk.client import AiravataClient
+
+
+def _client_with_claims(claims):
+    """Construct an AiravataClient shell without opening a gRPC channel."""
+    c = AiravataClient.__new__(AiravataClient)
+    c.claims = claims
+    return c
+
+
+def test_username_returns_value_from_claims():
+    c = _client_with_claims({"gatewayID": "default", "userName": "default-admin"})
+    assert AiravataClient.username.fget(c) == "default-admin"
+
+
+def test_username_none_when_key_missing():
+    c = _client_with_claims({"gatewayID": "default"})
+    assert AiravataClient.username.fget(c) is None
+
+
+def test_username_none_when_claims_none():
+    c = _client_with_claims(None)
+    assert AiravataClient.username.fget(c) is None
+
+
+def test_username_none_when_claims_empty():
+    c = _client_with_claims({})
+    assert AiravataClient.username.fget(c) is None

--- a/conf/keycloak/realm-default.json
+++ b/conf/keycloak/realm-default.json
@@ -1406,7 +1406,8 @@
       "clientAuthenticatorType": "client-secret",
       "secret": "m36BXQIxX3j3VILadeHMK5IvbOeRlCCc",
       "redirectUris": [
-        "http://localhost:8000/*"
+        "http://airavata.localhost:8000/*",
+        "https://gateway.airavata.localhost/*"
       ],
       "webOrigins": [
         "+"


### PR DESCRIPTION
Re-architects airavata-python-sdk into a proto-direct gRPC client. The resource helpers (research/compute/storage/iam/sharing/credential) return protobuf messages — or thin WithAccess/WithGroupAccess envelopes and composed pydantic models for cross-service shapes — instead of dict-transformed Thrift output, removing the legacy Thrift mapping layer and its enum-int tables in favor of proto-native types and strict typing, with deduplicated helpers aligned to the gRPC service breakdown and accompanying unit tests. Adds the public entry points the thin portal consumes directly (build_experiment, wrap_groups, list_application_deployments_for_module). Also enables Keycloak-owned account self-service in the dev realm seed (registration / password reset / remember-me) and registers the portal's local OIDC callback + post-logout URIs.