### PR TITLE
Clean dead members from VirtualStreamProducer

### DIFF
--- a/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/util/VirtualStreamProducer.java
+++ b/airavata-api/storage-service/src/main/java/org/apache/airavata/storage/util/VirtualStreamProducer.java
@@ -22,7 +22,6 @@ package org.apache.airavata.storage.util;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 public class VirtualStreamProducer {
@@ -31,7 +30,6 @@ public class VirtualStreamProducer {
     private OutputStream outputStream;
 
     public VirtualStreamProducer(int bufferSize, long streamLength) {
-        ConcurrentLinkedQueue q = new ConcurrentLinkedQueue();
         BlockingQueue<Integer> queue = new LinkedBlockingQueue<>(bufferSize);
         inputStream = new VirtualInputStream(queue, streamLength);
         outputStream = new VirtualOutputStream(queue, streamLength);
@@ -41,15 +39,7 @@ public class VirtualStreamProducer {
         return inputStream;
     }
 
-    public void setInputStream(InputStream inputStream) {
-        this.inputStream = inputStream;
-    }
-
     public OutputStream getOutputStream() {
         return outputStream;
-    }
-
-    public void setOutputStream(OutputStream outputStream) {
-        this.outputStream = outputStream;
     }
 }


### PR DESCRIPTION
Removes from `VirtualStreamProducer`:
- unused `setInputStream`/`setOutputStream` setters (0 callers — streams are only set in the constructor, read via getters),
- the dead local `ConcurrentLinkedQueue q` (the real buffer is the `LinkedBlockingQueue queue`),
- the now-unused `ConcurrentLinkedQueue` import.

The class stays — it is live via its constructor + getters in `DataStagingTask`.

## Test plan
- Grep: setters have 0 callers.
- `mvn install -DskipTests` (full reactor) green.