### PR TITLE
feat(research): short, human-readable experiment ids (EXP-XXXXXXXX)

### DIFF
--- a/airavata-api/research-service/src/main/java/org/apache/airavata/research/repository/ExperimentRepository.java
+++ b/airavata-api/research-service/src/main/java/org/apache/airavata/research/repository/ExperimentRepository.java
@@ -164,11 +164,15 @@ public class ExperimentRepository extends AbstractRepository<ExperimentModel, Ex
                 .setState(ExperimentState.EXPERIMENT_STATE_CREATED)
                 .setTimeOfStateChange(AiravataUtils.getCurrentTimestamp().getTime())
                 .build();
-        String expName = experimentModel.getExperimentName();
-        // This is to avoid overflow of experiment id size. Total experiment id length is <= 50 + UUID
+        // experiment_id is a short, human-readable, URL-safe code (e.g. EXP-7QK2F9MX). The experiment
+        // name is kept separately in experiment_name. Regenerate on the rare collision since it's the PK.
+        String experimentId;
+        do {
+            experimentId = AiravataUtils.getReadableId("EXP");
+        } while (isExperimentExist(experimentId));
         experimentModel = experimentModel.toBuilder()
                 .addExperimentStatus(experimentStatus)
-                .setExperimentId(AiravataUtils.getId(expName.substring(0, Math.min(expName.length(), 50))))
+                .setExperimentId(experimentId)
                 .build();
 
         return saveExperimentModelData(experimentModel);

