### PR TITLE
Remove dead research-service methods

### DIFF
--- a/airavata-api/research-service/src/main/java/org/apache/airavata/research/service/AgentExperimentService.java
+++ b/airavata-api/research-service/src/main/java/org/apache/airavata/research/service/AgentExperimentService.java
@@ -64,10 +64,6 @@ public class AgentExperimentService {
         return experimentService;
     }
 
-    public ProjectService projectService() {
-        return projectService;
-    }
-
     public GroupResourceProfileProvider groupResourceProfileService() {
         return groupResourceProfileService;
     }

--- a/airavata-api/research-service/src/main/java/org/apache/airavata/research/service/AgentManagementService.java
+++ b/airavata-api/research-service/src/main/java/org/apache/airavata/research/service/AgentManagementService.java
@@ -204,18 +204,6 @@ public class AgentManagementService {
         }
     }
 
-    public void terminateApplication(String gatewayId, String experimentId) {
-        try {
-            LOGGER.info("Terminating the application with experiment Id: {}", experimentId);
-            RequestContext ctx = agentExperimentService.requestContext();
-            agentExperimentService.experimentService().terminateExperiment(ctx, experimentId);
-        } catch (Exception e) {
-            LOGGER.error("Error while terminating the application with the experiment Id: {}", experimentId);
-            throw new RuntimeException(
-                    "Error while terminating the application with the experiment Id: " + experimentId, e);
-        }
-    }
-
     public ProcessModel getEnvProcessModel(String expId) {
         try {
             LOGGER.info("Extracting the process model for experiment id: {}", expId);

--- a/airavata-api/research-service/src/main/java/org/apache/airavata/research/service/AiravataService.java
+++ b/airavata-api/research-service/src/main/java/org/apache/airavata/research/service/AiravataService.java
@@ -44,12 +44,4 @@ public class AiravataService {
         }
         return profile;
     }
-
-    public UserProfile getUserProfile(String authzToken, String userId, String gatewayId) {
-        UserProfile profile = userProfileProvider.getUserProfileByIdAndGateWay(userId, gatewayId);
-        if (profile == null) {
-            throw new RuntimeException("User profile not found for id: " + userId + " in gateway: " + gatewayId);
-        }
-        return profile;
-    }
 }


### PR DESCRIPTION
Three unused public methods with **zero callers** across both repos:
- `AgentManagementService.terminateApplication(gatewayId, experimentId)`
- `AiravataService.getUserProfile(authzToken, userId, gatewayId)` — the 1-arg `getUserProfile(userId)` is the live overload (used by `ResearchResourceService`)
- `AgentExperimentService.projectService()` accessor — the `projectService` field stays (read by `getProjects`); only the unused accessor is removed

## Test plan
- Per-method caller grep across both repos: 0 callers each (1-arg getUserProfile and the projectService field remain referenced).
- `mvn install -DskipTests` (full reactor) green.