### PR TITLE
Tidy airavata-api dependencies (drop unused snakeyaml, relocate groovy/mail)

### DIFF
--- a/airavata-api/compute-service/pom.xml
+++ b/airavata-api/compute-service/pom.xml
@@ -111,6 +111,10 @@ under the License.
             <version>2.12.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-templates</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/airavata-api/orchestration-service/pom.xml
+++ b/airavata-api/orchestration-service/pom.xml
@@ -126,6 +126,10 @@ under the License.
             <artifactId>junit-platform-launcher</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/airavata-api/pom.xml
+++ b/airavata-api/pom.xml
@@ -82,10 +82,6 @@ under the License.
     </dependency>
     <!-- Other utilities -->
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-mail</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
@@ -141,14 +137,6 @@ under the License.
       <artifactId>micrometer-core</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-templates</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-admin-client</artifactId>


### PR DESCRIPTION
- Drop the explicit `snakeyaml` dependency from `airavata-api` (0 imports); it remains available transitively via spring-boot, so the resolved tree is unchanged.
- Relocate two dependencies to the modules that actually use them: `groovy-templates` → compute-service (its only importer) and `spring-boot-starter-mail` → orchestration-service (its only importer), rather than declaring them in `airavata-api`.

## Test plan
- Grep: 0 snakeyaml imports; groovy used only in compute-service, mail only in orchestration-service.
- `mvn install -DskipTests` (full reactor) green; `dependency:list` confirms the airavata-server fat jar still resolves all three (so the deployed jar content is unchanged).