### PR TITLE
Remove dead ResearchProjectRepository query methods

### DIFF
--- a/airavata-api/research-service/src/main/java/org/apache/airavata/research/repository/ResearchProjectRepository.java
+++ b/airavata-api/research-service/src/main/java/org/apache/airavata/research/repository/ResearchProjectRepository.java
@@ -32,16 +32,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ResearchProjectRepository extends JpaRepository<ResearchProjectEntity, String> {
 
-    boolean existsByOwnerId(String ownerId);
-
-    List<ResearchProjectEntity> findProjectsByRepositoryResource(RepositoryResourceEntity repositoryResource);
-
-    List<ResearchProjectEntity> findProjectsByDatasetResourcesContaining(Set<DatasetResourceEntity> datasetResources);
-
-    List<ResearchProjectEntity> findAllByOwnerId(String ownerId);
-
-    List<ResearchProjectEntity> findAllByOwnerIdOrderByCreatedAtDesc(String ownerId);
-
     List<ResearchProjectEntity> findALlByState(StateEnum state);
 
     List<ResearchProjectEntity> findProjectsByRepositoryResourceAndState(
@@ -51,8 +41,6 @@ public interface ResearchProjectRepository extends JpaRepository<ResearchProject
 
     List<ResearchProjectEntity> findProjectsByDatasetResourcesContainingAndState(
             Set<DatasetResourceEntity> datasetResources, StateEnum state);
-
-    StateEnum State(StateEnum state);
 
     Optional<ResearchProjectEntity> findByIdAndState(String id, StateEnum state);
 }


### PR DESCRIPTION
Six unused Spring Data declarations with **zero callers** in `ResearchProjectRepository`:
`existsByOwnerId`, `findProjectsByRepositoryResource`, `findProjectsByDatasetResourcesContaining`, `findAllByOwnerId`, `findAllByOwnerIdOrderByCreatedAtDesc`, and the malformed no-op `State(StateEnum)` (matches no Spring Data derived-query prefix, so it generated no query).

The active state-scoped variants (`findALlByState`, the `...AndState` methods, `findByIdAndState`) are kept — verified each still has callers.

## Test plan
- Per-method caller grep across both repos: the six removed have 0 callers; kept methods have ≥1.
- `mvn install -DskipTests` (full reactor) green.