### PR TITLE
Fix SDK-launched experiment output listing and clone creation-time

### DIFF
--- a/airavata-api/research-service/src/main/java/org/apache/airavata/research/repository/ExperimentRepository.java
+++ b/airavata-api/research-service/src/main/java/org/apache/airavata/research/repository/ExperimentRepository.java
@@ -101,6 +101,17 @@ public class ExperimentRepository extends AbstractRepository<ExperimentModel, Ex
             experimentModel = experimentModel.toBuilder()
                     .setCreationTime(System.currentTimeMillis())
                     .build();
+        } else {
+            // creation_time is immutable after create. This update path persists the full model, and
+            // callers may resend it with creation_time cleared — a clone, for instance, re-sends the
+            // experiment via update_experiment with an unset creation_time. longToTimestamp maps 0 to a
+            // NULL column that reads back as epoch 1970 ("56 years ago"). Carry the stored value forward.
+            long existingCreationTime = getExperiment(experimentId).getCreationTime();
+            if (existingCreationTime > 0) {
+                experimentModel = experimentModel.toBuilder()
+                        .setCreationTime(existingCreationTime)
+                        .build();
+            }
         }
         ExperimentEntity experimentEntity = ResearchMapper.INSTANCE.experimentToEntity(experimentModel);
 

--- a/airavata-python-sdk/airavata_sdk/helpers/storage_resources.py
+++ b/airavata-python-sdk/airavata_sdk/helpers/storage_resources.py
@@ -84,9 +84,13 @@ def resolve_user_storage_path(
             if experiment.HasField("user_configuration_data")
             else None
         ) or ""
-        base = data_dir.rstrip("/")
+        # The experiment data dir is user-storage-relative. The SDK launch persists it with a
+        # leading '/' that the staging write side (DataStagingTask.buildDestinationFilePath) strips
+        # and anchors under the storage root; strip it here too and anchor under '~/' — otherwise
+        # list_dir/dir_exists resolve against the SFTP chroot root (outside it) and show "no files".
+        base = data_dir.strip("/")
         full = base + ("/" + rel if rel else "")
-        if full.startswith("/") or full.startswith("~/"):
+        if full.startswith("~/"):
             return full
         return "~/" + full
     if rel.startswith("~"):


### PR DESCRIPTION
## Summary

Two experiment-data fixes found while verifying the clean-slate devstack end to end.

### "No files" for SDK-launched experiment output
The Python SDK persists an **absolute** `experiment_data_dir` (`/project/experiment`). The staging **write** side (`DataStagingTask.buildDestinationFilePath`) strips the leading `/` and anchors the dir under the storage root, but the **read** side (`storage_resources.resolve_user_storage_path`) honored it as-is, so `list_dir`/`dir_exists` resolved against the SFTP chroot root (outside the storage root) and listed nothing — while UI-launched experiments (bare-relative dir) listed fine. Strip the leading `/` and anchor under `~/`, matching the write side.

### Clone shows creation time as "56 years ago"
Clone re-sends the full experiment via `update_experiment` with `creation_time` cleared, but `ExperimentRepository.saveExperiment` only stamped `creation_time` on insert, so the update nulled the column (`longToTimestamp(0)` → NULL → renders as epoch 1970). Make `creation_time` set-once: on update, carry the stored value forward.

## Test plan
- `resolve_user_storage_path` unit checks: SDK absolute `/Default_Project/Echo_goldstandard/` → `~/Default_Project/Echo_goldstandard`; UI relative unchanged (no regression). Confirmed the staged output file exists at the location the patched path resolves to.
- Real clone via the SDK flow against the live server: cloned experiment's `creation_time` is now a valid timestamp (was `NULL` pre-fix).
