### PR TITLE
Remove orphaned method, debug main()s, and stale plugin pins

### DIFF
--- a/airavata-api/compute-service/src/main/java/org/apache/airavata/compute/task/LSFOutputParser.java
+++ b/airavata-api/compute-service/src/main/java/org/apache/airavata/compute/task/LSFOutputParser.java
@@ -20,7 +20,6 @@
 package org.apache.airavata.compute.task;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -118,24 +117,5 @@ public class LSFOutputParser implements OutputParser {
             logger.error("Error: RawOutput shouldn't be null");
             return null;
         }
-    }
-
-    public static void main(String[] args) {
-        String test = "Job <2477982> is submitted to queue <short>.";
-        System.out.println(test.substring(test.indexOf("<") + 1, test.indexOf(">")));
-        String test1 = "JOBID   USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME\n"
-                + "2636607 lg11w   RUN   long       ghpcc06     c11b02      *069656647 Mar  7 00:58\n"
-                + "2636582 lg11w   RUN   long       ghpcc06     c02b01      2134490944 Mar  7 00:48";
-        Map<String, JobStatus> statusMap = new HashMap<String, JobStatus>();
-        statusMap.put(
-                "2477983,2134490944",
-                JobStatus.newBuilder().setJobState(JobState.JOB_STATE_UNKNOWN).build());
-        LSFOutputParser lsfOutputParser = new LSFOutputParser();
-        try {
-            lsfOutputParser.parseJobStatuses("cjh", statusMap, test1);
-        } catch (Exception e) {
-            logger.error(e.getMessage(), e);
-        }
-        System.out.println(statusMap.get("2477983,2134490944"));
     }
 }

--- a/airavata-api/iam-service/src/main/java/org/apache/airavata/iam/service/TenantManagementKeycloakImpl.java
+++ b/airavata-api/iam-service/src/main/java/org/apache/airavata/iam/service/TenantManagementKeycloakImpl.java
@@ -801,14 +801,4 @@ public class TenantManagementKeycloakImpl implements TenantManagementInterface {
         }
         return null;
     }
-
-    public static void main(String[] args) throws IamAdminServicesException, ApplicationSettingsException {
-        TenantManagementKeycloakImpl tenantManagementKeycloak = new TenantManagementKeycloakImpl();
-        ServerSettings.setSetting("iam.server.url", "");
-        String accessToken = "";
-        String tenantId = "";
-        String username = "";
-        boolean isUsernameAvailable = tenantManagementKeycloak.isUsernameAvailable(accessToken, tenantId, username);
-        System.out.println("Username " + username + " is " + (isUsernameAvailable ? "" : "NOT ") + "available");
-    }
 }

--- a/airavata-api/orchestration-service/src/main/java/org/apache/airavata/orchestration/task/DefaultComputeResourceSelectionPolicy.java
+++ b/airavata-api/orchestration-service/src/main/java/org/apache/airavata/orchestration/task/DefaultComputeResourceSelectionPolicy.java
@@ -73,10 +73,4 @@ public class DefaultComputeResourceSelectionPolicy extends ComputeResourceSelect
         }
         return Optional.empty();
     }
-
-    public static void main(String[] args) {
-        DefaultComputeResourceSelectionPolicy defaultComputeResourceSelectionPolicy =
-                new DefaultComputeResourceSelectionPolicy();
-        defaultComputeResourceSelectionPolicy.selectComputeResource("PROCESS_5dd4f56b-f0fd-41d0-9437-693ad25f4a1d");
-    }
 }

--- a/airavata-api/research-service/src/main/java/org/apache/airavata/research/service/AgentExperimentService.java
+++ b/airavata-api/research-service/src/main/java/org/apache/airavata/research/service/AgentExperimentService.java
@@ -24,16 +24,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.airavata.config.RequestContext;
 import org.apache.airavata.config.UserContext;
 import org.apache.airavata.exception.ServiceException;
 import org.apache.airavata.interfaces.GroupResourceProfileProvider;
 import org.apache.airavata.model.appcatalog.groupresourceprofile.proto.GroupComputeResourcePreference;
 import org.apache.airavata.model.appcatalog.groupresourceprofile.proto.GroupResourceProfile;
