### PR TITLE
fix(devstack): make reset a true wipe and retry the ingress check

### DIFF
--- a/devstack/lib/commands.sh
+++ b/devstack/lib/commands.sh
@@ -39,5 +39,12 @@ devstack_down() {  # stop the shared ingress + the VM (GLOBAL — affects all pr
 devstack_reset() {  # GLOBAL destructive — wipes ALL projects' state
   echo "WARNING: deletes the shared VM and ALL projects' data on it."
   read -r -p "type the profile name to confirm: " c
-  [ "$c" = "$DEVSTACK_PROFILE" ] && colima delete -p "$DEVSTACK_PROFILE" -f || echo "aborted"
+  if [ "$c" != "$DEVSTACK_PROFILE" ]; then echo "aborted"; return; fi
+  colima delete -p "$DEVSTACK_PROFILE" -f
+  # colima/Lima keeps a persistent data disk under _lima/_disks/<instance> (bind-mounted
+  # to /var/lib/docker) that SURVIVES `colima delete`, so images, volumes and
+  # `restart: unless-stopped` containers resurrect on the next VM start. Remove it so
+  # reset is a true from-scratch wipe.
+  local inst="colima-$DEVSTACK_PROFILE"; [ "$DEVSTACK_PROFILE" = default ] && inst="colima"
+  rm -rf "$HOME/.colima/_lima/_disks/$inst"
 }

--- a/devstack/lib/verify.sh
+++ b/devstack/lib/verify.sh
@@ -7,7 +7,14 @@ devstack_verify() {
     linux)
       getent hosts "$host" | grep -q '127.0.0.1' || { echo "DNS FAIL: $host !-> 127.0.0.1"; ok=0; } ;;
   esac
-  nc -z -w2 127.0.0.1 443 || { echo "INGRESS FAIL: nothing on 127.0.0.1:443"; ok=0; }
+  # Traefik may have only just started (fresh image pull / cold boot); retry briefly so
+  # a not-yet-ready ingress doesn't spuriously fail the gate.
+  local i ingress=0
+  for i in $(seq 1 15); do
+    nc -z -w2 127.0.0.1 443 && { ingress=1; break; }
+    sleep 1
+  done
+  [ "$ingress" = 1 ] || { echo "INGRESS FAIL: nothing on 127.0.0.1:443 after retries"; ok=0; }
   [ "$ok" = 1 ] && echo "devstack verify: OK ($host -> 127.0.0.1, Traefik :443 up)"
   [ "$ok" = 1 ]
 }


### PR DESCRIPTION
## Summary
- `devstack reset` only ran `colima delete`, but colima keeps a persistent Lima data disk (`_lima/_disks/<instance>`, bind-mounted to `/var/lib/docker`) that survives the delete — so images, volumes and `restart: unless-stopped` containers resurrected on the next VM start. Reset now also removes that disk, making it a true from-scratch wipe.
- Wrapped the verify gate's `:443` check in a short retry loop so a freshly pulled / cold Traefik doesn't spuriously fail it.

## Test plan
- `./devstack/devstack reset`, then recreate the VM → docker reports 0 containers / 0 images / 0 volumes (previously old state resurrected).
- `./devstack/devstack ensure` against a cold, freshly-pulled Traefik → verify passes on the first run.
- Full `tilt up` (server + infra) + portal bring-up from scratch succeeds.
