### PR TITLE
fix(keycloak): account console 500 — stop forcing 'airavata' as global default theme

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -60,7 +60,11 @@ services:
       - --health-enabled=true
       - --metrics-enabled=true
       - --log-level=INFO
-      - --spi-theme-default=airavata
+      # Don't force "airavata" as the global default theme: it only ships a
+      # `login` variant, so making it the default ACCOUNT/admin/email theme makes
+      # Keycloak's account console 500 (NPE: account theme "airavata" not found).
+      # The realm pins `loginTheme: airavata` explicitly, so login branding is
+      # unaffected; account/admin/email use Keycloak's built-in themes.
     networks:
       - airavata-devstack
     healthcheck:


### PR DESCRIPTION
## Summary
The devstack Keycloak ran with `--spi-theme-default=airavata`. The `airavata` theme only ships a **login** variant, so making it the global default also made it the default **account** theme. Keycloak's account console then 500s with a `NullPointerException` (`Failed to find ACCOUNT theme airavata` → `AccountLoader.getAccountResourceProvider` NPE), which broke the Django portal's **User Settings** link (it lands on a Keycloak "internal server error" page).

## Fix
Remove the `--spi-theme-default=airavata` flag. The `default` realm already pins `loginTheme: airavata`, so login branding is unchanged; account/admin/email fall back to Keycloak's built-in themes and the account console works.

## Test plan
- `https://auth.airavata.host/realms/default/account/` returns **HTTP 200** (was 500) after `tilt` recreated the keycloak container; no account-theme NPE in logs.
- Browser: the URL now loads the airavata-branded Keycloak sign-in for the `account-console` client and lands on the user profile after auth.
- Login page still renders the airavata theme.