--- a/airavata-api/research-service/src/test/java/org/apache/airavata/integration/ExperimentRepositoryIntegrationTest.java
+++ b/airavata-api/research-service/src/test/java/org/apache/airavata/integration/ExperimentRepositoryIntegrationTest.java
@@ -210,20 +210,24 @@ public class ExperimentRepositoryIntegrationTest extends TestBase {
 
     @Test
     @Order(4)
-    @DisplayName("Slashes in experiment name are replaced with underscores in generated id")
-    void slashesInNameAreNormalized() throws Exception {
+    @DisplayName("experiment_id is a short readable code and the experiment name is preserved verbatim")
+    void experimentIdIsShortCodeAndNamePreserved() throws Exception {
         ExperimentModel experiment = buildExperiment("name/forward-slash//a");
         String experimentId = experimentRepository.addExperiment(experiment);
-        assertTrue(
-                experimentId.startsWith("name_forward-slash__a"),
-                "forward slashes should be replaced with underscores");
+        assertTrue(experimentId.startsWith("EXP-"), "experiment id should be a short EXP- code");
+        assertEquals(
+                "name/forward-slash//a",
+                experimentRepository.getExperiment(experimentId).getExperimentName(),
+                "experiment name should be preserved verbatim");
         experimentRepository.removeExperiment(experimentId);
 
         experiment = buildExperiment("name\\backward-slash\\\\a");
         experimentId = experimentRepository.addExperiment(experiment);
-        assertTrue(
-                experimentId.startsWith("name_backward-slash__a"),
-                "backward slashes should be replaced with underscores");
+        assertTrue(experimentId.startsWith("EXP-"), "experiment id should be a short EXP- code");
+        assertEquals(
+                "name\\backward-slash\\\\a",
+                experimentRepository.getExperiment(experimentId).getExperimentName(),
+                "experiment name should be preserved verbatim");
         experimentRepository.removeExperiment(experimentId);
     }
 }

--- a/airavata-api/research-service/src/test/java/org/apache/airavata/research/repository/ExperimentRepositoryTest.java
+++ b/airavata-api/research-service/src/test/java/org/apache/airavata/research/repository/ExperimentRepositoryTest.java
@@ -306,10 +306,11 @@ public class ExperimentRepositoryTest extends TestBase {
     }
 
     /**
-     * Verify that slashes (forward and backward) are replaced with underscores.
+     * The generated experiment id is a short, readable code (independent of the name), and the
+     * experiment name is preserved verbatim (slashes are no longer mangled into the id).
      */
     @Test
-    public void testSlashesInExperimentName() throws RegistryException {
+    public void testGeneratedExperimentIdAndNamePreservation() throws RegistryException {
 
         // Forward slashes
         ExperimentModel experimentModel =
@@ -327,7 +328,10 @@ public class ExperimentRepositoryTest extends TestBase {
                 .build();
 
         String experimentId = experimentRepository.addExperiment(experimentModel);
-        assertTrue(experimentId.startsWith("name_forward-slash__a"));
+        assertTrue(experimentId.startsWith("EXP-"));
+        assertEquals(
+                "name/forward-slash//a",
+                experimentRepository.getExperiment(experimentId).getExperimentName());
 
         // Backward slashes
         experimentModel = ExperimentModel.newBuilder().setProjectId(projectId).build();
@@ -344,6 +348,9 @@ public class ExperimentRepositoryTest extends TestBase {
                 .build();
 
         experimentId = experimentRepository.addExperiment(experimentModel);
-        assertTrue(experimentId.startsWith("name_backward-slash__a"));
+        assertTrue(experimentId.startsWith("EXP-"));
+        assertEquals(
+                "name\\backward-slash\\\\a",
+                experimentRepository.getExperiment(experimentId).getExperimentName());
     }
 }

--- a/airavata-api/src/main/java/org/apache/airavata/util/AiravataUtils.java
+++ b/airavata-api/src/main/java/org/apache/airavata/util/AiravataUtils.java
@@ -19,11 +19,18 @@
 */
 package org.apache.airavata.util;
 
+import java.security.SecureRandom;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.UUID;
 
 public class AiravataUtils {
+
+    // Unambiguous Crockford-style base32 alphabet (no 0/1/I/L/O) for short, human-readable,
+    // URL-safe ids.
+    private static final char[] READABLE_ID_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ".toCharArray();
+    private static final int READABLE_ID_LENGTH = 8;
+    private static final SecureRandom READABLE_ID_RANDOM = new SecureRandom();
 
     public static Timestamp getCurrentTimestamp() {
         Calendar calender = Calendar.getInstance();
@@ -41,5 +48,18 @@ public class AiravataUtils {
     public static String getId(String name) {
         String id = name.trim().replaceAll("\\s|\\.|/|\\\\", "_");
         return id + "_" + UUID.randomUUID();
+    }
+
+    /**
+     * Generate a short, human-readable, URL-safe id of the form {@code <prefix>-XXXXXXXX} using an
+     * unambiguous alphabet (no 0/1/I/L/O). The id carries no semantic meaning; callers that use it as
+     * a primary key should regenerate it on the (vanishingly rare) collision.
+     */
+    public static String getReadableId(String prefix) {
+        StringBuilder sb = new StringBuilder(prefix).append('-');
+        for (int i = 0; i < READABLE_ID_LENGTH; i++) {
+            sb.append(READABLE_ID_ALPHABET[READABLE_ID_RANDOM.nextInt(READABLE_ID_ALPHABET.length)]);
+        }
+        return sb.toString();
     }
 }


### PR DESCRIPTION
## Summary
Experiment ids were generated as `sanitize(name)[:50] + "_" + UUID` — e.g. `Echo_on_Jun_14,_2026_9:36_PM_96aa3cbd-6ff9-4664-970e-30a803e03a6c` — mashing the experiment name and a uuid into the primary key, which is also the portal's URL identifier.

This generates a short, URL-safe, collision-checked code instead (e.g. `EXP-7QK2F9MX`) and keeps the human name in the separate `experiment_name` field.

## Changes
- `AiravataUtils.getReadableId(prefix)` — `<prefix>-XXXXXXXX` from an unambiguous Crockford-style alphabet (no `0/1/I/L/O`).
- `ExperimentRepository.addExperiment()` — mint `EXP-…` and regenerate on the (vanishingly rare) collision via the existing `isExperimentExist()`. `experiment_name` is untouched.
- `experiment_id` stays a `varchar(255)` PK, so existing ids and all FK references (PROCESS/EXPERIMENT_STATUS/EXPERIMENT_ERROR) keep working. **Only new experiments are affected.**
- Two tests that asserted the id embeds the normalized name now assert the new contract: a short `EXP-` code, with the experiment name **preserved verbatim** (it was previously mangled into the id).

`AiravataUtils.getId()` is unchanged (projects/applications/tasks/processes still use it; they aren't URL-facing).

## Why it's safe
A cross-repo sweep found **no code that parses the name/uuid out of `experiment_id`**. The Django portal needs **no change** — it already routes by `experiment_id` (`[^/]+`), and `EXP-7QK2F9MX` is URL-safe.

## Test plan
- Verified live: creating + launching an Echo experiment yields `/workspace/experiments/EXP-7TF68CM7/`, with the name preserved as "Echo on Jun 15, 2026 12:18 AM", status LAUNCHED.
- Updated unit + integration tests assert the new id format and name preservation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)