### PR TITLE
Rename IAM provisioning roles to admin-rw/admin-ro/user

### DIFF
--- a/airavata-api/iam-service/src/main/java/org/apache/airavata/iam/service/TenantManagementKeycloakImpl.java
+++ b/airavata-api/iam-service/src/main/java/org/apache/airavata/iam/service/TenantManagementKeycloakImpl.java
@@ -131,15 +131,15 @@ public class TenantManagementKeycloakImpl implements TenantManagementInterface {
     public static RealmRepresentation createDefaultRoles(RealmRepresentation realmDetails) {
         List<RoleRepresentation> defaultRoles = new ArrayList<RoleRepresentation>();
         RoleRepresentation adminRole = new RoleRepresentation();
-        adminRole.setName("admin");
+        adminRole.setName("admin-rw");
         adminRole.setDescription("Admin role for PGA users");
         defaultRoles.add(adminRole);
         RoleRepresentation adminReadOnlyRole = new RoleRepresentation();
-        adminReadOnlyRole.setName("admin-read-only");
+        adminReadOnlyRole.setName("admin-ro");
         adminReadOnlyRole.setDescription("Read only role for PGA Admin users");
         defaultRoles.add(adminReadOnlyRole);
         RoleRepresentation gatewayUserRole = new RoleRepresentation();
-        gatewayUserRole.setName("gateway-user");
+        gatewayUserRole.setName("user");
         gatewayUserRole.setDescription("default role for PGA users");
         defaultRoles.add(gatewayUserRole);
         RoleRepresentation pendingUserRole = new RoleRepresentation();
@@ -183,9 +183,9 @@ public class TenantManagementKeycloakImpl implements TenantManagementInterface {
                         .users()
                         .get(retrieveCreatedUserList.get(0).getId());
 
-                // Add user to the "admin" role
+                // Add user to the "admin-rw" role
                 RoleResource adminRoleResource =
-                        client.realm(gatewayDetails.getGatewayId()).roles().get("admin");
+                        client.realm(gatewayDetails.getGatewayId()).roles().get("admin-rw");
                 retrievedUser.roles().realmLevel().add(Arrays.asList(adminRoleResource.toRepresentation()));
 
                 CredentialRepresentation credential = new CredentialRepresentation();


### PR DESCRIPTION
Aligns the Keycloak provisioning code with the renamed realm roles. `TenantManagementKeycloakImpl.createDefaultRoles` now defines `admin-rw` / `admin-ro` / `user` (previously `admin` / `admin-read-only` / `gateway-user`), and `createTenantAdminAccount` grants a new gateway admin the `admin-rw` role. This keeps newly-provisioned gateways consistent with the dev realm vocabulary established for the role-based admin authorization work.

No dev runtime change: these paths run only during new-gateway/realm provisioning, not against the seeded dev realm. The dead Thrift-era `KeyCloakSecurityManager` permission matrix still references the old names and is left for separate dead-code removal. Compile verified.