### PR TITLE
Drop placeholder class javadoc and fix corrupted license header

### DIFF
--- a/airavata-api/compute-service/src/main/java/org/apache/airavata/compute/util/Agent.java
+++ b/airavata-api/compute-service/src/main/java/org/apache/airavata/compute/util/Agent.java
@@ -19,10 +19,4 @@
 */
 package org.apache.airavata.compute.util;
 
-/**
- * TODO: Class level comments please
- *
- * @author dimuthu
- * @since 1.0.0-SNAPSHOT
- */
 public class Agent {}

--- a/airavata-api/compute-service/src/main/java/org/apache/airavata/compute/util/StandardOutReader.java
+++ b/airavata-api/compute-service/src/main/java/org/apache/airavata/compute/util/StandardOutReader.java
@@ -23,12 +23,6 @@ import java.io.*;
 import org.apache.airavata.interfaces.CommandOutput;
 import org.apache.commons.io.IOUtils;
 
-/**
- * TODO: Class level comments please
- *
- * @author dimuthu
- * @since 1.0.0-SNAPSHOT
- */
 public class StandardOutReader implements CommandOutput {
 
     private String stdOut;

--- a/airavata-api/src/main/java/org/apache/airavata/task/AdaptorSupport.java
+++ b/airavata-api/src/main/java/org/apache/airavata/task/AdaptorSupport.java
@@ -23,12 +23,6 @@ import org.apache.airavata.interfaces.AgentAdaptor;
 import org.apache.airavata.interfaces.AgentException;
 import org.apache.airavata.interfaces.StorageResourceAdaptor;
 
-/**
- * TODO: Class level comments please
- *
- * @author dimuthu
- * @since 1.0.0-SNAPSHOT
- */
 public interface AdaptorSupport {
     void initializeAdaptor();
 

--- a/airavata-api/src/main/java/org/apache/airavata/task/AdaptorSupportImpl.java
+++ b/airavata-api/src/main/java/org/apache/airavata/task/AdaptorSupportImpl.java
@@ -26,12 +26,6 @@ import org.apache.airavata.interfaces.StorageResourceAdaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * TODO: Class level comments please
- *
- * @author dimuthu
- * @since 1.0.0-SNAPSHOT
- */
 public class AdaptorSupportImpl implements AdaptorSupport {
 
     private static final Logger logger = LoggerFactory.getLogger(AdaptorSupportImpl.class);

--- a/airavata-api/src/main/java/org/apache/airavata/task/AgentStore.java
+++ b/airavata-api/src/main/java/org/apache/airavata/task/AgentStore.java
@@ -25,12 +25,6 @@ import java.util.Optional;
 import org.apache.airavata.interfaces.AgentAdaptor;
 import org.apache.airavata.interfaces.StorageResourceAdaptor;
 
-/**
- * TODO: Class level comments please
- *
- * @author dimuthu
- * @since 1.0.0-SNAPSHOT
- */
 public class AgentStore {
 
     // compute resource: auth token: user: adaptor
@@ -61,8 +55,7 @@ public class AgentStore {
         userToAdaptorMap.put(userId, agentAdaptor);
     }
 
-    public Optional<StorageResourceAdaptor> getStorageAdaptor(
-            String storageResource, String authToken, String userId) {
+    public Optional<StorageResourceAdaptor> getStorageAdaptor(String storageResource, String authToken, String userId) {
         Map<String, Map<String, StorageResourceAdaptor>> tokenToUserMap = storageAdaptorCache.get(storageResource);
         if (tokenToUserMap != null) {
             Map<String, StorageResourceAdaptor> userToAdaptorMap = tokenToUserMap.get(authToken);

--- a/airavata-api/src/main/java/org/apache/airavata/task/TaskDef.java
+++ b/airavata-api/src/main/java/org/apache/airavata/task/TaskDef.java
@@ -24,12 +24,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * TODO: Class level comments please
- *
- * @author dimuthu
- * @since 1.0.0-SNAPSHOT
- */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface TaskDef {

--- a/airavata-api/src/main/java/org/apache/airavata/task/TaskHelper.java
+++ b/airavata-api/src/main/java/org/apache/airavata/task/TaskHelper.java
@@ -19,12 +19,6 @@
 */
 package org.apache.airavata.task;
 
-/**
- * TODO: Class level comments please
- *
- * @author dimuthu
- * @since 1.0.0-SNAPSHOT
- */
 public interface TaskHelper {
     public AdaptorSupport getAdaptorSupport();
 }

--- a/airavata-api/src/main/java/org/apache/airavata/task/TaskHelperImpl.java
+++ b/airavata-api/src/main/java/org/apache/airavata/task/TaskHelperImpl.java
@@ -19,12 +19,6 @@
 */
 package org.apache.airavata.task;
 
-/**
- * TODO: Class level comments please
- *
- * @author dimuthu
- * @since 1.0.0-SNAPSHOT
- */
 public class TaskHelperImpl implements TaskHelper {
 
     public AdaptorSupportImpl getAdaptorSupport() {

--- a/airavata-api/src/main/java/org/apache/airavata/task/TaskParam.java
+++ b/airavata-api/src/main/java/org/apache/airavata/task/TaskParam.java
@@ -24,12 +24,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * TODO: Class level comments please
- *
- * @author dimuthu
- * @since 1.0.0-SNAPSHOT
- */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface TaskParam {

--- a/airavata-api/src/main/java/org/apache/airavata/task/TaskUtil.java
+++ b/airavata-api/src/main/java/org/apache/airavata/task/TaskUtil.java
@@ -26,12 +26,6 @@ import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * TODO: Class level comments please
- *
- * @author dimuthu
- * @since 1.0.0-SNAPSHOT
- */
 public class TaskUtil {
 
     private static final Logger logger = LoggerFactory.getLogger(TaskUtil.class);

--- a/airavata-python-sdk/airavata_sdk/clients/file_handling_client.py
+++ b/airavata-python-sdk/airavata_sdk/clients/file_handling_client.py
@@ -1,4 +1,4 @@
-#  Licrecursive=Nonepache Software Foundation (ASF) under one or more
+#  Licensed to the Apache Software Foundation (ASF) under one or more
 #  contributor license agreements.  See the NOTICE file distributed with
 #  this work for additional information regarding copyright ownership.
 #  The ASF licenses this file to You under the Apache License, Version 2.0


### PR DESCRIPTION
Comment hygiene:
- Remove the boilerplate `TODO: Class level comments please` placeholder javadoc (the template `@author dimuthu / @since 1.0.0-SNAPSHOT` block) from 10 `task/` and `compute/util` classes — it conveys nothing.
- Fix the ASF license header in `file_handling_client.py`, whose first line was mangled by a stray find/replace (`Licrecursive=Nonepache` → `Licensed to the Apache`).

## Test plan
- `mvn install -DskipTests` (full reactor) green; 0 remaining placeholders.