-import org.apache.airavata.model.experiment.proto.ExperimentSearchFields;
-import org.apache.airavata.model.experiment.proto.ExperimentSummaryModel;
 import org.apache.airavata.model.workspace.proto.Project;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -120,26 +116,5 @@ public class AgentExperimentService {
                 .findFirst()
                 .orElseThrow(() -> new RuntimeException("Could not find a matching Compute Resource Preference in the "
                         + groupProfileName + " group resource profile for the user: " + ctx.getUserId()));
-    }
-
-    public List<String> getUserExperimentIDs() throws ServiceException {
-        RequestContext ctx = requestContext();
-        int limit = 100;
-        String projectId = getProjectId("Default Project");
-        Map<ExperimentSearchFields, String> filters = Map.of(ExperimentSearchFields.PROJECT_ID, projectId);
-
-        return Stream.iterate(0, o -> o + limit)
-                .map(o -> {
-                    try {
-                        return experimentService.searchExperiments(
-                                ctx, ctx.getGatewayId(), ctx.getUserId(), filters, limit, o);
-                    } catch (ServiceException e) {
-                        throw new RuntimeException(e);
-                    }
-                })
-                .takeWhile(list -> !list.isEmpty())
-                .flatMap(List::stream)
-                .map(ExperimentSummaryModel::getExperimentId)
-                .collect(Collectors.toList());
     }
 }

--- a/airavata-api/src/main/java/org/apache/airavata/util/NameValidator.java
+++ b/airavata-api/src/main/java/org/apache/airavata/util/NameValidator.java
@@ -40,28 +40,4 @@ public class NameValidator {
 
         return matchFound;
     }
-
-    /**
-     * @param args
-     * @Description some quick tests
-     */
-    public static void main(String[] args) {
-        System.out.println(validate("abc90_90abc")); // true
-
-        System.out.println(validate("abc_abc_123")); // true
-
-        System.out.println(validate("abc_abc_")); // true
-
-        System.out.println(validate("abc_abc")); // true
-
-        System.out.println(validate("abc.abc")); // true
-
-        System.out.println(validate("9abc_abc")); // false, name cannot start with number
-
-        System.out.println(validate("_abc_abc")); // false, name cannot start with "_"
-
-        System.out.println(validate("\\abc_abc")); // false, name cannot start with "\"
-
-        System.out.println(validate("abc\\_abc")); // false, name cannot contain "\"
-    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -547,16 +547,6 @@ under the License.
                     <version>3.1.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>com.dkanejs.maven.plugins</groupId>
-                    <artifactId>docker-compose-maven-plugin</artifactId>
-                    <version>4.0.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>io.fabric8</groupId>
-                    <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.33.0</version>
-                </plugin>
-                <plugin>
                     <groupId>io.github.ascopes</groupId>
                     <artifactId>protobuf-maven-plugin</artifactId>
                     <version>3.10.2</version>


### PR DESCRIPTION
- `AgentExperimentService.getUserExperimentIDs()`: zero callers — orphaned when the FuseService removal deleted its only consumer.
- Four debug/demo `public static void main()` methods embedded in live production classes (`DefaultComputeResourceSelectionPolicy`, `LSFOutputParser`, `TenantManagementKeycloakImpl`, `NameValidator`) — host classes stay.
- Two stale `pluginManagement` pins for abandoned tooling (`docker-compose-maven-plugin`, fabric8 `docker-maven-plugin`) that no module activates.

## Test plan
- Grep: getUserExperimentIDs 0 callers; the four main()s are the trailing methods of their classes; the plugin pins are pluginManagement-only (no `<build><plugins>` activation).
- `mvn install -DskipTests` (full reactor) green.