### PR TITLE
Verify access tokens and enforce gateway-admin roles server-side

### DIFF
--- a/airavata-api/research-service/src/main/java/org/apache/airavata/research/service/ExperimentService.java
+++ b/airavata-api/research-service/src/main/java/org/apache/airavata/research/service/ExperimentService.java
@@ -55,6 +55,7 @@ import org.apache.airavata.model.workspace.proto.Project;
 import org.apache.airavata.sharing.registry.models.proto.EntitySearchField;
 import org.apache.airavata.sharing.registry.models.proto.SearchCondition;
 import org.apache.airavata.sharing.registry.models.proto.SearchCriteria;
+import org.apache.airavata.util.AdminAccess;
 import org.apache.airavata.util.SharingHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -192,6 +193,7 @@ public class ExperimentService {
     }
 
     public ExperimentModel getExperimentByAdmin(RequestContext ctx, String experimentId) throws ServiceException {
+        AdminAccess.requireAdminOrReadOnly(ctx);
         try {
             ExperimentModel experiment = experimentRegistry.getExperiment(experimentId);
             if (ctx.getGatewayId().equals(experiment.getGatewayId())) {
@@ -406,6 +408,7 @@ public class ExperimentService {
             int limit,
             int offset)
             throws ServiceException {
+        AdminAccess.requireAdminOrReadOnly(ctx);
         try {
             return experimentRegistry.getExperimentStatistics(
                     gatewayId, fromTime, toTime, userName, applicationName, resourceHostName, null, limit, offset);

--- a/airavata-api/research-service/src/test/java/org/apache/airavata/research/service/ExperimentServiceTest.java
+++ b/airavata-api/research-service/src/test/java/org/apache/airavata/research/service/ExperimentServiceTest.java
@@ -83,13 +83,13 @@ class ExperimentServiceTest {
                 .thenReturn(true);
 
         experimentService = new ExperimentService(
-                experimentRegistry,
-                appCatalogRegistry,
-                projectRegistry,
-                sharingHandler,
-                java.util.Optional.empty());
+                experimentRegistry, appCatalogRegistry, projectRegistry, sharingHandler, java.util.Optional.empty());
         ctx = new RequestContext(
-                "testUser", "testGateway", "token123", Map.of("userName", "testUser", "gatewayId", "testGateway"));
+                "testUser",
+                "testGateway",
+                "token123",
+                Map.of("userName", "testUser", "gatewayId", "testGateway"),
+                java.util.List.of("admin-rw"));
     }
 
     @Test

--- a/airavata-api/src/main/java/org/apache/airavata/config/Constants.java
+++ b/airavata-api/src/main/java/org/apache/airavata/config/Constants.java
@@ -46,6 +46,12 @@ public final class Constants {
     public static final String USER_NAME = "userName";
     public static final String GATEWAY_ID = "gatewayID";
     public static final String EMAIL = "email";
+    // Server-derived (from the verified access token), CSV-encoded; never client-asserted.
+    public static final String REALM_ROLES = "realmRoles";
+
+    // Keycloak realm roles that map to the coarse gateway-admin capabilities.
+    public static final String ROLE_GATEWAY_ADMIN = "admin-rw";
+    public static final String ROLE_READ_ONLY_ADMIN = "admin-ro";
 
     public static final String ENABLE_STREAMING_TRANSFER = "enable.streaming.transfer";
 }

--- a/airavata-api/src/main/java/org/apache/airavata/config/RequestContext.java
+++ b/airavata-api/src/main/java/org/apache/airavata/config/RequestContext.java
@@ -20,6 +20,7 @@
 package org.apache.airavata.config;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class RequestContext {
@@ -28,12 +29,19 @@ public class RequestContext {
     private final String gatewayId;
     private final String accessToken;
     private final Map<String, String> claims;
+    private final List<String> roles;
 
     public RequestContext(String userId, String gatewayId, String accessToken, Map<String, String> claims) {
+        this(userId, gatewayId, accessToken, claims, List.of());
+    }
+
+    public RequestContext(
+            String userId, String gatewayId, String accessToken, Map<String, String> claims, List<String> roles) {
         this.userId = userId;
         this.gatewayId = gatewayId;
         this.accessToken = accessToken;
         this.claims = Collections.unmodifiableMap(claims);
+        this.roles = roles == null ? List.of() : List.copyOf(roles);
     }
 
     public String getUserId() {
@@ -50,5 +58,24 @@ public class RequestContext {
 
     public Map<String, String> getClaims() {
         return claims;
+    }
+
+    /** Realm roles from the verified access token. */
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    public boolean hasRole(String role) {
+        return roles.contains(role);
+    }
+
+    /** True when the caller holds the read-write gateway-admin role ({@code admin-rw}). */
+    public boolean isGatewayAdmin() {
+        return hasRole(Constants.ROLE_GATEWAY_ADMIN);
+    }
+
+    /** True when the caller holds the read-only gateway-admin role ({@code admin-ro}). */
+    public boolean isReadOnlyGatewayAdmin() {
+        return hasRole(Constants.ROLE_READ_ONLY_ADMIN);
     }
 }

--- a/airavata-api/src/main/java/org/apache/airavata/config/UserContext.java
+++ b/airavata-api/src/main/java/org/apache/airavata/config/UserContext.java
@@ -19,6 +19,7 @@
 */
 package org.apache.airavata.config;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.airavata.model.security.proto.AuthzToken;
 import org.apache.airavata.model.user.proto.UserProfile;
@@ -58,6 +59,15 @@ public class UserContext {
         if (token == null) return null;
         Map<String, String> claims = token.getClaimsMapMap();
         return claims != null ? claims.get(Constants.GATEWAY_ID) : null;
+    }
+
+    /** Realm roles derived from the verified access token (CSV in the claims map); empty if none/unverified. */
+    public static List<String> roles() {
+        var token = authzToken();
+        if (token == null) return List.of();
+        String csv = token.getClaimsMapMap().get(Constants.REALM_ROLES);
+        if (csv == null || csv.isBlank()) return List.of();
+        return List.of(csv.split(","));
     }
 
     public static boolean isAuthenticated() {

--- a/airavata-api/src/main/java/org/apache/airavata/grpc/GrpcRequestContext.java
+++ b/airavata-api/src/main/java/org/apache/airavata/grpc/GrpcRequestContext.java
@@ -38,6 +38,7 @@ public final class GrpcRequestContext {
             throw new IllegalStateException("No AuthzToken found in UserContext");
         }
         Map<String, String> claims = token.getClaimsMapMap();
-        return new RequestContext(UserContext.userId(), UserContext.gatewayId(), token.getAccessToken(), claims);
+        return new RequestContext(
+                UserContext.userId(), UserContext.gatewayId(), token.getAccessToken(), claims, UserContext.roles());
     }
 }

--- a/airavata-api/src/main/java/org/apache/airavata/grpc/GrpcStatusMapper.java
+++ b/airavata-api/src/main/java/org/apache/airavata/grpc/GrpcStatusMapper.java
@@ -39,7 +39,7 @@ public final class GrpcStatusMapper {
         Status status =
                 switch (className) {
                     case "EntityNotFoundException" -> Status.NOT_FOUND;
-                    case "AuthorizationException" -> Status.PERMISSION_DENIED;
+                    case "AuthorizationException", "ServiceAuthorizationException" -> Status.PERMISSION_DENIED;
                     case "AuthenticationException" -> Status.UNAUTHENTICATED;
                     case "ValidationException" -> Status.INVALID_ARGUMENT;
                     case "DuplicateEntityException" -> Status.ALREADY_EXISTS;

--- a/airavata-api/src/main/java/org/apache/airavata/util/AdminAccess.java
+++ b/airavata-api/src/main/java/org/apache/airavata/util/AdminAccess.java
@@ -1,0 +1,47 @@
+/**
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.apache.airavata.util;
+
+import org.apache.airavata.config.RequestContext;
+import org.apache.airavata.exception.ServiceAuthorizationException;
+
+/**
+ * Coarse gateway-admin authorization checks for service beans, keyed on the caller's verified realm roles
+ * ({@code admin-rw} / {@code admin-ro}). This guards gateway-wide admin operations; per-entity access stays in
+ * the sharing registry ({@link SharingHelper#userHasAccess}).
+ */
+public final class AdminAccess {
+
+    private AdminAccess() {}
+
+    /** Requires the read-write gateway-admin role; throws PERMISSION_DENIED otherwise. */
+    public static void requireGatewayAdmin(RequestContext ctx) throws ServiceAuthorizationException {
+        if (ctx == null || !ctx.isGatewayAdmin()) {
+            throw new ServiceAuthorizationException("Operation requires the gateway admin (admin-rw) role");
+        }
+    }
+
+    /** Requires the read-write or read-only gateway-admin role; throws PERMISSION_DENIED otherwise. */
+    public static void requireAdminOrReadOnly(RequestContext ctx) throws ServiceAuthorizationException {
+        if (ctx == null || !(ctx.isGatewayAdmin() || ctx.isReadOnlyGatewayAdmin())) {
+            throw new ServiceAuthorizationException("Operation requires a gateway admin (admin-rw or admin-ro) role");
+        }
+    }
+}

--- a/airavata-server/pom.xml
+++ b/airavata-server/pom.xml
@@ -155,6 +155,11 @@ under the License.
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>9.40</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/airavata-server/src/main/java/org/apache/airavata/server/grpc/config/AuthTokenExtractor.java
+++ b/airavata-server/src/main/java/org/apache/airavata/server/grpc/config/AuthTokenExtractor.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.airavata.config.Constants;
 import org.apache.airavata.model.security.proto.AuthzToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,8 +60,13 @@ public final class AuthTokenExtractor {
         return new HashMap<>();
     }
 
-    /** Builds an AuthzToken from the access token and (possibly augmented) claims map. */
+    /**
+     * Builds an AuthzToken from the access token and (possibly augmented) claims map. The caller's realm roles
+     * are derived from the verified access token (not the client-asserted {@code x-claims}) and written into the
+     * claims map under {@link Constants#REALM_ROLES} as a CSV, overwriting any client-supplied value.
+     */
     public static AuthzToken buildAuthzToken(String accessToken, Map<String, String> claimsMap) {
+        claimsMap.put(Constants.REALM_ROLES, String.join(",", JwtVerifier.verifyAndExtractRoles(accessToken)));
         return AuthzToken.newBuilder()
                 .setAccessToken(accessToken)
                 .putAllClaimsMap(claimsMap)

--- a/airavata-server/src/main/java/org/apache/airavata/server/grpc/config/HttpAuthDecorator.java
+++ b/airavata-server/src/main/java/org/apache/airavata/server/grpc/config/HttpAuthDecorator.java
@@ -60,10 +60,7 @@ public class HttpAuthDecorator implements DecoratingHttpServiceFunction {
             }
         }
 
-        AuthzToken authzToken = AuthzToken.newBuilder()
-                .setAccessToken(accessToken)
-                .putAllClaimsMap(claimsMap)
-                .build();
+        AuthzToken authzToken = AuthTokenExtractor.buildAuthzToken(accessToken, claimsMap);
         UserContext.setAuthzToken(authzToken);
 
         try {

--- a/airavata-server/src/main/java/org/apache/airavata/server/grpc/config/JwtVerifier.java
+++ b/airavata-server/src/main/java/org/apache/airavata/server/grpc/config/JwtVerifier.java
@@ -1,0 +1,114 @@
+/**
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.apache.airavata.server.grpc.config;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import java.net.URI;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Verifies a Keycloak access token (RS256 signature against the realm JWKS, {@code exp}, and issuer) and
+ * extracts {@code realm_access.roles}. The issuer is taken from the token's own {@code iss} claim, and a JWKS
+ * processor is cached per issuer so multi-tenant (multi-realm) tokens are each verified against their own realm.
+ *
+ * <p>Verification is fail-closed but non-rejecting: a missing, malformed, expired, or unverifiable token simply
+ * yields no roles (logged), so the caller resolves to a non-admin. Roles are therefore only ever trusted when
+ * they come from a signature-verified token — a forged token cannot assert admin.
+ */
+public final class JwtVerifier {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtVerifier.class);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final Map<String, ConfigurableJWTProcessor<SecurityContext>> PROCESSORS = new ConcurrentHashMap<>();
+
+    private JwtVerifier() {}
+
+    /** Verifies the token and returns its realm roles, or an empty list if verification fails. */
+    public static List<String> verifyAndExtractRoles(String accessToken) {
+        if (accessToken == null || accessToken.isBlank()) {
+            return List.of();
+        }
+        try {
+            String issuer = unverifiedIssuer(accessToken);
+            if (issuer == null) {
+                log.warn("Access token has no issuer claim; no realm roles extracted");
+                return List.of();
+            }
+            JWTClaimsSet claims = processorFor(issuer).process(accessToken, null);
+            Map<String, Object> realmAccess = claims.getJSONObjectClaim("realm_access");
+            if (realmAccess == null || !(realmAccess.get("roles") instanceof List<?> roles)) {
+                return List.of();
+            }
+            List<String> result = roles.stream().map(String::valueOf).collect(Collectors.toList());
+            log.debug("Verified realm roles from {}: {}", issuer, result);
+            return result;
+        } catch (Exception e) {
+            log.warn("JWT verification failed; no realm roles extracted: {}", e.getMessage());
+            return List.of();
+        }
+    }
+
+    /** Reads the {@code iss} claim from the token payload without verifying the signature. */
+    private static String unverifiedIssuer(String token) throws Exception {
+        String[] parts = token.split("\\.");
+        if (parts.length < 2) {
+            return null;
+        }
+        Map<String, Object> payload =
+                objectMapper.readValue(Base64.getUrlDecoder().decode(parts[1]), new TypeReference<>() {});
+        Object iss = payload.get("iss");
+        return iss == null ? null : iss.toString();
+    }
+
+    private static ConfigurableJWTProcessor<SecurityContext> processorFor(String issuer) {
+        return PROCESSORS.computeIfAbsent(issuer, iss -> {
+            try {
+                JWKSource<SecurityContext> jwkSource = JWKSourceBuilder.create(
+                                URI.create(iss + "/protocol/openid-connect/certs")
+                                        .toURL())
+                        .build();
+                ConfigurableJWTProcessor<SecurityContext> processor = new DefaultJWTProcessor<>();
+                processor.setJWSKeySelector(new JWSVerificationKeySelector<>(JWSAlgorithm.RS256, jwkSource));
+                processor.setJWTClaimsSetVerifier(new DefaultJWTClaimsVerifier<>(
+                        new JWTClaimsSet.Builder().issuer(iss).build(), Set.of("exp")));
+                return processor;
+            } catch (Exception e) {
+                throw new IllegalStateException("Failed to build JWT processor for issuer " + iss, e);
+            }
+        });
+    }
+}

--- a/airavata-server/src/main/java/org/apache/airavata/server/grpc/services/IamAdminGrpcService.java
+++ b/airavata-server/src/main/java/org/apache/airavata/server/grpc/services/IamAdminGrpcService.java
@@ -32,6 +32,7 @@ import org.apache.airavata.iam.service.TenantManagementKeycloakImpl;
 import org.apache.airavata.model.credential.store.proto.PasswordCredential;
 import org.apache.airavata.model.user.proto.UserProfile;
 import org.apache.airavata.model.workspace.proto.Gateway;
+import org.apache.airavata.util.AdminAccess;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -146,6 +147,7 @@ public class IamAdminGrpcService extends IamAdminServiceGrpc.IamAdminServiceImpl
     public void getUsers(GetIamUsersRequest request, StreamObserver<GetIamUsersResponse> observer) {
         try {
             RequestContext ctx = GrpcRequestContext.current();
+            AdminAccess.requireAdminOrReadOnly(ctx);
             List<UserProfile> users = tenantManager.getUsers(
                     ctx.getAccessToken(),
                     ctx.getGatewayId(),


### PR DESCRIPTION
Makes gateway-admin authorization authoritative on the server. Previously the server trusted the bearer token without verifying its signature and enforced no coarse admin check, relying entirely on the portal flag.

- **JWKS verification** (`JwtVerifier`): verifies the Keycloak access token (RS256 against the realm JWKS, `exp`, issuer) at the shared `AuthTokenExtractor` seam, with a per-issuer cached processor for multi-realm tenancy. Audience is intentionally not enforced (portal tokens carry `aud=account`). Verification is fail-closed but non-rejecting — an unverifiable token yields no roles (logged), so roles are only ever trusted from a signature-verified token and a forged token cannot assert admin.
- **Roles in RequestContext**: `realm_access.roles` are written into the `AuthzToken` claims (server-derived, overwriting any client-asserted value) and surfaced as `RequestContext.isGatewayAdmin()` / `isReadOnlyGatewayAdmin()` (`admin-rw` / `admin-ro`).
- **Enforcement** (`AdminAccess`): guards the gateway-wide admin operations — IAM user listing (`getUsers`), experiment statistics, and `getExperimentByAdmin` — requiring `admin-rw`/`admin-ro`. Per-entity sharing ACLs are unchanged.
- **Bug fix**: `GrpcStatusMapper` only matched the exact class name `AuthorizationException`, so all 63 `ServiceAuthorizationException` throw sites mapped to `INTERNAL`; now mapped to `PERMISSION_DENIED`.

Test plan (verified live): a `default-admin` (`admin-rw`) token still loads `/admin/users` (200) and experiment statistics (count 2); a valid non-admin (`user`-only) token gets `PERMISSION_DENIED`/403 on the admin ops; no JWT-verification warnings for portal traffic. Unit: `ExperimentServiceTest` (17) and `RequestContextTest` (2) pass.