### PR TITLE
Remove unused research config (portal-url / dev-url / dev-user)

### DIFF
--- a/airavata-api/research-service/src/main/java/org/apache/airavata/research/config/ResearchProperties.java
+++ b/airavata-api/research-service/src/main/java/org/apache/airavata/research/config/ResearchProperties.java
@@ -26,9 +26,6 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "airavata.research")
 public class ResearchProperties {
     private String hubUrl;
-    private String portalUrl;
-    private String devUrl;
-    private String devUser;
     private String adminApiKey;
     private int limit = 10;
 
@@ -38,30 +35,6 @@ public class ResearchProperties {
 
     public void setHubUrl(String hubUrl) {
         this.hubUrl = hubUrl;
-    }
-
-    public String getPortalUrl() {
-        return portalUrl;
-    }
-
-    public void setPortalUrl(String portalUrl) {
-        this.portalUrl = portalUrl;
-    }
-
-    public String getDevUrl() {
-        return devUrl;
-    }
-
-    public void setDevUrl(String devUrl) {
-        this.devUrl = devUrl;
-    }
-
-    public String getDevUser() {
-        return devUser;
-    }
-
-    public void setDevUser(String devUser) {
-        this.devUser = devUser;
     }
 
     public String getAdminApiKey() {

--- a/airavata-server/src/main/resources/application.properties
+++ b/airavata-server/src/main/resources/application.properties
@@ -103,9 +103,6 @@ airavata.agent.tunnel.server-api-url=http://localhost:8000
 
 # --- Research Hub ---
 airavata.research.hub-url=http://localhost:20000
-airavata.research.portal-url=http://localhost:5173
-airavata.research.dev-url=http://localhost:5173
-airavata.research.dev-user=airavata@apache.org
 airavata.research.admin-api-key=JUPYTER_ADMIN_API_KEY
 airavata.research.limit=10
 

--- a/dev-tools/ansible/inventories/template/group_vars/all/vault.yml.example
+++ b/dev-tools/ansible/inventories/template/group_vars/all/vault.yml.example
@@ -104,8 +104,6 @@ research_hub_url: "https://CHANGEME_RESEARCH_HUB"
 research_hub_dev_user: "airavata@apache.org"
 research_hub_admin_api_key: "CHANGEME_API_KEY"
 research_hub_limit: 10
-research_portal_dev_url: "https://CHANGEME_PORTAL"
-research_portal_url: "https://CHANGEME_PORTAL"
 openid_url: "https://CHANGEME_AUTH_SERVER/realms/default/.well-known/openid-configuration"
 user_profile_server_url: "CHANGEME_PROFILE_SERVER"
 user_profile_server_port: 8962


### PR DESCRIPTION
`ResearchProperties` bound `airavata.research.portal-url`, `dev-url`, and `dev-user` from `application.properties`, but nothing reads `getPortalUrl`/`getDevUrl`/`getDevUser` (0 readers). Removes the three fields + getters/setters, the matching `application.properties` lines, and the two orphaned `research_portal_url`/`research_portal_dev_url` example vars in the ansible vault template (no `.j2` consumed them).

`hub-url`, `admin-api-key`, and `limit` stay (live).

## Test plan
- Grep: 0 readers of the three getters; the ansible vars had no `.j2` consumer.
- `mvn install -DskipTests` (full reactor) green.