### PR TITLE
Ignore blank experiment-statistics filters

### DIFF
--- a/airavata-api/research-service/src/main/java/org/apache/airavata/research/repository/ExperimentSummaryRepository.java
+++ b/airavata-api/research-service/src/main/java/org/apache/airavata/research/repository/ExperimentSummaryRepository.java
@@ -487,13 +487,13 @@ public class ExperimentSummaryRepository
             }
         }
 
-        if (userName != null) {
+        if (userName != null && !userName.isEmpty()) {
             logger.debug("Filter Experiments by UserName");
             queryParameters.put(DBConstants.Experiment.USER_NAME, userName);
             query += "ES.userName = :" + DBConstants.Experiment.USER_NAME + " AND ";
         }
 
-        if (applicationName != null) {
+        if (applicationName != null && !applicationName.isEmpty()) {
             logger.debug("Filter Experiments by ApplicationName");
             queryParameters.put(DBConstants.Experiment.EXECUTION_ID, applicationName);
             query += "ES.executionId = :" + DBConstants.Experiment.EXECUTION_ID + " AND ";
@@ -509,7 +509,7 @@ public class ExperimentSummaryRepository
             }
         }
 
-        if (resourceHostName != null) {
+        if (resourceHostName != null && !resourceHostName.isEmpty()) {
             logger.debug("Filter Experiments by ResourceHostName");
             queryParameters.put(DBConstants.Experiment.RESOURCE_HOST_ID, resourceHostName);
             query += "ES.resourceHostId = :" + DBConstants.Experiment.RESOURCE_HOST_ID + " ";


### PR DESCRIPTION
The experiment-statistics gRPC handler forwards the proto `userName` / `applicationName` / `resourceHostName` fields verbatim, and unset proto strings default to `""` (not null). `filterExperimentStatisticsQuery` only skipped `null` values, so an unset field became a literal `ES.userName = ''` (etc.) predicate that matched no rows. The admin experiment-statistics page sends none of these filters, so it always returned zero experiments. This guards each optional string filter against blank values.

Test plan: with two experiments seeded under the gateway, `GET /api/experiment-statistics/` previously returned `all_experiment_count=0`; after this change it returns `all_experiment_count=2` (verified live).