### PR TITLE
Grant dev default-admin the Keycloak realm-management roles

### DIFF
--- a/conf/keycloak/realm-default.json
+++ b/conf/keycloak/realm-default.json
@@ -595,6 +595,11 @@
         "default-roles-10000000",
         "admin-rw"
       ],
+      "clientRoles": {
+        "realm-management": [
+          "realm-admin"
+        ]
+      },
       "notBefore": 0,
       "groups": []
     },


### PR DESCRIPTION
The dev realm's `default-admin` had the `admin-rw` role but no `realm-management` client roles. Server-side IAM operations call the Keycloak admin API using the caller's own access token (`IamAdminService.getUsers` → `TenantManagementKeycloakImpl.getUsers` → `client.realm(tenantId).users().search(...)`), so without those roles the admin users page (`/admin/users`) failed with HTTP 403. Production gateway admins receive all realm-management roles via `createTenantAdminAccount`; this mirrors that for the dev admin by granting the `realm-management` `realm-admin` composite.

Test plan: recreate the keycloak container; a fresh `default-admin` token now carries `resource_access.realm-management.roles` (incl. `view-users`/`manage-users`), and `GET /api/iam-user-profiles/` returns 200 with the user list (previously 403). Verified live.